### PR TITLE
Build prototype hex crawl backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# hex-crawl-app
+# Hex Crawl Web Application
+
+This repository contains a prototype implementation of the hex crawl platform described in `docs/architecture.md`.
+It ships both the Phoenix/Absinthe backend and the SvelteKit frontend, together with docker-compose assets for
+local development.
+
+## Repository Layout
+
+- `backend/` – Phoenix application exposing the GraphQL API, Phoenix Channels, and Oban job worker definitions.
+- `frontend/` – SvelteKit SPA that renders DM and player experiences powered by MapLibre and Phoenix WebSocket clients.
+- `docs/` – Architecture documentation.
+- `docker-compose.yml` – Local orchestration for Postgres, Redis, MinIO, backend, and frontend containers.
+
+## Getting Started
+
+### Prerequisites
+
+- Elixir 1.15 and Erlang/OTP 26
+- Node.js 20+
+- PostgreSQL 15+
+- Redis 7+
+- A MinIO or S3-compatible object storage endpoint (the compose stack provides MinIO automatically)
+
+### Local Development (without Docker)
+
+1. Install backend dependencies:
+   ```bash
+   cd backend
+   mix deps.get
+   mix ecto.create
+   mix ecto.migrate
+   mix phx.server
+   ```
+
+2. Install frontend dependencies:
+   ```bash
+   cd ../frontend
+   npm install
+   npm run dev -- --host
+   ```
+
+3. Open the DM console at [http://localhost:5173/dm](http://localhost:5173/dm). Player links can load maps at
+   `/player/<map-id>`.
+
+### docker-compose
+
+The included `docker-compose.yml` provisions the full stack:
+
+```bash
+docker compose up --build
+```
+
+The services expose:
+
+- Backend GraphQL API at `http://localhost:4000/api/graphql`
+- Phoenix Channels at `ws://localhost:4000/socket`
+- Frontend SPA at `http://localhost:5173`
+- MinIO console at `http://localhost:9001`
+
+### Environment Variables
+
+Key settings are surfaced as environment variables for container and local use:
+
+- `DATABASE_URL` – PostgreSQL connection string.
+- `SECRET_KEY_BASE` – Phoenix secret used for session signing.
+- `STORAGE_*` – Object storage connection details for map and icon uploads.
+- `VITE_GRAPHQL_URL` / `VITE_SOCKET_URL` – Frontend endpoints for the API and realtime layer.
+
+## Tests & Tooling
+
+The project currently focuses on delivering the feature-complete prototype; automated tests are not yet implemented.
+Running `mix test` and `npm run test` are recommended additions when extending the platform.
+
+## Known Limitations
+
+- The backend ships with in-memory state seeded at runtime rather than a persistent Postgres implementation.
+- Background map tiling jobs simulate progress events but do not perform real image processing.
+- Authentication is stubbed for demonstration purposes.
+- Because outbound internet access is restricted in this environment, dependency installation commands may require
+  mirrored package registries.
+
+## Contributing
+
+1. Fork and clone the repository.
+2. Make your changes in a feature branch.
+3. Ensure `mix format` and `npm run lint` (or `svelte-check`) pass locally.
+4. Submit a pull request summarizing your changes.

--- a/backend/.formatter.exs
+++ b/backend/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+backend-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,29 @@
+FROM hexpm/elixir:1.15.7-erlang-26.1.2-debian-bullseye-20240130 AS build
+
+ENV MIX_ENV=prod
+WORKDIR /app
+
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY mix.exs mix.exs
+COPY config config
+RUN mix deps.get --only prod
+
+COPY lib lib
+COPY priv priv
+
+RUN mix compile
+
+FROM debian:bullseye-slim AS app
+
+RUN apt-get update && apt-get install -y openssl ncurses-libs && rm -rf /var/lib/apt/lists/*
+
+ENV MIX_ENV=prod
+WORKDIR /app
+
+COPY --from=build /root/.cache/ /root/.cache/
+COPY --from=build /root/.mix/ /root/.mix/
+COPY --from=build /app /app
+
+EXPOSE 4000
+CMD ["mix", "phx.server"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# Hex Crawl Backend
+
+This Phoenix application exposes the GraphQL API, Phoenix Channels realtime layer, and Oban job queues that
+power the hex crawl experience. The current implementation keeps campaign state in memory for rapid prototyping
+but mirrors the schema designed for a PostgreSQL persistence layer.
+
+## Running Locally
+
+```bash
+mix deps.get
+mix phx.server
+```
+
+By default the server boots on `http://localhost:4000` with the GraphQL endpoint at `/api/graphql` and the GraphiQL
+playground at `/api/graphiql`.
+
+## Key Folders
+
+- `lib/backend/` – context modules for campaigns, storage, and background workers.
+- `lib/backend_web/` – Phoenix endpoint, router, GraphQL schema, and channel definitions.
+- `priv/` – static assets and future location for Ecto migrations.
+
+## Environment Variables
+
+The backend reads a handful of configuration values via environment variables:
+
+- `DATABASE_URL` – PostgreSQL connection string (not yet used by the in-memory store).
+- `SECRET_KEY_BASE` – secret used for signing cookies/sessions.
+- `STORAGE_*` – credentials for the S3-compatible object storage service.
+
+## Testing
+
+Unit tests are not yet implemented. Once persistent storage is wired up, add `ExUnit` tests covering the GraphQL
+resolvers and context modules.

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -1,0 +1,29 @@
+import Config
+
+config :backend,
+  ecto_repos: [Backend.Repo]
+
+config :backend, BackendWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [view: BackendWeb.ErrorView, accepts: ~w(json), layout: false],
+  pubsub_server: Backend.PubSub,
+  live_view: [signing_salt: "hexcrawl"]
+
+config :backend, BackendWeb.Endpoint, secret_key_base: "AReallyLongSecretKeyBaseForDevOnly"
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :phoenix, :json_library, Jason
+
+config :backend, Oban,
+  repo: Backend.Repo,
+  queues: [default: 10, ingestion: 5],
+  plugins: [Oban.Plugins.Pruner]
+
+config :backend, Backend.Auth.Guardian,
+  issuer: "hex_crawl",
+  secret_key: "super_secret_key_change_me"
+
+import_config "#{config_env()}.exs"

--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -1,0 +1,25 @@
+import Config
+
+config :backend, Backend.Repo,
+  database: "hex_crawl_dev",
+  username: "postgres",
+  password: "postgres",
+  hostname: System.get_env("POSTGRES_HOST", "localhost"),
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :backend, BackendWeb.Endpoint,
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4000"))],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "dev_secret_key_base",
+  watchers: []
+
+config :backend, :storage,
+  bucket: System.get_env("STORAGE_BUCKET", "hexcrawl"),
+  endpoint: System.get_env("STORAGE_ENDPOINT", "http://localhost:9000"),
+  access_key_id: System.get_env("STORAGE_ACCESS_KEY", "minioadmin"),
+  secret_access_key: System.get_env("STORAGE_SECRET_KEY", "minioadmin"),
+  region: System.get_env("STORAGE_REGION", "us-east-1"),
+  scheme: :http

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -1,0 +1,25 @@
+import Config
+
+if config_env() == :prod do
+  database_url =
+    System.get_env("DATABASE_URL") ||
+      raise "DATABASE_URL environment variable is missing."
+
+  config :backend, Backend.Repo,
+    url: database_url,
+    pool_size: String.to_integer(System.get_env("POOL_SIZE", "10"))
+
+  secret_key_base =
+    System.get_env("SECRET_KEY_BASE") ||
+      raise "SECRET_KEY_BASE is missing"
+
+  config :backend, BackendWeb.Endpoint,
+    url: [host: System.get_env("PHX_HOST", "example.com"), port: 443],
+    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4000"))],
+    secret_key_base: secret_key_base
+
+  config :backend, Backend.Auth.Guardian,
+    secret_key:
+      System.get_env("GUARDIAN_SECRET") ||
+        raise("GUARDIAN_SECRET not provided")
+end

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -1,0 +1,15 @@
+import Config
+
+config :backend, Backend.Repo,
+  database: "hex_crawl_test",
+  username: "postgres",
+  password: "postgres",
+  hostname: System.get_env("POSTGRES_HOST", "localhost"),
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :backend, BackendWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
+  secret_key_base: "test_secret_key_base",
+  server: false
+
+config :backend, Oban, testing: :manual

--- a/backend/lib/backend.ex
+++ b/backend/lib/backend.ex
@@ -1,0 +1,20 @@
+defmodule Backend do
+  @moduledoc """
+  Entry point providing convenience accessors for the different contexts
+  that power the hex crawl experience (campaigns, storage, history).
+  """
+
+  alias Backend.Campaigns
+
+  defdelegate list_campaigns(opts \\ []), to: Campaigns, as: :list_campaigns
+  defdelegate get_campaign(id), to: Campaigns, as: :get_campaign
+  defdelegate create_campaign(attrs), to: Campaigns, as: :create_campaign
+  defdelegate upsert_map(campaign_id, attrs), to: Campaigns, as: :upsert_map
+  defdelegate set_player_location(map_id, coords), to: Campaigns
+  defdelegate reveal_hexes(map_id, hex_ids, opts \\ []), to: Campaigns
+  defdelegate conceal_hexes(map_id, hex_ids), to: Campaigns
+  defdelegate create_hex_item(map_id, hex_id, attrs), to: Campaigns
+  defdelegate update_hex_item(map_id, hex_id, item_id, attrs), to: Campaigns
+  defdelegate delete_hex_item(map_id, hex_id, item_id), to: Campaigns
+  defdelegate exploration_history(map_id, opts \\ []), to: Campaigns
+end

--- a/backend/lib/backend/application.ex
+++ b/backend/lib/backend/application.ex
@@ -1,0 +1,34 @@
+defmodule Backend.Application do
+  @moduledoc """
+  Bootstraps the Hex Crawl backend application, wiring together the
+  database repo, realtime pubsub, in-memory state agent, Oban queues,
+  and the Phoenix web endpoint.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      Backend.Repo,
+      Backend.State,
+      {Phoenix.PubSub, name: Backend.PubSub},
+      BackendWeb.Telemetry,
+      {Oban, Application.fetch_env!(:backend, Oban)},
+      BackendWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: Backend.Supervisor]
+
+    with {:ok, pid} = result <- Supervisor.start_link(children, opts) do
+      :ok = Backend.State.seed_demo_data()
+      result
+    end
+  end
+
+  @impl true
+  def config_change(changed, _new, removed) do
+    BackendWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/backend/lib/backend/application.ex
+++ b/backend/lib/backend/application.ex
@@ -20,7 +20,7 @@ defmodule Backend.Application do
 
     opts = [strategy: :one_for_one, name: Backend.Supervisor]
 
-    with {:ok, pid} = result <- Supervisor.start_link(children, opts) do
+    with {:ok, _pid} = result <- Supervisor.start_link(children, opts) do
       :ok = Backend.State.seed_demo_data()
       result
     end

--- a/backend/lib/backend/auth/guardian.ex
+++ b/backend/lib/backend/auth/guardian.ex
@@ -1,0 +1,19 @@
+defmodule Backend.Auth.Guardian do
+  @moduledoc """
+  Guardian implementation that issues JWT tokens for authenticated
+  Dungeon Masters. The current implementation simply uses the user ID as
+  the subject; integration with a full user database can be added later.
+  """
+
+  use Guardian, otp_app: :backend
+
+  @impl Guardian
+  def subject_for_token(%{id: id}, _claims), do: {:ok, to_string(id)}
+
+  def subject_for_token(id, _claims) when is_binary(id), do: {:ok, id}
+  def subject_for_token(_, _), do: {:error, :unknown_resource}
+
+  @impl Guardian
+  def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+  def resource_from_claims(_), do: {:error, :unknown_resource}
+end

--- a/backend/lib/backend/campaigns.ex
+++ b/backend/lib/backend/campaigns.ex
@@ -1,0 +1,429 @@
+defmodule Backend.Campaigns do
+  @moduledoc """
+  Business logic for campaigns, maps, hex exploration, and timeline
+  tracking. The current implementation stores data in an in-memory Agent
+  so that the prototype works out-of-the-box while matching the
+  persistence model planned for PostgreSQL.
+  """
+
+  alias Backend.State
+  alias Backend.Events
+  alias Backend.Campaigns.Models.{Campaign, HexItem, ExplorationEvent, PlayerLink}
+  alias Backend.Campaigns.Models.Map, as: CampaignMap
+
+  @type hex_coords :: {integer(), integer()}
+
+  @doc """
+  Returns all campaigns in memory.
+  """
+  def list_campaigns(_opts \\ []) do
+    State.read(fn %{campaigns: campaigns, maps: maps} ->
+      campaigns
+      |> Map.values()
+      |> Enum.map(&enrich_campaign(&1, maps))
+    end)
+  end
+
+  def get_campaign(id) do
+    State.read(fn %{campaigns: campaigns, maps: maps} ->
+      with %Campaign{} = campaign <- Map.get(campaigns, id) do
+        enrich_campaign(campaign, maps)
+      end
+    end)
+  end
+
+  def get_campaign_for_map(id) do
+    State.read(fn %{maps: maps, campaigns: campaigns, items: items} ->
+      with %CampaignMap{} = map <- Map.get(maps, id),
+           %Campaign{} = campaign <- Map.get(campaigns, map.campaign_id) do
+        map_items =
+          items
+          |> Enum.filter(fn {{map_id, _hex_id, _id}, _item} -> map_id == map.id end)
+          |> Enum.map(fn {_key, item} -> normalise_item(item) end)
+
+        map
+        |> maybe_normalise_map()
+        |> Map.put(:campaign, Map.from_struct(campaign))
+        |> Map.put(:items, map_items)
+      end
+    end)
+  end
+
+  defp enrich_campaign(%Campaign{} = campaign, maps) do
+    campaign
+    |> Map.from_struct()
+    |> Map.put(
+      :maps,
+      Enum.map(campaign.maps, fn map_id -> maybe_normalise_map(Map.get(maps, map_id)) end)
+    )
+    |> Map.update(:share_links, [], &Enum.map(&1, &Map.from_struct/1))
+  end
+
+  def create_campaign(attrs) do
+    id = Map.get(attrs, :id, "cmp-#{System.unique_integer([:positive])}")
+
+    campaign = %Campaign{
+      id: id,
+      name: Map.fetch!(attrs, :name),
+      description: Map.get(attrs, :description, ""),
+      default_hex_size: Map.get(attrs, :default_hex_size, 6),
+      maps: []
+    }
+
+    State.transaction(fn state ->
+      new_state = put_in(state, [:campaigns, campaign.id], campaign)
+      {{:ok, Map.from_struct(campaign)}, new_state}
+    end)
+  end
+
+  def upsert_map(campaign_id, attrs) do
+    id = Map.get(attrs, :id, "map-#{System.unique_integer([:positive])}")
+
+    map = %CampaignMap{
+      id: id,
+      campaign_id: campaign_id,
+      name: Map.fetch!(attrs, :name),
+      hex_size_px: Map.fetch!(attrs, :hex_size_px),
+      scale_ratio: Map.get(attrs, :scale_ratio, 1.0),
+      parent_map_id: Map.get(attrs, :parent_map_id),
+      parent_region: Map.get(attrs, :parent_region),
+      tileset_path: Map.fetch!(attrs, :tileset_path),
+      bounds: Map.fetch!(attrs, :bounds),
+      child_maps: Map.get(attrs, :child_maps, []),
+      explored_hexes: MapSet.new(Map.get(attrs, :explored_hexes, [])),
+      current_player_hex: Map.get(attrs, :current_player_hex)
+    }
+
+    State.transaction(fn state ->
+      new_state =
+        state
+        |> put_in([:maps, map.id], map)
+        |> update_in([:campaigns, campaign_id, :maps], fn maps ->
+          maps = maps || []
+
+          if map.id in maps do
+            maps
+          else
+            maps ++ [map.id]
+          end
+        end)
+
+      Events.broadcast_campaign(campaign_id, {:map_upserted, maybe_normalise_map(map)})
+      {{:ok, maybe_normalise_map(map)}, new_state}
+    end)
+  end
+
+  def set_player_location(map_id, {q, r} = coords) do
+    State.transaction(fn state ->
+      map = get_in(state, [:maps, map_id])
+
+      updated = %{
+        map
+        | current_player_hex: coords,
+          explored_hexes: MapSet.put(map.explored_hexes, coords)
+      }
+
+      state_with_map = put_in(state, [:maps, map_id], updated)
+
+      {event, new_state} =
+        record_event(state_with_map, map.campaign_id, map_id, :move_players, %{q: q, r: r})
+
+      Events.broadcast_map(
+        map_id,
+        {:player_moved, %{coords: coords_to_map(coords), event: event}}
+      )
+
+      {{:ok, maybe_normalise_map(updated)}, new_state}
+    end)
+  end
+
+  def reveal_hexes(map_id, coords_list, opts \\ []) do
+    annotate? = Keyword.get(opts, :annotate_history, true)
+
+    State.transaction(fn state ->
+      map = get_in(state, [:maps, map_id])
+
+      new_explored =
+        Enum.reduce(coords_list, map.explored_hexes, fn coords, acc -> MapSet.put(acc, coords) end)
+
+      updated = %{map | explored_hexes: new_explored}
+      state_with_map = put_in(state, [:maps, map_id], updated)
+
+      converted_hexes = Enum.map(coords_list, &coords_to_map/1)
+
+      {event, new_state} =
+        if annotate? do
+          record_event(state_with_map, map.campaign_id, map_id, :reveal_hexes, %{
+            hexes: converted_hexes
+          })
+        else
+          {nil, state_with_map}
+        end
+
+      Events.broadcast_map(
+        map_id,
+        {:hexes_revealed, %{hexes: Enum.map(coords_list, &coords_to_map/1), event: event}}
+      )
+
+      {{:ok, maybe_normalise_map(updated)}, new_state}
+    end)
+  end
+
+  def conceal_hexes(map_id, coords_list) do
+    State.transaction(fn state ->
+      map = get_in(state, [:maps, map_id])
+
+      new_explored =
+        Enum.reduce(coords_list, map.explored_hexes, fn coords, acc ->
+          MapSet.delete(acc, coords)
+        end)
+
+      updated = %{map | explored_hexes: new_explored}
+      new_state = put_in(state, [:maps, map_id], updated)
+
+      Events.broadcast_map(
+        map_id,
+        {:hexes_concealed, %{hexes: Enum.map(coords_list, &coords_to_map/1)}}
+      )
+
+      {{:ok, maybe_normalise_map(updated)}, new_state}
+    end)
+  end
+
+  def create_hex_item(map_id, {q, r}, attrs) do
+    hex_id = "#{q}:#{r}"
+    id = Map.get(attrs, :id, "itm-#{System.unique_integer([:positive])}")
+
+    item = %HexItem{
+      id: id,
+      map_id: map_id,
+      hex_id: hex_id,
+      name: Map.fetch!(attrs, :name),
+      description: Map.get(attrs, :description, ""),
+      icon: Map.get(attrs, :icon),
+      visibility_distance: Map.get(attrs, :visibility_distance, 1),
+      always_visible: Map.get(attrs, :always_visible, false)
+    }
+
+    State.transaction(fn state ->
+      key = {map_id, hex_id, item.id}
+      new_state = put_in(state, [:items, key], item)
+      normalised = normalise_item(item)
+
+      Events.broadcast_map(
+        map_id,
+        {:hex_item_created, %{hex: coords_to_map({q, r}), item: normalised}}
+      )
+
+      {{:ok, normalised}, new_state}
+    end)
+  end
+
+  def update_hex_item(map_id, {q, r}, id, attrs) do
+    hex_id = "#{q}:#{r}"
+
+    State.transaction(fn state ->
+      key = {map_id, hex_id, id}
+
+      case get_in(state, [:items, key]) do
+        nil ->
+          {{:error, :not_found}, state}
+
+        item ->
+          updated =
+            item
+            |> Map.merge(
+              Map.take(attrs, [:name, :description, :icon, :visibility_distance, :always_visible])
+            )
+
+          new_state = put_in(state, [:items, key], updated)
+          normalised = normalise_item(updated)
+
+          Events.broadcast_map(
+            map_id,
+            {:hex_item_updated, %{hex: coords_to_map({q, r}), item: normalised}}
+          )
+
+          {{:ok, normalised}, new_state}
+      end
+    end)
+  end
+
+  def delete_hex_item(map_id, {q, r}, id) do
+    hex_id = "#{q}:#{r}"
+
+    State.transaction(fn state ->
+      key = {map_id, hex_id, id}
+
+      case get_in(state, [:items, key]) do
+        nil ->
+          {{:error, :not_found}, state}
+
+        item ->
+          new_state = update_in(state, [:items], &Map.delete(&1, key))
+          normalised = normalise_item(item)
+
+          Events.broadcast_map(
+            map_id,
+            {:hex_item_deleted, %{hex: coords_to_map({q, r}), item: normalised}}
+          )
+
+          {{:ok, normalised}, new_state}
+      end
+    end)
+  end
+
+  def exploration_history(map_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 20)
+    cursor = Keyword.get(opts, :cursor, nil)
+
+    State.read(fn %{events: events} ->
+      events
+      |> Enum.filter(&(&1.map_id == map_id))
+      |> Enum.sort_by(& &1.occurred_at, {:desc, DateTime})
+      |> maybe_apply_cursor(cursor)
+      |> Enum.take(limit)
+    end)
+  end
+
+  def generate_player_link(campaign_id, attrs \\ %{}) do
+    token = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    id = Map.get(attrs, :id, "lnk-#{System.unique_integer([:positive])}")
+
+    link = %PlayerLink{
+      id: id,
+      campaign_id: campaign_id,
+      token: token,
+      created_by: Map.get(attrs, :created_by, "system"),
+      label: Map.get(attrs, :label),
+      expires_at:
+        Map.get(
+          attrs,
+          :expires_at,
+          DateTime.utc_now()
+          |> DateTime.add(86_400)
+          |> DateTime.truncate(:second)
+          |> DateTime.to_naive()
+        )
+    }
+
+    State.transaction(fn state ->
+      new_state =
+        update_in(state, [:campaigns, campaign_id, :share_links], fn links ->
+          links = links || []
+          links ++ [link]
+        end)
+
+      normalised = Map.from_struct(link)
+      Events.broadcast_campaign(campaign_id, {:player_link_created, normalised})
+      {{:ok, normalised}, new_state}
+    end)
+  end
+
+  def list_visible_items(map_id, {q, r}, distance) do
+    coords = {q, r}
+
+    State.read(fn %{items: items} ->
+      items
+      |> Enum.filter(fn
+        {{item_map_id, _hex_id, _id}, item} ->
+          item_map_id == map_id and item_visible?(item, coords, distance)
+      end)
+      |> Enum.map(fn {_key, item} -> normalise_item(item) end)
+    end)
+  end
+
+  defp maybe_normalise_map(nil), do: nil
+
+  defp maybe_normalise_map(%CampaignMap{} = map) do
+    map
+    |> Map.from_struct()
+    |> Map.update(:explored_hexes, [], fn set -> Enum.map(set, &coords_to_map/1) end)
+    |> Map.update(:current_player_hex, nil, &maybe_coords_to_map/1)
+    |> Map.update(:bounds, %{}, &normalise_bounds/1)
+    |> Map.update(:parent_region, nil, &normalise_bounds/1)
+    |> Map.update(:child_maps, [], fn child_maps ->
+      Enum.map(child_maps, fn child -> Map.update(child, :region, nil, &normalise_bounds/1) end)
+    end)
+  end
+
+  defp item_visible?(%HexItem{always_visible: true}, _coords, _distance), do: true
+
+  defp item_visible?(
+         %HexItem{hex_id: hex_id, visibility_distance: max_distance},
+         {q, r},
+         :infinite
+       ) do
+    within_visibility?(hex_id, {q, r}, max_distance)
+  end
+
+  defp item_visible?(
+         %HexItem{hex_id: hex_id, visibility_distance: max_distance},
+         {q, r},
+         distance
+       ) do
+    distance <= max_distance and within_visibility?(hex_id, {q, r}, max_distance)
+  end
+
+  defp within_visibility?(hex_id, {q, r}, max_distance) do
+    [hex_q, hex_r] = hex_id |> String.split(":") |> Enum.map(&String.to_integer/1)
+    axial_distance({hex_q, hex_r}, {q, r}) <= max_distance
+  end
+
+  defp axial_distance({q1, r1}, {q2, r2}) do
+    s1 = -q1 - r1
+    s2 = -q2 - r2
+
+    Enum.max([abs(q1 - q2), abs(r1 - r2), abs(s1 - s2)])
+  end
+
+  defp record_event(state, campaign_id, map_id, type, payload) do
+    event = %ExplorationEvent{
+      id: "evt-#{System.unique_integer([:positive])}",
+      campaign_id: campaign_id,
+      map_id: map_id,
+      type: type,
+      occurred_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive(),
+      payload: payload
+    }
+
+    _ = Events.broadcast_campaign(campaign_id, {:history_event, event})
+
+    {event, update_in(state, [:events], fn events -> [event | events] end)}
+  end
+
+  defp maybe_apply_cursor(events, nil), do: events
+
+  defp maybe_apply_cursor(events, cursor) do
+    Enum.drop_while(events, fn event -> event.id != cursor end)
+    |> case do
+      [] -> events
+      [_matched | rest] -> rest
+    end
+  end
+
+  defp coords_to_map({q, r}), do: %{q: q, r: r}
+  defp coords_to_map(%{q: q, r: r}), do: %{q: q, r: r}
+
+  defp maybe_coords_to_map(nil), do: nil
+  defp maybe_coords_to_map(coords), do: coords_to_map(coords)
+
+  defp normalise_bounds(nil), do: nil
+
+  defp normalise_bounds(%{min_q: _, max_q: _, min_r: _, max_r: _} = bounds), do: bounds
+
+  defp normalise_bounds(%{q: %Range{} = q_range, r: %Range{} = r_range}) do
+    %{min_q: q_range.first, max_q: q_range.last, min_r: r_range.first, max_r: r_range.last}
+  end
+
+  defp normalise_bounds(%{q: q_range, r: r_range})
+       when is_struct(q_range, Range) and is_struct(r_range, Range) do
+    %{min_q: q_range.first, max_q: q_range.last, min_r: r_range.first, max_r: r_range.last}
+  end
+
+  defp normalise_bounds(%{min_q: _, max_q: _, min_r: _, max_r: _} = bounds), do: bounds
+  defp normalise_bounds(_), do: nil
+
+  defp normalise_item(%HexItem{} = item), do: Map.from_struct(item)
+  defp normalise_item(nil), do: nil
+end

--- a/backend/lib/backend/campaigns.ex
+++ b/backend/lib/backend/campaigns.ex
@@ -378,19 +378,24 @@ defmodule Backend.Campaigns do
   end
 
   defp record_event(state, campaign_id, map_id, type, payload) do
+    payload_string = encode_payload(payload)
+
     event = %ExplorationEvent{
       id: "evt-#{System.unique_integer([:positive])}",
       campaign_id: campaign_id,
       map_id: map_id,
       type: type,
       occurred_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive(),
-      payload: payload
+      payload: payload_string
     }
 
     _ = Events.broadcast_campaign(campaign_id, {:history_event, event})
 
     {event, update_in(state, [:events], fn events -> [event | events] end)}
   end
+
+  defp encode_payload(payload) when is_binary(payload), do: payload
+  defp encode_payload(payload), do: Jason.encode!(payload)
 
   defp maybe_apply_cursor(events, nil), do: events
 

--- a/backend/lib/backend/campaigns.ex
+++ b/backend/lib/backend/campaigns.ex
@@ -56,7 +56,7 @@ defmodule Backend.Campaigns do
       :maps,
       Enum.map(campaign.maps, fn map_id -> maybe_normalise_map(Map.get(maps, map_id)) end)
     )
-    |> Map.update(:share_links, [], &Enum.map(&1, &Map.from_struct/1))
+    |> Map.update(:share_links, [], fn links -> Enum.map(links, &Map.from_struct/1) end)
   end
 
   def create_campaign(attrs) do

--- a/backend/lib/backend/campaigns/models.ex
+++ b/backend/lib/backend/campaigns/models.ex
@@ -1,0 +1,71 @@
+defmodule Backend.Campaigns.Models.Campaign do
+  @enforce_keys [:id, :name, :description, :maps, :default_hex_size]
+  @derive {Jason.Encoder,
+           only: [:id, :name, :description, :maps, :default_hex_size, :members, :share_links]}
+  defstruct @enforce_keys ++ [members: [], share_links: []]
+end
+
+defmodule Backend.Campaigns.Models.Map do
+  @enforce_keys [
+    :id,
+    :campaign_id,
+    :name,
+    :hex_size_px,
+    :scale_ratio,
+    :tileset_path,
+    :bounds,
+    :child_maps,
+    :explored_hexes,
+    :current_player_hex
+  ]
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :campaign_id,
+             :name,
+             :hex_size_px,
+             :scale_ratio,
+             :tileset_path,
+             :bounds,
+             :child_maps,
+             :explored_hexes,
+             :current_player_hex,
+             :parent_map_id,
+             :parent_region
+           ]}
+  defstruct @enforce_keys ++ [parent_map_id: nil, parent_region: nil]
+end
+
+defmodule Backend.Campaigns.Models.Hex do
+  @enforce_keys [:id, :map_id, :q, :r, :terrain]
+  @derive {Jason.Encoder, only: [:id, :map_id, :q, :r, :terrain, :notes]}
+  defstruct @enforce_keys ++ [notes: nil]
+end
+
+defmodule Backend.Campaigns.Models.HexItem do
+  @enforce_keys [:id, :hex_id, :map_id, :name, :description, :visibility_distance]
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :hex_id,
+             :map_id,
+             :name,
+             :description,
+             :visibility_distance,
+             :icon,
+             :always_visible
+           ]}
+  defstruct @enforce_keys ++ [icon: nil, always_visible: false]
+end
+
+defmodule Backend.Campaigns.Models.ExplorationEvent do
+  @enforce_keys [:id, :map_id, :campaign_id, :type, :occurred_at, :payload]
+  @derive {Jason.Encoder, only: [:id, :map_id, :campaign_id, :type, :occurred_at, :payload]}
+  defstruct @enforce_keys
+end
+
+defmodule Backend.Campaigns.Models.PlayerLink do
+  @enforce_keys [:id, :campaign_id, :token, :expires_at, :created_by]
+  @derive {Jason.Encoder, only: [:id, :campaign_id, :token, :expires_at, :created_by, :label]}
+  defstruct @enforce_keys ++ [label: nil]
+end

--- a/backend/lib/backend/events.ex
+++ b/backend/lib/backend/events.ex
@@ -1,0 +1,13 @@
+defmodule Backend.Events do
+  @moduledoc """
+  Helper utilities for publishing domain events to Phoenix PubSub topics.
+  """
+
+  def broadcast_campaign(campaign_id, payload) do
+    Phoenix.PubSub.broadcast(Backend.PubSub, "campaign:" <> campaign_id, payload)
+  end
+
+  def broadcast_map(map_id, payload) do
+    Phoenix.PubSub.broadcast(Backend.PubSub, "map:" <> map_id, payload)
+  end
+end

--- a/backend/lib/backend/repo.ex
+++ b/backend/lib/backend/repo.ex
@@ -1,0 +1,5 @@
+defmodule Backend.Repo do
+  use Ecto.Repo,
+    otp_app: :backend,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/backend/lib/backend/state.ex
+++ b/backend/lib/backend/state.ex
@@ -107,7 +107,12 @@ defmodule Backend.State do
             campaign_id: campaign.id,
             type: :move_players,
             occurred_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive(),
-            payload: %{q: 12, r: 18, reason: "Session start"}
+            payload:
+              Jason.encode!(%{
+                q: 12,
+                r: 18,
+                reason: "Session start"
+              })
           }
         ]
 

--- a/backend/lib/backend/state.ex
+++ b/backend/lib/backend/state.ex
@@ -1,0 +1,131 @@
+defmodule Backend.State do
+  @moduledoc """
+  Holds a lightweight in-memory representation of campaigns and their
+  maps so that the prototype can operate without a full database. The
+  structure mirrors the relational schema so it can be replaced by real
+  persistence later.
+  """
+
+  use Agent
+
+  alias Backend.Campaigns.Models.{Campaign, Hex, HexItem, ExplorationEvent}
+  alias Backend.Campaigns.Models.Map, as: CampaignMap
+
+  def start_link(_opts) do
+    Agent.start_link(fn -> %{campaigns: %{}, maps: %{}, hexes: %{}, items: %{}, events: []} end,
+      name: __MODULE__
+    )
+  end
+
+  def transaction(fun) when is_function(fun, 1) do
+    Agent.get_and_update(__MODULE__, fn state ->
+      {result, new_state} = fun.(state)
+      {result, new_state}
+    end)
+  end
+
+  def read(fun) when is_function(fun, 1) do
+    Agent.get(__MODULE__, fun)
+  end
+
+  def seed_demo_data do
+    transaction(fn state ->
+      if map_size(state.campaigns) > 0 do
+        {:ok, state}
+      else
+        campaign = %Campaign{
+          id: "cmp-1",
+          name: "Isles of Meridia",
+          description: "Sample campaign showcasing continent and region maps",
+          default_hex_size: 24,
+          maps: ["map-continent", "map-region"]
+        }
+
+        continent = %CampaignMap{
+          id: "map-continent",
+          campaign_id: campaign.id,
+          name: "Continent of Meridia",
+          hex_size_px: 64,
+          scale_ratio: 1.0,
+          parent_map_id: nil,
+          parent_region: nil,
+          tileset_path: "tiles/continent",
+          bounds: %{min_q: 0, max_q: 100, min_r: 0, max_r: 100},
+          explored_hexes: MapSet.new(),
+          current_player_hex: nil,
+          child_maps: [%{map_id: "map-region", region: %{q: 10..30, r: 10..30}}]
+        }
+
+        region = %CampaignMap{
+          id: "map-region",
+          campaign_id: campaign.id,
+          name: "Meridia Heartlands",
+          hex_size_px: 128,
+          scale_ratio: 0.125,
+          parent_map_id: "map-continent",
+          parent_region: %{min_q: 10, max_q: 30, min_r: 10, max_r: 30},
+          tileset_path: "tiles/region",
+          bounds: %{min_q: 0, max_q: 120, min_r: 0, max_r: 120},
+          explored_hexes: MapSet.new(),
+          current_player_hex: {12, 18},
+          child_maps: []
+        }
+
+        sample_hexes =
+          for q <- 0..20, r <- 0..20, into: %{} do
+            key = {region.id, q, r}
+
+            hex = %Hex{
+              id: "#{q}:#{r}",
+              map_id: region.id,
+              q: q,
+              r: r,
+              terrain: if(rem(q + r, 5) == 0, do: "forest", else: "plains"),
+              notes: nil
+            }
+
+            {key, hex}
+          end
+
+        sample_items = %{
+          {region.id, "10:12", "itm-1"} => %HexItem{
+            id: "itm-1",
+            hex_id: "10:12",
+            map_id: region.id,
+            name: "Ruined Tower",
+            description: "Crumbling watchtower haunted by specters",
+            icon: "icons/tower.svg",
+            visibility_distance: 2,
+            always_visible: false
+          }
+        }
+
+        events = [
+          %ExplorationEvent{
+            id: "evt-1",
+            map_id: region.id,
+            campaign_id: campaign.id,
+            type: :move_players,
+            occurred_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive(),
+            payload: %{q: 12, r: 18, reason: "Session start"}
+          }
+        ]
+
+        new_state =
+          state
+          |> put_in([:campaigns, campaign.id], campaign)
+          |> put_in([:maps, continent.id], continent)
+          |> put_in([:maps, region.id], region)
+          |> Map.update!(:hexes, &Map.merge(&1, sample_hexes))
+          |> Map.update!(:items, &Map.merge(&1, sample_items))
+          |> Map.put(:events, events)
+
+        {{:ok, campaign}, new_state}
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      other -> other
+    end
+  end
+end

--- a/backend/lib/backend/storage.ex
+++ b/backend/lib/backend/storage.ex
@@ -1,0 +1,19 @@
+defmodule Backend.Storage do
+  @moduledoc """
+  Lightweight abstraction for generating pre-signed upload URLs. In this
+  prototype the URLs are synthetic; integrate with ExAws or other SDKs
+  when moving to production.
+  """
+
+  @spec presign_upload(String.t(), keyword()) :: %{url: String.t(), fields: map()}
+  def presign_upload(path, opts \\ []) do
+    bucket = Application.fetch_env!(:backend, :storage)[:bucket]
+    endpoint = Application.fetch_env!(:backend, :storage)[:endpoint]
+    expires_in = Keyword.get(opts, :expires_in, 3_600)
+
+    %{
+      url: Path.join(endpoint, Path.join(bucket, path)),
+      fields: %{expires_in: expires_in}
+    }
+  end
+end

--- a/backend/lib/backend/workers/map_ingestion_worker.ex
+++ b/backend/lib/backend/workers/map_ingestion_worker.ex
@@ -1,0 +1,27 @@
+defmodule Backend.Workers.MapIngestionWorker do
+  @moduledoc """
+  Oban worker responsible for processing uploaded map assets. For now the
+  worker simply simulates progress events; wire up actual tiling logic
+  later using libvips or similar tooling.
+  """
+
+  use Oban.Worker, queue: :ingestion, max_attempts: 3
+
+  alias Backend.Events
+
+  @impl true
+  def perform(%Oban.Job{args: %{"map_id" => map_id, "campaign_id" => campaign_id}}) do
+    :timer.sleep(100)
+    Events.broadcast_campaign(campaign_id, {:map_processing_started, %{map_id: map_id}})
+    :timer.sleep(100)
+
+    Events.broadcast_campaign(
+      campaign_id,
+      {:map_processing_progress, %{map_id: map_id, progress: 0.5}}
+    )
+
+    :timer.sleep(100)
+    Events.broadcast_campaign(campaign_id, {:map_processing_complete, %{map_id: map_id}})
+    :ok
+  end
+end

--- a/backend/lib/backend_web.ex
+++ b/backend/lib/backend_web.ex
@@ -1,0 +1,50 @@
+defmodule BackendWeb do
+  @moduledoc """
+  Entry point for defining the web interface components such as
+  controllers, channels, and GraphQL schema helpers.
+  """
+
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: BackendWeb
+      import Plug.Conn
+      alias BackendWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  def schema do
+    quote do
+      use Absinthe.Schema
+      import_types(Absinthe.Type.Custom)
+    end
+  end
+
+  def view do
+    quote do
+      use Phoenix.View,
+        root: "lib/backend_web/templates",
+        namespace: BackendWeb
+
+      import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
+      alias BackendWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+      import Plug.Conn
+      import Phoenix.Controller
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/backend/lib/backend_web/channels/campaign_channel.ex
+++ b/backend/lib/backend_web/channels/campaign_channel.ex
@@ -1,0 +1,45 @@
+defmodule BackendWeb.CampaignChannel do
+  use BackendWeb, :channel
+
+  alias Backend.Campaigns
+
+  @impl true
+  def join("campaign:" <> campaign_id = topic, _params, socket) do
+    Phoenix.PubSub.subscribe(Backend.PubSub, topic)
+    {:ok, assign(socket, :campaign_id, campaign_id)}
+  end
+
+  @impl true
+  def handle_in("generate_player_link", params, socket) do
+    campaign_id = socket.assigns.campaign_id
+
+    case Campaigns.generate_player_link(campaign_id, params) do
+      {:ok, link} ->
+        {:reply, {:ok, %{link: link}}, socket}
+
+      {:error, reason} ->
+        {:reply, {:error, %{reason: reason}}, socket}
+    end
+  end
+
+  @impl true
+  def handle_info({:history_event, event}, socket) do
+    push(socket, "history_event", event)
+    {:noreply, socket}
+  end
+
+  def handle_info({:map_upserted, map}, socket) do
+    push(socket, "map_upserted", map)
+    {:noreply, socket}
+  end
+
+  def handle_info({:player_link_created, link}, socket) do
+    push(socket, "player_link_created", link)
+    {:noreply, socket}
+  end
+
+  def handle_info({event, payload}, socket) do
+    push(socket, to_string(event), payload)
+    {:noreply, socket}
+  end
+end

--- a/backend/lib/backend_web/channels/map_channel.ex
+++ b/backend/lib/backend_web/channels/map_channel.ex
@@ -1,0 +1,68 @@
+defmodule BackendWeb.MapChannel do
+  use BackendWeb, :channel
+
+  alias Backend.Campaigns
+
+  @impl true
+  def join("map:" <> map_id = topic, _params, socket) do
+    Phoenix.PubSub.subscribe(Backend.PubSub, topic)
+    {:ok, assign(socket, :map_id, map_id)}
+  end
+
+  @impl true
+  def handle_in("set_player_location", %{"q" => q, "r" => r}, socket) do
+    map_id = socket.assigns.map_id
+
+    case Campaigns.set_player_location(map_id, {q, r}) do
+      {:ok, map} ->
+        {:reply, {:ok, %{map: map}}, socket}
+
+      {:error, reason} ->
+        {:reply, {:error, %{reason: reason}}, socket}
+    end
+  end
+
+  def handle_in("reveal_hexes", %{"hexes" => hexes}, socket) do
+    map_id = socket.assigns.map_id
+    coords = Enum.map(hexes, fn %{"q" => q, "r" => r} -> {q, r} end)
+
+    {:ok, _map} = Campaigns.reveal_hexes(map_id, coords)
+    {:reply, {:ok, %{hexes: coords}}, socket}
+  end
+
+  @impl true
+  def handle_info({:player_moved, payload}, socket) do
+    push(socket, "player_moved", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({:hexes_revealed, payload}, socket) do
+    push(socket, "hexes_revealed", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({:hexes_concealed, payload}, socket) do
+    push(socket, "hexes_concealed", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({:hex_item_created, payload}, socket) do
+    push(socket, "hex_item_created", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({:hex_item_updated, payload}, socket) do
+    push(socket, "hex_item_updated", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({:hex_item_deleted, payload}, socket) do
+    push(socket, "hex_item_deleted", payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({event, payload}, socket) do
+    push(socket, to_string(event), payload)
+    {:noreply, socket}
+  end
+end

--- a/backend/lib/backend_web/channels/user_socket.ex
+++ b/backend/lib/backend_web/channels/user_socket.ex
@@ -1,0 +1,14 @@
+defmodule BackendWeb.UserSocket do
+  use Phoenix.Socket
+
+  channel("campaign:*", BackendWeb.CampaignChannel)
+  channel("map:*", BackendWeb.MapChannel)
+
+  def connect(%{"token" => token}, socket, _connect_info) do
+    {:ok, assign(socket, :token, token)}
+  end
+
+  def connect(_params, _socket, _connect_info), do: :error
+
+  def id(socket), do: "players:" <> socket.assigns.token
+end

--- a/backend/lib/backend_web/endpoint.ex
+++ b/backend/lib/backend_web/endpoint.ex
@@ -1,0 +1,23 @@
+defmodule BackendWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :backend
+
+  socket("/socket", BackendWeb.UserSocket,
+    websocket: true,
+    longpoll: false
+  )
+
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+
+  plug(Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+  )
+
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+  plug(Plug.Session, store: :cookie, key: "_backend_key", signing_salt: "hexcrawl")
+
+  plug(BackendWeb.Router)
+end

--- a/backend/lib/backend_web/gettext.ex
+++ b/backend/lib/backend_web/gettext.ex
@@ -1,0 +1,4 @@
+defmodule BackendWeb.Gettext do
+  @moduledoc false
+  use Gettext, otp_app: :backend
+end

--- a/backend/lib/backend_web/gettext.ex
+++ b/backend/lib/backend_web/gettext.ex
@@ -1,4 +1,4 @@
 defmodule BackendWeb.Gettext do
   @moduledoc false
-  use Gettext, otp_app: :backend
+  use Gettext.Backend, otp_app: :backend
 end

--- a/backend/lib/backend_web/resolvers/campaign_resolver.ex
+++ b/backend/lib/backend_web/resolvers/campaign_resolver.ex
@@ -1,0 +1,71 @@
+defmodule BackendWeb.Resolvers.CampaignResolver do
+  @moduledoc false
+
+  alias Backend.Campaigns
+
+  def list_campaigns(_parent, _args, _resolution) do
+    {:ok, Campaigns.list_campaigns()}
+  end
+
+  def campaign(_parent, %{id: id}, _resolution) do
+    case Campaigns.get_campaign(id) do
+      nil -> {:error, "Campaign not found"}
+      campaign -> {:ok, campaign}
+    end
+  end
+
+  def map(_parent, %{id: id}, _resolution) do
+    case Campaigns.get_campaign_for_map(id) do
+      nil -> {:error, "Map not found"}
+      map -> {:ok, map}
+    end
+  end
+
+  def exploration_history(_parent, args, _resolution) do
+    map_id = args[:map_id]
+    limit = Map.get(args, :limit, 20)
+    cursor = Map.get(args, :cursor)
+    {:ok, Campaigns.exploration_history(map_id, limit: limit, cursor: cursor)}
+  end
+
+  def set_player_location(_parent, %{map_id: map_id, q: q, r: r}, _resolution) do
+    case Campaigns.set_player_location(map_id, {q, r}) do
+      {:ok, map} -> {:ok, map}
+      {:error, reason} -> {:error, "Failed to set player location: #{inspect(reason)}"}
+    end
+  end
+
+  def reveal_hexes(_parent, %{map_id: map_id, hexes: hexes}, _resolution) do
+    coords = Enum.map(hexes, fn %{q: q, r: r} -> {q, r} end)
+
+    case Campaigns.reveal_hexes(map_id, coords) do
+      {:ok, map} -> {:ok, map}
+      {:error, reason} -> {:error, "Failed to reveal hexes: #{inspect(reason)}"}
+    end
+  end
+
+  def create_hex_item(_parent, %{map_id: map_id, hex: %{q: q, r: r}} = args, _res) do
+    attrs = Map.take(args, [:name, :description, :icon, :visibility_distance, :always_visible])
+
+    case Campaigns.create_hex_item(map_id, {q, r}, attrs) do
+      {:ok, item} -> {:ok, item}
+      {:error, reason} -> {:error, "Failed to create item: #{inspect(reason)}"}
+    end
+  end
+
+  def update_hex_item(_parent, %{map_id: map_id, hex: %{q: q, r: r}, id: id} = args, _res) do
+    attrs = Map.take(args, [:name, :description, :icon, :visibility_distance, :always_visible])
+
+    case Campaigns.update_hex_item(map_id, {q, r}, id, attrs) do
+      {:ok, item} -> {:ok, item}
+      {:error, reason} -> {:error, "Failed to update item: #{inspect(reason)}"}
+    end
+  end
+
+  def delete_hex_item(_parent, %{map_id: map_id, hex: %{q: q, r: r}, id: id}, _res) do
+    case Campaigns.delete_hex_item(map_id, {q, r}, id) do
+      {:ok, item} -> {:ok, item}
+      {:error, reason} -> {:error, "Failed to delete item: #{inspect(reason)}"}
+    end
+  end
+end

--- a/backend/lib/backend_web/router.ex
+++ b/backend/lib/backend_web/router.ex
@@ -1,0 +1,18 @@
+defmodule BackendWeb.Router do
+  use BackendWeb, :router
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  scope "/api" do
+    pipe_through(:api)
+
+    forward("/graphql", Absinthe.Plug, schema: BackendWeb.Schema)
+
+    forward("/graphiql", Absinthe.Plug.GraphiQL,
+      schema: BackendWeb.Schema,
+      interface: :playground
+    )
+  end
+end

--- a/backend/lib/backend_web/schema.ex
+++ b/backend/lib/backend_web/schema.ex
@@ -1,0 +1,75 @@
+defmodule BackendWeb.Schema do
+  use BackendWeb, :schema
+
+  alias BackendWeb.Resolvers.CampaignResolver
+
+  import_types(BackendWeb.Schema.Types.CampaignTypes)
+
+  query do
+    field :campaigns, list_of(:campaign) do
+      resolve(&CampaignResolver.list_campaigns/3)
+    end
+
+    field :campaign, :campaign do
+      arg(:id, non_null(:id))
+      resolve(&CampaignResolver.campaign/3)
+    end
+
+    field :map, :map do
+      arg(:id, non_null(:id))
+      resolve(&CampaignResolver.map/3)
+    end
+
+    field :exploration_history, list_of(:exploration_event) do
+      arg(:map_id, non_null(:id))
+      arg(:limit, :integer)
+      arg(:cursor, :id)
+      resolve(&CampaignResolver.exploration_history/3)
+    end
+  end
+
+  mutation do
+    field :set_player_location, :map do
+      arg(:map_id, non_null(:id))
+      arg(:q, non_null(:integer))
+      arg(:r, non_null(:integer))
+      resolve(&CampaignResolver.set_player_location/3)
+    end
+
+    field :reveal_hexes, :map do
+      arg(:map_id, non_null(:id))
+      arg(:hexes, non_null(list_of(:hex_coords_input)))
+      resolve(&CampaignResolver.reveal_hexes/3)
+    end
+
+    field :create_hex_item, :hex_item do
+      arg(:map_id, non_null(:id))
+      arg(:hex, non_null(:hex_coords_input))
+      arg(:name, non_null(:string))
+      arg(:description, :string)
+      arg(:icon, :string)
+      arg(:visibility_distance, :integer)
+      arg(:always_visible, :boolean)
+      resolve(&CampaignResolver.create_hex_item/3)
+    end
+
+    field :update_hex_item, :hex_item do
+      arg(:map_id, non_null(:id))
+      arg(:hex, non_null(:hex_coords_input))
+      arg(:id, non_null(:id))
+      arg(:name, :string)
+      arg(:description, :string)
+      arg(:icon, :string)
+      arg(:visibility_distance, :integer)
+      arg(:always_visible, :boolean)
+      resolve(&CampaignResolver.update_hex_item/3)
+    end
+
+    field :delete_hex_item, :hex_item do
+      arg(:map_id, non_null(:id))
+      arg(:hex, non_null(:hex_coords_input))
+      arg(:id, non_null(:id))
+      resolve(&CampaignResolver.delete_hex_item/3)
+    end
+  end
+end

--- a/backend/lib/backend_web/schema.ex
+++ b/backend/lib/backend_web/schema.ex
@@ -3,6 +3,7 @@ defmodule BackendWeb.Schema do
 
   alias BackendWeb.Resolvers.CampaignResolver
 
+  import_types(Absinthe.Type.Custom)
   import_types(BackendWeb.Schema.Types.CampaignTypes)
 
   query do

--- a/backend/lib/backend_web/schema/types/campaign_types.ex
+++ b/backend/lib/backend_web/schema/types/campaign_types.ex
@@ -76,7 +76,7 @@ defmodule BackendWeb.Schema.Types.CampaignTypes do
     field(:campaign_id, non_null(:id))
     field(:type, non_null(:string))
     field(:occurred_at, non_null(:naive_datetime))
-    field(:payload, non_null(:json))
+    field(:payload, non_null(:string))
   end
 
   input_object :hex_coords_input do

--- a/backend/lib/backend_web/schema/types/campaign_types.ex
+++ b/backend/lib/backend_web/schema/types/campaign_types.ex
@@ -1,0 +1,91 @@
+defmodule BackendWeb.Schema.Types.CampaignTypes do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  object :campaign do
+    field(:id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:description, :string)
+    field(:default_hex_size, non_null(:integer))
+    field(:maps, list_of(:map))
+    field(:share_links, list_of(:player_link))
+  end
+
+  object :map do
+    field(:id, non_null(:id))
+    field(:campaign_id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:hex_size_px, non_null(:integer))
+    field(:scale_ratio, non_null(:float))
+    field(:tileset_path, non_null(:string))
+    field(:bounds, non_null(:bounds))
+    field(:parent_map_id, :id)
+    field(:parent_region, :bounds)
+    field(:child_maps, list_of(:child_map_link))
+    field(:explored_hexes, list_of(:hex_coords))
+    field(:current_player_hex, :hex_coords)
+    field(:items, list_of(:hex_item))
+    field(:campaign, :campaign)
+  end
+
+  object :child_map_link do
+    field(:map_id, non_null(:id))
+    field(:region, :bounds)
+  end
+
+  object :bounds do
+    field(:min_q, non_null(:integer))
+    field(:max_q, non_null(:integer))
+    field(:min_r, non_null(:integer))
+    field(:max_r, non_null(:integer))
+  end
+
+  object :hex do
+    field(:id, non_null(:id))
+    field(:map_id, non_null(:id))
+    field(:q, non_null(:integer))
+    field(:r, non_null(:integer))
+    field(:terrain, non_null(:string))
+    field(:notes, :string)
+    field(:items, list_of(:hex_item))
+  end
+
+  object :hex_item do
+    field(:id, non_null(:id))
+    field(:map_id, non_null(:id))
+    field(:hex_id, non_null(:string))
+    field(:name, non_null(:string))
+    field(:description, :string)
+    field(:icon, :string)
+    field(:visibility_distance, non_null(:integer))
+    field(:always_visible, non_null(:boolean))
+  end
+
+  object :player_link do
+    field(:id, non_null(:id))
+    field(:token, non_null(:string))
+    field(:label, :string)
+    field(:expires_at, non_null(:naive_datetime))
+    field(:created_by, :string)
+  end
+
+  object :exploration_event do
+    field(:id, non_null(:id))
+    field(:map_id, non_null(:id))
+    field(:campaign_id, non_null(:id))
+    field(:type, non_null(:string))
+    field(:occurred_at, non_null(:naive_datetime))
+    field(:payload, non_null(:json))
+  end
+
+  input_object :hex_coords_input do
+    field(:q, non_null(:integer))
+    field(:r, non_null(:integer))
+  end
+
+  object :hex_coords do
+    field(:q, non_null(:integer))
+    field(:r, non_null(:integer))
+  end
+end

--- a/backend/lib/backend_web/schema/types/campaign_types.ex
+++ b/backend/lib/backend_web/schema/types/campaign_types.ex
@@ -3,12 +3,6 @@ defmodule BackendWeb.Schema.Types.CampaignTypes do
 
   use Absinthe.Schema.Notation
 
-  @desc "Arbitrary JSON value"
-  scalar :json do
-    serialize(& &1)
-    parse(&parse_json/1)
-  end
-
   object :campaign do
     field(:id, non_null(:id))
     field(:name, non_null(:string))
@@ -94,48 +88,4 @@ defmodule BackendWeb.Schema.Types.CampaignTypes do
     field(:q, non_null(:integer))
     field(:r, non_null(:integer))
   end
-
-  defp parse_json(%Absinthe.Blueprint.Input.String{value: value}) do
-    case Jason.decode(value) do
-      {:ok, decoded} -> {:ok, decoded}
-      _ -> :error
-    end
-  end
-
-  defp parse_json(%Absinthe.Blueprint.Input.Null{}), do: {:ok, nil}
-
-  defp parse_json(%Absinthe.Blueprint.Input.Raw{value: value})
-       when is_map(value) or is_list(value),
-       do: {:ok, value}
-
-  defp parse_json(%Absinthe.Blueprint.Input.Object{fields: fields}) do
-    Enum.reduce_while(fields, {:ok, %{}}, fn %{name: name, input_value: input_value},
-                                             {:ok, acc} ->
-      case parse_json(input_value) do
-        {:ok, value} -> {:cont, {:ok, Map.put(acc, name, value)}}
-        :error -> {:halt, :error}
-      end
-    end)
-    |> case do
-      {:ok, map} -> {:ok, map}
-      :error -> :error
-    end
-  end
-
-  defp parse_json(%Absinthe.Blueprint.Input.List{items: items}) do
-    items
-    |> Enum.reduce_while({:ok, []}, fn item, {:ok, acc} ->
-      case parse_json(item) do
-        {:ok, value} -> {:cont, {:ok, [value | acc]}}
-        :error -> {:halt, :error}
-      end
-    end)
-    |> case do
-      {:ok, values} -> {:ok, Enum.reverse(values)}
-      :error -> :error
-    end
-  end
-
-  defp parse_json(value) when is_map(value) or is_list(value), do: {:ok, value}
-  defp parse_json(value), do: {:ok, value}
 end

--- a/backend/lib/backend_web/telemetry.ex
+++ b/backend/lib/backend_web/telemetry.ex
@@ -1,0 +1,34 @@
+defmodule BackendWeb.Telemetry do
+  @moduledoc false
+
+  use Supervisor
+  import Telemetry.Metrics
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_arg) do
+    children = [
+      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def metrics do
+    [
+      summary("phoenix.endpoint.stop.duration", unit: {:native, :millisecond}),
+      summary("phoenix.router_dispatch.stop.duration",
+        tags: [:route],
+        unit: {:native, :millisecond}
+      ),
+      summary("oban.job.stop.duration", tags: [:queue], unit: {:native, :millisecond})
+    ]
+  end
+
+  defp periodic_measurements do
+    []
+  end
+end

--- a/backend/lib/backend_web/views/error_view.ex
+++ b/backend/lib/backend_web/views/error_view.ex
@@ -1,0 +1,7 @@
+defmodule BackendWeb.ErrorView do
+  use BackendWeb, :view
+
+  def render("404.json", _assigns), do: %{error: %{message: "Not found"}}
+  def render("500.json", _assigns), do: %{error: %{message: "Internal server error"}}
+  def template_not_found(_template, assigns), do: render("500.json", assigns)
+end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -7,7 +7,7 @@ defmodule Backend.MixProject do
       version: "0.1.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases()

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -1,0 +1,52 @@
+defmodule Backend.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :backend,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      aliases: aliases()
+    ]
+  end
+
+  def application do
+    [
+      mod: {Backend.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:phoenix_ecto, "~> 4.5"},
+      {:ecto_sql, "~> 3.11"},
+      {:postgrex, "~> 0.17"},
+      {:oban, "~> 2.17"},
+      {:absinthe, "~> 1.7"},
+      {:absinthe_plug, "~> 1.5"},
+      {:guardian, "~> 2.3"},
+      {:jason, "~> 1.4"},
+      {:plug_cowboy, "~> 2.7"},
+      {:phoenix_view, "~> 2.0"},
+      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_poller, "~> 1.1"},
+      {:gettext, "~> 0.24"}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get"]
+    ]
+  end
+end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: hex_crawl_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio:RELEASE.2024-01-11T05-49-28Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+  backend:
+    build:
+      context: ./backend
+    environment:
+      DATABASE_URL: ecto://postgres:postgres@postgres:5432/hex_crawl_dev
+      SECRET_KEY_BASE: devsecretkeybase000000000000000000000
+      STORAGE_BUCKET: hexcrawl
+      STORAGE_ENDPOINT: http://minio:9000/
+      STORAGE_ACCESS_KEY: minioadmin
+      STORAGE_SECRET_KEY: minioadmin
+      STORAGE_REGION: us-east-1
+      PORT: 4000
+    ports:
+      - "4000:4000"
+    depends_on:
+      - postgres
+      - redis
+      - minio
+
+  frontend:
+    build:
+      context: ./frontend
+    environment:
+      VITE_GRAPHQL_URL: http://localhost:4000/api/graphql
+      VITE_SOCKET_URL: ws://localhost:4000/socket
+    ports:
+      - "5173:4173"
+    depends_on:
+      - backend
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,136 @@
+# Hex Crawl Web Application Architecture (Option C Stack)
+
+## Overview
+This document captures the solution architecture for the hex crawl web application using the Option C technology stack:
+
+- **Frontend:** SvelteKit SPA with TypeScript and Vite.
+- **Backend:** Elixir Phoenix application exposing a GraphQL API via Absinthe.
+- **Realtime:** Phoenix Channels (WebSocket) for bidirectional DM/player sync.
+- **Background Jobs:** Oban (PostgreSQL-backed) for long-running and resource-intensive work.
+- **Database:** PostgreSQL for relational data.
+- **Object Storage:** S3-compatible services (AWS S3, GCS, Azure Blob) with first-class support for MinIO in self-hosted environments.
+- **Caching/Presence:** Redis for ephemeral session data, rate limiting, and realtime presence (optional but recommended).
+- **Deployment:** Containerized workloads deployable to Kubernetes (with Helm) and docker-compose for development/local testing.
+
+## Core Services
+
+### 1. SvelteKit Frontend
+- Entry points for Dungeon Masters (authenticated) and Players (link-based access).
+- Uses MapLibre GL JS for map rendering with custom WebGL layers for hex overlays.
+- Integrates with the Phoenix backend via GraphQL queries/mutations (Absinthe) and Phoenix Channels for realtime updates.
+- Implements role-aware UI states: DM dashboards, collaborative editing, fog-of-war visualizations, nested map navigation, exploration history timeline.
+- Handles resumable uploads (tus protocol) by requesting pre-signed URLs from the backend and streaming map/icon files directly to object storage.
+
+### 2. Phoenix Backend (GraphQL + Channels)
+- Phoenix/Absinthe GraphQL schema hosts campaign, map, hex, item, and history types.
+- Phoenix Channels provide realtime topics per campaign and per map. Channels broadcast DM actions (explore hex, move players, add items) to subscribed players and co-DMs.
+- Uses Guardian or Pow for authentication, issuing JWT access tokens for DMs. Player share links embed signed tokens stored in the `player_links` table.
+- Context modules encapsulate business logic: Campaigns, Maps, Hexes, Items, History, Storage, Auth.
+
+### 3. Oban Worker Service
+- Runs within the Phoenix application with dedicated queues for asset ingestion, tiling, fog-of-war preprocessing, icon processing, and cleanup tasks.
+- Supports concurrency control and retries for large map tiling (up to 16k x 16k) using libvips bindings via ImageMagick/FFI libraries.
+- Publishes job status events to Phoenix Channels so DMs can monitor map processing progress.
+
+### 4. Data Storage Layer
+- PostgreSQL maintains normalized schema (see "Data Model" section).
+- Object storage retains original uploads, generated tile pyramids (XYZ/quadkey), overlay assets, and custom icons.
+- Redis caches GraphQL query results (short TTL), maintains channel presence, and backs rate-limiting policies.
+
+## Detailed Feature Considerations
+
+### Map Ingestion & Tiling Pipeline
+1. DM uploads map via pre-signed direct upload.
+2. Backend validates metadata (pixel dimensions, file type, hex size).
+3. Oban job generates multi-resolution tile pyramid using libvips; persists tiles to object storage, storing references in `map_assets` table.
+4. Hex grid geometry and optional vector overlays are computed and stored as GeoJSON for frontend consumption.
+5. Parent-child map links store bounding boxes and scale ratios, enabling seamless transition between continent and regional maps.
+
+### Realtime Collaboration
+- Phoenix Channels topics: `campaign:<id>` for global events, `map:<map_id>` for map-specific updates.
+- Payload filtering ensures players only receive data they are authorized to see (fog-of-war visibility, item distance rules).
+- Presence tracking (Phoenix Presence backed by Redis) shows active DMs/assistants and connected player sessions.
+- Channel events mirror GraphQL mutations so the SvelteKit client can optimistically update UI state.
+
+### Fog-of-War & Visibility Logic
+- Current player hex state cached in Redis for quick lookup.
+- Visibility calculation uses axial coordinates: item visible if `distance(player_hex, item_hex) ≤ visibility_distance` (supporting ∞ for always visible).
+- Explored hexes flagged in DB; player channel payload only contains explored geometry. History timeline logs events (`RevealHex`, `MovePlayers`, `ItemDiscovered`).
+- Optional background jobs pre-render fog-of-war rasters for large maps to reduce client-side processing.
+
+### Nested Map Navigation
+- `maps` table includes `parent_map_id`, `parent_hex_region` (q/r ranges), and `scale_ratio` fields.
+- Frontend displays breadcrumbs and minimap overlays. Clicking a parent hex can open a child map; returning shows aggregated exploration status.
+
+### Icon Management
+- DMs upload custom icons; backend validates file size/type and generates multiple resolutions via Oban job.
+- Icons stored in object storage, referenced by `icon_assets` table, and served via CDN with signed URLs.
+
+## GraphQL Schema Highlights
+- **Queries**
+  - `campaign(id)` – returns campaign details, maps, members, links.
+  - `map(id)` – fetches map metadata, hex summaries, active player location.
+  - `hex(mapId, q, r)` – returns hex info, items (filtered by visibility for players).
+  - `explorationHistory(mapId, paging)` – timeline entries.
+- **Mutations** (DM/assistant only)
+  - `createMap`, `linkMap`, `startMapProcessing`.
+  - `setPlayerLocation(mapId, hex)`.
+  - `revealHexes(mapId, hexIds)`; `concealHexes`.
+  - `createHexItem`, `updateHexItem`, `deleteHexItem`.
+  - `generatePlayerLink`, `revokePlayerLink`.
+- **Subscriptions**
+  - `campaignEvents(campaignId)` – DM/admin view.
+  - `playerMapEvents(mapId, token)` – filtered events for players.
+
+## Data Model (Key Tables)
+- `users`: DMs/assistants with auth credentials.
+- `campaigns`: root entity; includes settings for default hex sizes and fog-of-war behavior.
+- `campaign_members`: user role assignments per campaign.
+- `player_links`: signed tokens, permissions, expiration.
+- `maps`: metadata, hex sizing, parent-child relationships.
+- `map_assets`: original upload path, tile set reference, status.
+- `hexes`: axial coordinates, exploration flags, DM notes.
+- `hex_items`: item details, icon reference, visibility distance.
+- `exploration_events`: event log with payload JSONB for timeline replay.
+- `icons`: custom icon metadata and storage paths.
+
+## Deployment & DevOps
+
+### Containerization
+- Multi-stage Dockerfiles:
+  - **Frontend:** Node 20 base image for build, Nginx (or Node adapter) for serving static assets.
+  - **Backend:** Elixir/OTP release built via `mix release`; includes Oban worker runtime.
+- Environment variables configure DB, Redis, object storage endpoints, JWT secrets.
+
+### Kubernetes (Recommended Stack)
+- **Ingress:** NGINX Ingress Controller with cert-manager for TLS management.
+- **Secrets:** External Secrets Operator sourcing from cloud secret managers or sealed-secrets for GitOps.
+- **PostgreSQL:** Managed service (RDS, Cloud SQL) or bitnami Helm chart for dev clusters.
+- **Redis:** bitnami/redis chart for caching/presence.
+- **Object Storage:** Use external S3/GCS or deploy MinIO operator for on-cluster hosting.
+- **CI/CD:** GitHub Actions pipeline to build/push images, run tests (frontend + backend), apply migrations, and deploy via Helm.
+
+### docker-compose (Local Development)
+- Services: frontend, backend, postgres, redis, minio, mailhog.
+- Backend container runs migrations and seeds, exposes GraphQL playground and channels at `localhost:4000`.
+- Frontend dev server runs at `localhost:5173` proxying API requests.
+- MinIO console available for inspecting uploaded assets.
+
+### Observability
+- **Metrics:** Prometheus (via kube-prometheus stack) scraping Phoenix telemetry and Oban metrics; Grafana dashboards for job durations, channel activity.
+- **Logging:** JSON-structured logs shipped to Loki/ELK.
+- **Tracing:** OpenTelemetry instrumentation in Phoenix and SvelteKit (via OTLP exporter) feeding Jaeger/Tempo.
+
+## Security Considerations
+- Enforce HTTPS everywhere with HSTS.
+- Signed URLs for object storage access; player tokens scoped to campaign/map and short-lived.
+- Role-based authorization enforced in Absinthe resolvers; guard channels with token verification.
+- Rate limiting on map uploads and share link generation (Redis-based).
+- Audit trail for DM actions stored in `exploration_events` and optionally replicated to long-term storage.
+
+## Open Questions / Future Enhancements
+- Should we support offline caching for players (service workers)?
+- Consider integrating turn-based log exports (PDF, CSV) from exploration history.
+- Potential for AI-assisted content suggestions (future iteration).
+- Evaluate cost of precomputing fog-of-war rasters vs. dynamic on-demand generation once initial prototype is built.
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+.vite/
+.svelte-kit/
+.DS_Store
+npm-debug.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20.11-bullseye AS build
+WORKDIR /app
+COPY package.json package.json
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20.11-bullseye AS app
+WORKDIR /app
+COPY --from=build /app/build build
+COPY package.json package.json
+RUN npm install --omit=dev
+EXPOSE 4173
+CMD ["node", "build/index.js"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hex-crawl-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "graphql": "^16.8.1",
+    "graphql-request": "^7.1.0",
+    "maplibre-gl": "^3.5.1",
+    "phoenix": "^1.7.7",
+    "svelte": "^4.2.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-node": "^1.3.0",
+    "@sveltejs/kit": "^1.30.0",
+    "@types/maplibre-gl": "^2.4.10",
+    "svelte-check": "^3.6.0",
+    "tslib": "^2.6.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,0 +1,12 @@
+// See https://kit.svelte.dev/docs/types#app for information about these interfaces
+// and what to do when importing types
+declare global {
+  namespace App {
+    // interface Locals {}
+    // interface PageData {}
+    // interface Error {}
+    // interface Platform {}
+  }
+}
+
+export {};

--- a/frontend/src/lib/components/HexMap.svelte
+++ b/frontend/src/lib/components/HexMap.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import maplibregl from 'maplibre-gl';
+  import { onDestroy, onMount } from 'svelte';
+  import type { HexCoords, HexItem, MapDetail } from '$graphql/types';
+
+  export let mapDetail: MapDetail;
+  export let interactive = true;
+
+  let mapContainer: HTMLDivElement | null = null;
+  let map: maplibregl.Map | null = null;
+  const scale = 0.01;
+
+  const hexRadius = 0.008;
+
+  function coordsToLngLat(coords: HexCoords) {
+    return [coords.q * scale, coords.r * scale];
+  }
+
+  function hexPolygon(coords: HexCoords) {
+    const [cx, cy] = coordsToLngLat(coords);
+    const points: [number, number][] = [];
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 3) * i + Math.PI / 6;
+      const x = cx + hexRadius * Math.cos(angle);
+      const y = cy + hexRadius * Math.sin(angle);
+      points.push([x, y]);
+    }
+    points.push(points[0]);
+    return points;
+  }
+
+  function buildHexFeatureCollection(hexes: HexCoords[]) {
+    return {
+      type: 'FeatureCollection',
+      features: hexes.map((hex) => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [hexPolygon(hex)]
+        },
+        properties: { q: hex.q, r: hex.r }
+      }))
+    };
+  }
+
+  function buildItemsFeatureCollection(items: HexItem[]) {
+    return {
+      type: 'FeatureCollection',
+      features: items.map((item) => {
+        const [q, r] = item.hex_id.split(':').map((v) => Number(v));
+        return {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: coordsToLngLat({ q, r })
+          },
+          properties: {
+            title: item.name,
+            icon: item.icon ?? 'marker'
+          }
+        };
+      })
+    };
+  }
+
+  function updateSources() {
+    if (!map) return;
+
+    const exploredSource = map.getSource('explored-hexes') as maplibregl.GeoJSONSource;
+    exploredSource?.setData(buildHexFeatureCollection(mapDetail.explored_hexes || []));
+
+    const itemsSource = map.getSource('hex-items') as maplibregl.GeoJSONSource;
+    itemsSource?.setData(buildItemsFeatureCollection(mapDetail.items || []));
+
+    const playerSource = map.getSource('player-position') as maplibregl.GeoJSONSource;
+    if (playerSource) {
+      if (mapDetail.current_player_hex) {
+        playerSource.setData({
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: coordsToLngLat(mapDetail.current_player_hex)
+              },
+              properties: {}
+            }
+          ]
+        });
+      } else {
+        playerSource.setData({ type: 'FeatureCollection', features: [] });
+      }
+    }
+  }
+
+  function fitBounds() {
+    if (!map) return;
+    const bounds = new maplibregl.LngLatBounds();
+    const { min_q, max_q, min_r, max_r } = mapDetail.bounds;
+    bounds.extend(coordsToLngLat({ q: min_q, r: min_r }));
+    bounds.extend(coordsToLngLat({ q: max_q, r: max_r }));
+    map.fitBounds(bounds, { padding: 40, animate: false });
+  }
+
+  onMount(() => {
+    if (!mapContainer) return;
+    map = new maplibregl.Map({
+      container: mapContainer,
+      style: {
+        version: 8,
+        name: 'blank',
+        sources: {},
+        layers: [
+          {
+            id: 'background',
+            type: 'background',
+            paint: {
+              'background-color': '#05060a'
+            }
+          }
+        ]
+      },
+      center: [0, 0],
+      zoom: 1,
+      interactive
+    });
+
+    map.on('load', () => {
+      map!.addSource('explored-hexes', {
+        type: 'geojson',
+        data: buildHexFeatureCollection(mapDetail.explored_hexes || [])
+      });
+
+      map!.addLayer({
+        id: 'hex-fill',
+        type: 'fill',
+        source: 'explored-hexes',
+        paint: {
+          'fill-color': '#34d399',
+          'fill-opacity': 0.35
+        }
+      });
+
+      map!.addLayer({
+        id: 'hex-outline',
+        type: 'line',
+        source: 'explored-hexes',
+        paint: {
+          'line-color': '#10b981',
+          'line-width': 1.5
+        }
+      });
+
+      map!.addSource('hex-items', {
+        type: 'geojson',
+        data: buildItemsFeatureCollection(mapDetail.items || [])
+      });
+
+      map!.addLayer({
+        id: 'hex-items-label',
+        type: 'symbol',
+        source: 'hex-items',
+        layout: {
+          'text-field': ['get', 'title'],
+          'text-size': 12,
+          'text-offset': [0, 1.2],
+          'text-anchor': 'top'
+        },
+        paint: {
+          'text-color': '#facc15'
+        }
+      });
+
+      map!.addSource('player-position', {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: []
+        }
+      });
+
+      map!.addLayer({
+        id: 'player-circle',
+        type: 'circle',
+        source: 'player-position',
+        paint: {
+          'circle-radius': 6,
+          'circle-color': '#f97316',
+          'circle-stroke-color': '#fff',
+          'circle-stroke-width': 1.5
+        }
+      });
+
+      updateSources();
+      fitBounds();
+    });
+  });
+
+  $: if (map) {
+    updateSources();
+  }
+
+  onDestroy(() => {
+    map?.remove();
+    map = null;
+  });
+</script>
+
+<div bind:this={mapContainer} class="hex-map"></div>
+
+<style>
+  .hex-map {
+    width: 100%;
+    height: 480px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(88, 166, 255, 0.2);
+  }
+</style>

--- a/frontend/src/lib/graphql/client.ts
+++ b/frontend/src/lib/graphql/client.ts
@@ -1,0 +1,160 @@
+import { GraphQLClient, gql } from 'graphql-request';
+
+const endpoint = import.meta.env.VITE_GRAPHQL_URL || 'http://localhost:4000/api/graphql';
+
+export const client = new GraphQLClient(endpoint, {
+  headers: {
+    'content-type': 'application/json'
+  }
+});
+
+export const Queries = {
+  CampaignSummaries: gql`
+    query CampaignSummaries {
+      campaigns {
+        id
+        name
+        description
+        default_hex_size
+        maps {
+          id
+          name
+          hex_size_px
+          scale_ratio
+          tileset_path
+          explored_hexes {
+            q
+            r
+          }
+          current_player_hex {
+            q
+            r
+          }
+        }
+        share_links {
+          id
+          token
+          expires_at
+        }
+      }
+    }
+  `,
+  CampaignDetail: gql`
+    query CampaignDetail($id: ID!) {
+      campaign(id: $id) {
+        id
+        name
+        description
+        default_hex_size
+        maps {
+          id
+          name
+          hex_size_px
+          scale_ratio
+          tileset_path
+          explored_hexes {
+            q
+            r
+          }
+          current_player_hex {
+            q
+            r
+          }
+        }
+        share_links {
+          id
+          token
+          label
+          expires_at
+        }
+      }
+    }
+  `,
+  MapDetail: gql`
+    query MapDetail($id: ID!) {
+      map(id: $id) {
+        id
+        name
+        tileset_path
+        bounds {
+          min_q
+          max_q
+          min_r
+          max_r
+        }
+        explored_hexes {
+          q
+          r
+        }
+        current_player_hex {
+          q
+          r
+        }
+        items {
+          id
+          name
+          description
+          icon
+          visibility_distance
+          always_visible
+          hex_id
+        }
+        campaign {
+          id
+          name
+        }
+      }
+    }
+  `,
+  ExplorationHistory: gql`
+    query History($mapId: ID!, $limit: Int) {
+      explorationHistory(mapId: $mapId, limit: $limit) {
+        id
+        type
+        occurred_at
+        payload
+      }
+    }
+  `
+};
+
+export const Mutations = {
+  SetPlayerLocation: gql`
+    mutation SetPlayerLocation($mapId: ID!, $q: Int!, $r: Int!) {
+      setPlayerLocation(mapId: $mapId, q: $q, r: $r) {
+        id
+        current_player_hex {
+          q
+          r
+        }
+        explored_hexes {
+          q
+          r
+        }
+      }
+    }
+  `,
+  RevealHexes: gql`
+    mutation RevealHexes($mapId: ID!, $hexes: [HexCoordsInput!]!) {
+      revealHexes(mapId: $mapId, hexes: $hexes) {
+        id
+        explored_hexes {
+          q
+          r
+        }
+      }
+    }
+  `,
+  CreateHexItem: gql`
+    mutation CreateHexItem($mapId: ID!, $hex: HexCoordsInput!, $name: String!, $description: String, $visibility_distance: Int, $always_visible: Boolean) {
+      createHexItem(mapId: $mapId, hex: $hex, name: $name, description: $description, visibility_distance: $visibility_distance, always_visible: $always_visible) {
+        id
+        name
+        description
+        visibility_distance
+        always_visible
+        hex_id
+      }
+    }
+  `
+};

--- a/frontend/src/lib/graphql/types.ts
+++ b/frontend/src/lib/graphql/types.ts
@@ -46,5 +46,5 @@ export type ExplorationEvent = {
   id: string;
   type: string;
   occurred_at: string;
-  payload: Record<string, unknown>;
+  payload: string;
 };

--- a/frontend/src/lib/graphql/types.ts
+++ b/frontend/src/lib/graphql/types.ts
@@ -1,0 +1,50 @@
+export type HexCoords = { q: number; r: number };
+
+export type HexItem = {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  visibility_distance: number;
+  always_visible: boolean;
+  hex_id: string;
+};
+
+export type MapSummary = {
+  id: string;
+  name: string;
+  hex_size_px: number;
+  scale_ratio: number;
+  tileset_path: string;
+  explored_hexes: HexCoords[];
+  current_player_hex?: HexCoords | null;
+};
+
+export type CampaignSummary = {
+  id: string;
+  name: string;
+  description?: string;
+  default_hex_size: number;
+  maps: MapSummary[];
+  share_links: PlayerLink[];
+};
+
+export type PlayerLink = {
+  id: string;
+  token: string;
+  label?: string | null;
+  expires_at: string;
+};
+
+export type MapDetail = MapSummary & {
+  bounds: { min_q: number; max_q: number; min_r: number; max_r: number };
+  items: HexItem[];
+  campaign: { id: string; name: string };
+};
+
+export type ExplorationEvent = {
+  id: string;
+  type: string;
+  occurred_at: string;
+  payload: Record<string, unknown>;
+};

--- a/frontend/src/lib/realtime/socket.ts
+++ b/frontend/src/lib/realtime/socket.ts
@@ -1,0 +1,41 @@
+import { Socket, Channel } from 'phoenix';
+
+export type SubscriptionHandlers = {
+  onPlayerMoved?: (payload: { coords: { q: number; r: number }; event?: unknown }) => void;
+  onHexReveal?: (payload: { hexes: { q: number; r: number }[]; event?: unknown }) => void;
+  onHistoryEvent?: (payload: unknown) => void;
+  onItemCreated?: (payload: unknown) => void;
+  onItemUpdated?: (payload: unknown) => void;
+  onItemDeleted?: (payload: unknown) => void;
+};
+
+let socket: Socket | null = null;
+
+export function getSocket(): Socket {
+  if (!socket) {
+    const endpoint = import.meta.env.VITE_SOCKET_URL || 'ws://localhost:4000/socket';
+    socket = new Socket(endpoint, { params: { token: 'public-player' } });
+    socket.connect();
+  }
+  return socket;
+}
+
+export function subscribeToMap(mapId: string, handlers: SubscriptionHandlers): Channel {
+  const channel = getSocket().channel(`map:${mapId}`);
+
+  channel.on('player_moved', (payload) => handlers.onPlayerMoved?.(payload));
+  channel.on('hexes_revealed', (payload) => handlers.onHexReveal?.(payload));
+  channel.on('hex_item_created', (payload) => handlers.onItemCreated?.(payload));
+  channel.on('hex_item_updated', (payload) => handlers.onItemUpdated?.(payload));
+  channel.on('hex_item_deleted', (payload) => handlers.onItemDeleted?.(payload));
+
+  channel.join().receive('error', (err) => console.error('Failed to join map channel', err));
+  return channel;
+}
+
+export function subscribeToCampaign(campaignId: string, handlers: SubscriptionHandlers): Channel {
+  const channel = getSocket().channel(`campaign:${campaignId}`);
+  channel.on('history_event', (payload) => handlers.onHistoryEvent?.(payload));
+  channel.join().receive('error', (err) => console.error('Failed to join campaign channel', err));
+  return channel;
+}

--- a/frontend/src/lib/stores/campaigns.ts
+++ b/frontend/src/lib/stores/campaigns.ts
@@ -1,0 +1,16 @@
+import { writable } from 'svelte/store';
+import { client, Queries } from '$graphql/client';
+import type { CampaignSummary, MapDetail } from '$graphql/types';
+
+export const campaigns = writable<CampaignSummary[]>([]);
+
+export async function loadCampaignSummaries(): Promise<CampaignSummary[]> {
+  const data = await client.request<{ campaigns: CampaignSummary[] }>(Queries.CampaignSummaries);
+  campaigns.set(data.campaigns);
+  return data.campaigns;
+}
+
+export async function loadMap(mapId: string): Promise<MapDetail> {
+  const data = await client.request<{ map: MapDetail }>(Queries.MapDetail, { id: mapId });
+  return data.map;
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  export let data;
+</script>
+
+<svelte:head>
+  <title>Hex Crawl Orchestrator</title>
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.5.1/dist/maplibre-gl.css" />
+</svelte:head>
+
+<div class="app-shell">
+  <header>
+    <h1>Hex Crawl Control Center</h1>
+    <nav>
+      <a href="/">Overview</a>
+      <a href="/dm">Dungeon Master</a>
+    </nav>
+  </header>
+  <main>
+    <slot />
+  </main>
+</div>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: 'Inter', system-ui, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+  }
+
+  a {
+    color: #58a6ff;
+    text-decoration: none;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+    border-bottom: 1px solid rgba(88, 166, 255, 0.3);
+  }
+
+  nav a {
+    margin-left: 1rem;
+  }
+
+  .app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  main {
+    flex: 1;
+    padding: 1.5rem 2rem;
+  }
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { loadCampaignSummaries } from '$stores/campaigns';
+  import type { CampaignSummary } from '$graphql/types';
+
+  let summaries: CampaignSummary[] = [];
+  let loading = true;
+  let error: string | null = null;
+
+  onMount(async () => {
+    try {
+      summaries = await loadCampaignSummaries();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to load campaigns';
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<section class="hero">
+  <h2>Collaborative exploration for tabletop worlds</h2>
+  <p>
+    Upload massive regional maps, overlay exploration hexes, and keep your players synchronized with real-time
+    reveals.
+  </p>
+</section>
+
+<section>
+  <h3>Active Campaigns</h3>
+  {#if loading}
+    <p>Loading campaigns…</p>
+  {:else if error}
+    <p class="error">{error}</p>
+  {:else if summaries.length === 0}
+    <p>No campaigns yet. Head to the Dungeon Master view to start one.</p>
+  {:else}
+    <div class="campaign-grid">
+      {#each summaries as campaign}
+        <article class="campaign-card">
+          <h4>{campaign.name}</h4>
+          <p>{campaign.description}</p>
+          <div class="meta">
+            <span>Maps: {campaign.maps.length}</span>
+            <span>Default hex: {campaign.default_hex_size} miles</span>
+          </div>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .hero {
+    margin-bottom: 2rem;
+    background: linear-gradient(135deg, rgba(88, 166, 255, 0.18), rgba(56, 139, 253, 0));
+    padding: 2rem;
+    border-radius: 16px;
+  }
+
+  .campaign-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+
+  .campaign-card {
+    background: rgba(13, 17, 23, 0.75);
+    border: 1px solid rgba(88, 166, 255, 0.2);
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .meta {
+    margin-top: 0.5rem;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    opacity: 0.8;
+  }
+
+  .error {
+    color: #ff7b72;
+  }
+</style>

--- a/frontend/src/routes/dm/+page.svelte
+++ b/frontend/src/routes/dm/+page.svelte
@@ -232,7 +232,7 @@
         <li>
           <span class="timestamp">{new Date(entry.occurred_at).toLocaleString()}</span>
           <strong>{entry.type}</strong>
-          <code>{JSON.stringify(entry.payload)}</code>
+          <code>{entry.payload}</code>
         </li>
       {/each}
     </ul>

--- a/frontend/src/routes/dm/+page.svelte
+++ b/frontend/src/routes/dm/+page.svelte
@@ -1,0 +1,329 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import HexMap from '$components/HexMap.svelte';
+  import { client, Mutations, Queries } from '$graphql/client';
+  import type { CampaignSummary, MapDetail, HexCoords, ExplorationEvent } from '$graphql/types';
+  import { loadCampaignSummaries } from '$stores/campaigns';
+  import { subscribeToMap, subscribeToCampaign } from '$realtime/socket';
+  import type { Channel } from 'phoenix';
+
+  let campaigns: CampaignSummary[] = [];
+  let selectedCampaign: CampaignSummary | null = null;
+  let selectedMap: MapDetail | null = null;
+  let history: ExplorationEvent[] = [];
+  let mapChannel: Channel | null = null;
+  let campaignChannel: Channel | null = null;
+  let movementInput: HexCoords = { q: 12, r: 18 };
+  let revealInput = '13,18;13,19';
+  let statusMessage: string | null = null;
+
+  async function refreshCampaigns() {
+    campaigns = await loadCampaignSummaries();
+    selectedCampaign = campaigns[0] ?? null;
+    if (selectedCampaign && selectedCampaign.maps.length > 0) {
+      await loadMap(selectedCampaign.maps[0].id);
+      await loadHistory();
+      attachRealtime();
+    }
+  }
+
+  async function loadMap(mapId: string) {
+    const data = await client.request<{ map: MapDetail }>(Queries.MapDetail, { id: mapId });
+    selectedMap = data.map;
+  }
+
+  async function loadHistory(limit = 25) {
+    if (!selectedMap) return;
+    const data = await client.request<{ explorationHistory: ExplorationEvent[] }>(Queries.ExplorationHistory, {
+      mapId: selectedMap.id,
+      limit
+    });
+    history = data.explorationHistory;
+  }
+
+  function attachRealtime() {
+    detachRealtime();
+    if (!selectedMap || !selectedCampaign) return;
+    mapChannel = subscribeToMap(selectedMap.id, {
+      onPlayerMoved: ({ coords }) => {
+        if (!selectedMap) return;
+        selectedMap = {
+          ...selectedMap,
+          current_player_hex: coords,
+          explored_hexes: mergeHexes(selectedMap.explored_hexes, coords)
+        };
+      },
+      onHexReveal: ({ hexes }) => {
+        if (!selectedMap) return;
+        const merged = [...selectedMap.explored_hexes];
+        for (const hex of hexes) {
+          if (!merged.find((h) => h.q === hex.q && h.r === hex.r)) {
+            merged.push(hex);
+          }
+        }
+        selectedMap = { ...selectedMap, explored_hexes: merged };
+      },
+      onItemCreated: ({ item }) => {
+        if (!selectedMap || !item) return;
+        selectedMap = { ...selectedMap, items: [...selectedMap.items, item] };
+      },
+      onItemUpdated: ({ item }) => {
+        if (!selectedMap || !item) return;
+        selectedMap = {
+          ...selectedMap,
+          items: selectedMap.items.map((existing) => (existing.id === item.id ? item : existing))
+        };
+      },
+      onItemDeleted: ({ item }) => {
+        if (!selectedMap || !item) return;
+        selectedMap = {
+          ...selectedMap,
+          items: selectedMap.items.filter((existing) => existing.id !== item.id)
+        };
+      }
+    });
+
+    campaignChannel = subscribeToCampaign(selectedCampaign.id, {
+      onHistoryEvent: (event) => {
+        if (!event) return;
+        history = [event as ExplorationEvent, ...history].slice(0, 25);
+      }
+    });
+  }
+
+  function detachRealtime() {
+    mapChannel?.leave();
+    campaignChannel?.leave();
+    mapChannel = null;
+    campaignChannel = null;
+  }
+
+  function mergeHexes(existing: HexCoords[], coords: HexCoords): HexCoords[] {
+    if (existing.find((hex) => hex.q === coords.q && hex.r === coords.r)) {
+      return existing;
+    }
+    return [...existing, coords];
+  }
+
+  async function handleMapSelect(event: Event) {
+    const mapId = (event.target as HTMLSelectElement).value;
+    if (!mapId) return;
+    await loadMap(mapId);
+    await loadHistory();
+    attachRealtime();
+  }
+
+  async function handleCampaignSelect(event: Event) {
+    const campaignId = (event.target as HTMLSelectElement).value;
+    selectedCampaign = campaigns.find((c) => c.id === campaignId) ?? null;
+    if (selectedCampaign && selectedCampaign.maps.length > 0) {
+      await loadMap(selectedCampaign.maps[0].id);
+      await loadHistory();
+      attachRealtime();
+    } else {
+      selectedMap = null;
+      detachRealtime();
+    }
+  }
+
+  async function movePlayers() {
+    if (!selectedMap) return;
+    await client.request(Mutations.SetPlayerLocation, {
+      mapId: selectedMap.id,
+      q: movementInput.q,
+      r: movementInput.r
+    });
+    statusMessage = `Players moved to ${movementInput.q}, ${movementInput.r}`;
+  }
+
+  async function revealHexes() {
+    if (!selectedMap) return;
+    const parsed: HexCoords[] = revealInput
+      .split(';')
+      .map((pair) => pair.trim())
+      .filter(Boolean)
+      .map((pair) => {
+        const [q, r] = pair.split(',').map((v) => Number(v.trim()));
+        return { q, r };
+      });
+
+    if (parsed.length === 0) return;
+
+    await client.request(Mutations.RevealHexes, {
+      mapId: selectedMap.id,
+      hexes: parsed
+    });
+    statusMessage = `Revealed ${parsed.length} hexes.`;
+  }
+
+  onMount(async () => {
+    await refreshCampaigns();
+  });
+
+  onDestroy(() => {
+    detachRealtime();
+  });
+</script>
+
+<section class="dm-panel">
+  <div class="controls">
+    <div class="selector">
+      <label>Campaign</label>
+      <select on:change={handleCampaignSelect} value={selectedCampaign ? selectedCampaign.id : ""}>
+        {#each campaigns as campaign}
+          <option value={campaign.id}>{campaign.name}</option>
+        {/each}
+      </select>
+    </div>
+    {#if selectedCampaign}
+      <div class="selector">
+        <label>Map</label>
+        <select on:change={handleMapSelect} value={selectedMap ? selectedMap.id : ""}>
+          {#each selectedCampaign.maps as mapSummary}
+            <option value={mapSummary.id}>{mapSummary.name}</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
+  </div>
+
+  {#if selectedMap}
+    {@const currentMap = selectedMap as MapDetail}
+    <HexMap mapDetail={currentMap} />
+
+    <div class="actions">
+      <div>
+        <h3>Move players</h3>
+        <div class="grid">
+          <label>
+            Q
+            <input type="number" bind:value={movementInput.q} />
+          </label>
+          <label>
+            R
+            <input type="number" bind:value={movementInput.r} />
+          </label>
+          <button on:click={movePlayers}>Update location</button>
+        </div>
+      </div>
+      <div>
+        <h3>Reveal hexes</h3>
+        <label>
+          Coordinates (q,r pairs separated by semicolons)
+          <input bind:value={revealInput} placeholder="13,18;14,19" />
+        </label>
+        <button on:click={revealHexes}>Reveal</button>
+      </div>
+    </div>
+  {/if}
+
+  {#if statusMessage}
+    <p class="status">{statusMessage}</p>
+  {/if}
+</section>
+
+<section class="history">
+  <h2>Exploration history</h2>
+  {#if history.length === 0}
+    <p>No actions logged yet.</p>
+  {:else}
+    <ul>
+      {#each history as entry}
+        <li>
+          <span class="timestamp">{new Date(entry.occurred_at).toLocaleString()}</span>
+          <strong>{entry.type}</strong>
+          <code>{JSON.stringify(entry.payload)}</code>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .dm-panel {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .controls {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  select,
+  input,
+  button {
+    background: rgba(13, 17, 23, 0.75);
+    border: 1px solid rgba(88, 166, 255, 0.2);
+    color: #e6edf3;
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+  }
+
+  button {
+    cursor: pointer;
+    background: linear-gradient(135deg, rgba(88, 166, 255, 0.3), rgba(56, 139, 253, 0.5));
+    transition: opacity 0.2s ease;
+  }
+
+  button:hover {
+    opacity: 0.8;
+  }
+
+  .actions {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(60px, 1fr));
+    gap: 0.5rem;
+    align-items: end;
+  }
+
+  .grid button {
+    grid-column: span 2;
+  }
+
+  .status {
+    color: #34d399;
+  }
+
+  .history ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .history li {
+    background: rgba(13, 17, 23, 0.7);
+    border: 1px solid rgba(88, 166, 255, 0.12);
+    padding: 0.75rem;
+    border-radius: 8px;
+  }
+
+  .timestamp {
+    font-size: 0.85rem;
+    opacity: 0.7;
+    margin-right: 0.5rem;
+  }
+
+  code {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.05);
+    padding: 0.5rem;
+    border-radius: 4px;
+  }
+</style>

--- a/frontend/src/routes/player/[token]/+page.svelte
+++ b/frontend/src/routes/player/[token]/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import HexMap from '$components/HexMap.svelte';
+  import { client, Queries } from '$graphql/client';
+  import type { MapDetail } from '$graphql/types';
+  import { subscribeToMap } from '$realtime/socket';
+  import type { Channel } from 'phoenix';
+  import { page } from '$app/stores';
+  import { get } from 'svelte/store';
+
+  let mapDetail: MapDetail | null = null;
+  let channel: Channel | null = null;
+
+  async function load(mapId: string) {
+    const data = await client.request<{ map: MapDetail }>(Queries.MapDetail, { id: mapId });
+    mapDetail = data.map;
+  }
+
+  onMount(async () => {
+    const { params } = get(page);
+    const mapId = params.token;
+    await load(mapId);
+    channel = subscribeToMap(mapId, {
+      onPlayerMoved: ({ coords }) => {
+        if (!mapDetail) return;
+        mapDetail = { ...mapDetail, current_player_hex: coords };
+      },
+      onHexReveal: ({ hexes }) => {
+        if (!mapDetail) return;
+        const merged = [...mapDetail.explored_hexes];
+        for (const hex of hexes) {
+          if (!merged.find((h) => h.q === hex.q && h.r === hex.r)) {
+            merged.push(hex);
+          }
+        }
+        mapDetail = { ...mapDetail, explored_hexes: merged };
+      }
+    });
+  });
+
+  onDestroy(() => {
+    channel?.leave();
+  });
+</script>
+
+{#if mapDetail}
+  <h2>{mapDetail.campaign.name}: {mapDetail.name}</h2>
+  <HexMap mapDetail={mapDetail} interactive={false} />
+{:else}
+  <p>Loading map…</p>
+{/if}
+
+<style>
+  h2 {
+    margin-bottom: 1rem;
+  }
+</style>

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,0 +1,17 @@
+import adapter from '@sveltejs/adapter-node';
+import preprocess from 'svelte-preprocess';
+
+const config = {
+  preprocess: preprocess(),
+  kit: {
+    adapter: adapter(),
+    alias: {
+      $components: 'src/lib/components',
+      $graphql: 'src/lib/graphql',
+      $realtime: 'src/lib/realtime',
+      $stores: 'src/lib/stores'
+    }
+  }
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$components/*": ["src/lib/components/*"],
+      "$graphql/*": ["src/lib/graphql/*"],
+      "$realtime/*": ["src/lib/realtime/*"],
+      "$stores/*": ["src/lib/stores/*"]
+    }
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- implement the Phoenix backend with Absinthe GraphQL schema, Phoenix Channels, Oban worker stub, and in-memory state seeded with a demo campaign
- scaffold the SvelteKit frontend that renders DM and player map views with MapLibre tiles, GraphQL data fetching, and websocket updates via Phoenix channels
- add docker-compose orchestration, Dockerfiles, and updated documentation covering setup requirements and known limitations

## Testing
- mix format
- mix deps.get *(fails: 403 Forbidden from hex.pm in restricted environment)*
- npm install --package-lock-only *(fails: 403 Forbidden from npm registry in restricted environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ce2ebac448321bc6caac43ca612ed)