### PR TITLE
Seat recovery: release characters, remove stale seats

### DIFF
--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -7,9 +7,16 @@ public DNS entry at `hex-crawl.deeznuts.wiki`.
 All commands assume root SSH to `alder01` (172.16.1.10) and follow the homelab
 conventions already in use for the deeznuts-wiki stack.
 
-> **Status:** prepared but NOT executed — the deploying machine had no route to
-> the homelab LAN and Tailscale was offline. Run these once on-LAN (or once a
-> lab host is reachable).
+> **Status: EXECUTED 2026-08-29.** Live at https://hex-crawl.deeznuts.wiki and
+> http://hex-crawl.vaske.us:3000 (internal). Facts as deployed:
+> - iSCSI: target `block.vaske.us:hexcrawl` (zvol `block/hexcrawl`, 10 GiB sparse),
+>   XFS UUID `2bc8b607-9d5a-46c8-8f17-03f063adc57d`, node.startup=automatic
+> - Docker volume `hexcrawl_data`; image `hex-crawl:latest` built on alder01
+>   from `/root/hex-crawl-build`; compose project `hex-crawl` at
+>   `/root/stacks/hex-crawl` (mirrored in docker-compose repo `stacks/hex-crawl`)
+> - IP 172.16.2.40 (homenet); Traefik route `/dynamic/hex-crawl.yml`; public DNS
+>   A `hex-crawl.deeznuts.wiki -> 71.211.246.196` (Cloudflare); LE cert issued
+> - Campaign data seeded from dev `./data` (the deployed instance is authoritative now)
 
 ---
 

--- a/packages/client/src/components/panels/SettingsTab.tsx
+++ b/packages/client/src/components/panels/SettingsTab.tsx
@@ -39,19 +39,53 @@ export function SettingsTab({ campaignId }: { campaignId: string }) {
       <ShareLinks campaignId={campaignId} />
 
       <Section title="Seats">
+        <p className="text-xs text-ink-400 mb-2">
+          A seat is a browser that joined via an invite link. If a player lost their seat (new
+          device, cleared cookies), release their character here so they can claim it again after
+          re-joining, and remove the stale seat.
+        </p>
         <ul className="space-y-1">
-          {state.seats.map((seat) => (
-            <li key={seat.id} className="flex items-center gap-2 text-sm text-ink-200">
-              <span className={seat.online ? 'text-moss-500' : 'text-ink-600'}>●</span>
-              <span className="truncate">{seat.name}</span>
-              <span className="text-xs text-ink-400 uppercase">{seat.role}</span>
-              {seat.characterId && (
-                <span className="text-xs text-ink-400 truncate">
-                  → {state.characters.find((c) => c.id === seat.characterId)?.name}
+          {state.seats.map((seat) => {
+            const isMe = seat.id === useSession.getState().seatId;
+            return (
+              <li key={seat.id} className="flex items-center gap-2 text-sm text-ink-200">
+                <span className={seat.online ? 'text-moss-500' : 'text-ink-600'}>●</span>
+                <span className="truncate">
+                  {seat.name}
+                  {isMe && <span className="text-brass-400"> (you)</span>}
                 </span>
-              )}
-            </li>
-          ))}
+                <span className="text-xs text-ink-400 uppercase">{seat.role}</span>
+                {seat.characterId && (
+                  <span className="text-xs text-ink-400 truncate">
+                    → {state.characters.find((c) => c.id === seat.characterId)?.name}
+                  </span>
+                )}
+                <span className="flex-1" />
+                {seat.characterId && !isMe && (
+                  <button
+                    className="text-xs text-ink-400 hover:text-brass-300 cursor-pointer"
+                    title="Release this seat's character so someone can claim it again"
+                    onClick={() => send({ kind: 'seat.releaseCharacter', seatId: seat.id })}
+                  >
+                    release
+                  </button>
+                )}
+                {!isMe && (
+                  <button
+                    className="text-xs text-ink-400 hover:text-ember-500 cursor-pointer"
+                    title="Remove this seat (the browser behind it will have to re-join)"
+                    onClick={() => {
+                      if (confirm(`Remove seat "${seat.name}"? Their browser will need to re-join via the invite link.`)) {
+                        send({ kind: 'seat.delete', seatId: seat.id });
+                      }
+                    }}
+                  >
+                    ✕
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
       </Section>
     </div>

--- a/packages/client/src/views/CampaignGate.tsx
+++ b/packages/client/src/views/CampaignGate.tsx
@@ -121,6 +121,11 @@ function JoinForm({
           <Button type="submit" variant="primary" className="w-full" disabled={busy || !name.trim()}>
             {busy ? 'Joining…' : 'Join the table'}
           </Button>
+          <p className="text-xs text-ink-400 text-center">
+            Joined before? Your seat lives in the browser you used — open this link there and
+            you'll go straight in. If you're on a new device, join again and ask your DM to
+            release your character to you.
+          </p>
         </form>
       </div>
     </Centered>

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -245,6 +245,32 @@ describe('checks and encounters', () => {
   });
 });
 
+describe('seat recovery', () => {
+  it('DM can release a character claim and delete a stale seat; players cannot', () => {
+    const { charId, playerSeat } = setupPartyWithScout();
+    // Simulate a lost cookie: a second seat joins and cannot claim the character.
+    const newSeat = runtime.createSeat('player', 'Alice (new phone)');
+    expect(() =>
+      asSeat(newSeat, { kind: 'seat.claimCharacter', characterId: charId } as never),
+    ).toThrow(/already claimed/);
+    // Player seats cannot release others or delete seats.
+    expect(() =>
+      asSeat(newSeat, { kind: 'seat.releaseCharacter', seatId: playerSeat.id } as never),
+    ).toThrow(/DM/);
+    expect(() =>
+      asSeat(newSeat, { kind: 'seat.delete', seatId: playerSeat.id } as never),
+    ).toThrow(/DM/);
+    // DM releases the old seat's claim, deletes it, and the new seat claims.
+    dm({ kind: 'seat.releaseCharacter', seatId: playerSeat.id } as never);
+    dm({ kind: 'seat.delete', seatId: playerSeat.id } as never);
+    expect(runtime.seats.has(playerSeat.id)).toBe(false);
+    asSeat(newSeat, { kind: 'seat.claimCharacter', characterId: charId } as never);
+    expect(runtime.seats.get(newSeat.id)!.characterId).toBe(charId);
+    // DM cannot delete their own seat.
+    expect(() => dm({ kind: 'seat.delete', seatId: dmSeat.id } as never)).toThrow(/own seat/);
+  });
+});
+
 describe('narration', () => {
   it('narrate to all is visible to players; dm log entries are not', () => {
     const { playerSeat } = setupPartyWithScout();

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -354,6 +354,12 @@ export class CampaignRuntime {
     this.db.prepare('UPDATE seat SET name = ? WHERE id = ?').run(name, seatId);
   }
 
+  deleteSeat(seatId: string): void {
+    this.seats.delete(seatId);
+    this.online.delete(seatId);
+    this.db.prepare('DELETE FROM seat WHERE id = ?').run(seatId);
+  }
+
   claimCharacter(seatId: string, characterId: string | null): void {
     const seat = this.seats.get(seatId);
     if (!seat) throw new Error('Seat not found');

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -262,6 +262,18 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     ctx.runtime.renameSeat(ctx.seat.id, cmd.name);
   }) as Handler,
 
+  'seat.releaseCharacter': ((cmd: Extract<ClientCommand, { kind: 'seat.releaseCharacter' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    ctx.runtime.claimCharacter(cmd.seatId, null);
+  }) as Handler,
+
+  'seat.delete': ((cmd: Extract<ClientCommand, { kind: 'seat.delete' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    if (cmd.seatId === ctx.seat.id) throw new Error('You cannot remove your own seat');
+    ctx.runtime.deleteSeat(cmd.seatId);
+    ctx.hub.dropSeat(ctx.runtime, cmd.seatId);
+  }) as Handler,
+
   // -- content & clues -------------------------------------------------------
   'content.upsert': ((cmd: Extract<ClientCommand, { kind: 'content.upsert' }>, ctx: Ctx) => {
     requireDm(ctx);

--- a/packages/server/src/ws/hub.ts
+++ b/packages/server/src/ws/hub.ts
@@ -80,6 +80,19 @@ export class Hub {
     }
   }
 
+  /** Close every connection belonging to a seat (after the DM removes it). */
+  dropSeat(runtime: CampaignRuntime, seatId: string): void {
+    const room = this.rooms.get(runtime.id);
+    if (!room) return;
+    for (const conn of [...room]) {
+      if (conn.seat.id === seatId) {
+        conn.ws.close(4001, 'Seat removed by the DM');
+        room.delete(conn);
+      }
+    }
+    runtime.online.delete(seatId);
+  }
+
   /** Coalesced full-state resync for every client in the campaign. */
   scheduleSync(runtime: CampaignRuntime): void {
     if (this.pendingSync.has(runtime.id)) return;

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -234,6 +234,20 @@ export const SeatRenameCommand = z.object({
   name: z.string().min(1).max(60),
 });
 
+/** DM: release the character claimed by another seat (stale cookie recovery). */
+export const SeatReleaseCharacterCommand = z.object({
+  ...base,
+  kind: z.literal('seat.releaseCharacter'),
+  seatId: z.string(),
+});
+
+/** DM: remove a stale seat entirely. */
+export const SeatDeleteCommand = z.object({
+  ...base,
+  kind: z.literal('seat.delete'),
+  seatId: z.string(),
+});
+
 // --- content & clues --------------------------------------------------------
 
 export const ContentUpsertCommand = z.object({
@@ -345,6 +359,8 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   CharacterDeleteCommand,
   SeatClaimCharacterCommand,
   SeatRenameCommand,
+  SeatReleaseCharacterCommand,
+  SeatDeleteCommand,
   ContentUpsertCommand,
   ContentDeleteCommand,
   ClueRevealCommand,


### PR DESCRIPTION
DM tools for the lost-cookie case: release a seat's character claim and delete stale seats, plus join-page guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)