### PR TITLE
Token crowd spreading, teleport moves, drag hit-test fix

### DIFF
--- a/packages/client/src/components/PendingMoves.tsx
+++ b/packages/client/src/components/PendingMoves.tsx
@@ -36,14 +36,21 @@ export function PendingMoves() {
             </span>
             <button
               className="px-2.5 py-1 rounded-md text-xs font-medium bg-moss-500/20 text-moss-500 border border-moss-500/50 hover:bg-moss-500/35 cursor-pointer"
-              onClick={() => send({ kind: 'move.resolve', tokenId: pm.tokenId, approve: true })}
+              onClick={() => send({ kind: 'move.resolve', tokenId: pm.tokenId, approve: true, teleport: false })}
               title="Approve: the move happens, the trail is explored, discoveries fire"
             >
               ✓ Approve
             </button>
             <button
+              className="px-2 py-1 rounded-md text-xs font-medium bg-arcane-500/15 text-arcane-500 border border-arcane-500/40 hover:bg-arcane-500/30 cursor-pointer"
+              onClick={() => send({ kind: 'move.resolve', tokenId: pm.tokenId, approve: true, teleport: true })}
+              title="Teleport: the move happens instantly with no explored trail along the path"
+            >
+              ⚡
+            </button>
+            <button
               className="px-2.5 py-1 rounded-md text-xs font-medium bg-ember-500/15 text-ember-500 border border-ember-500/40 hover:bg-ember-500/30 cursor-pointer"
-              onClick={() => send({ kind: 'move.resolve', tokenId: pm.tokenId, approve: false })}
+              onClick={() => send({ kind: 'move.resolve', tokenId: pm.tokenId, approve: false, teleport: false })}
               title="Hold: the token stays put (roll an encounter first if something intervenes)"
             >
               ✗ Hold

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -1,4 +1,4 @@
-import { AlphaFilter, Application, Assets, Container, Graphics, Sprite, Text } from 'pixi.js';
+import { AlphaFilter, Application, Assets, Circle, Container, Graphics, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import type {
   CampaignState,
@@ -56,6 +56,8 @@ interface TokenView {
   targetX: number;
   targetY: number;
   dragging: boolean;
+  /** Shrink factor when sharing a hex with other tokens. */
+  crowdScale: number;
 }
 
 /**
@@ -129,6 +131,9 @@ export class CanvasEngine {
       return;
     }
     host.appendChild(this.app.canvas);
+    if (import.meta.env.DEV) {
+      (window as unknown as { __engine: CanvasEngine }).__engine = this;
+    }
 
     this.viewport = new Viewport({
       events: this.app.renderer.events,
@@ -158,6 +163,23 @@ export class CanvasEngine {
     this.viewport.addChild(this.exploredC);
     this.viewport.addChild(this.fogC);
     this.viewport.addChild(this.highlightG);
+
+    // Every layer except tokensC must be event-transparent: Pixi treats any
+    // Graphics whose geometry covers the pointer as a hit-search terminator
+    // even when non-interactive, which would steal pointerdown from tokens
+    // under the fog/highlight overlays.
+    for (const layer of [
+      this.imageLayerC,
+      this.terrainG,
+      this.gridG,
+      this.pinsC,
+      this.pendingC,
+      this.exploredC,
+      this.fogC,
+      this.highlightG,
+    ]) {
+      layer.eventMode = 'none';
+    }
 
     this.viewport.on('moved', () => {
       this.viewDirty = true;
@@ -600,7 +622,7 @@ export class CanvasEngine {
     const tokenWorldDiameter = this.layout.size * 1.1;
     const tokenScale = Math.max(1, TOKEN_MIN_SCREEN / (tokenWorldDiameter * zoom));
     for (const view of this.tokens.values()) {
-      view.root.scale.set(tokenScale);
+      view.root.scale.set(tokenScale * view.crowdScale);
     }
   }
 
@@ -863,9 +885,32 @@ export class CanvasEngine {
         this.tokens.delete(id);
       }
     }
+    // Tokens sharing a hex spread into a ring and shrink so all stay visible.
+    const byHex = new Map<string, Token[]>();
+    for (const t of tokens) {
+      const key = hexKey(t.q, t.r);
+      const list = byHex.get(key) ?? [];
+      list.push(t);
+      byHex.set(key, list);
+    }
+    const size = this.layout.size;
     for (const token of tokens) {
       let view = this.tokens.get(token.id);
-      const target = hexToPixel(this.layout, token);
+      const group = byHex.get(hexKey(token.q, token.r))!;
+      const n = group.length;
+      const idx = group.findIndex((t) => t.id === token.id);
+      const center = hexToPixel(this.layout, token);
+      let offX = 0;
+      let offY = 0;
+      let crowd = 1;
+      if (n > 1) {
+        const angle = (2 * Math.PI * idx) / n - Math.PI / 2;
+        const radius = size * (n === 2 ? 0.34 : 0.48);
+        offX = Math.cos(angle) * radius;
+        offY = Math.sin(angle) * radius;
+        crowd = n === 2 ? 0.62 : n <= 4 ? 0.5 : 0.4;
+      }
+      const target = { x: center.x + offX, y: center.y + offY };
       if (!view) {
         view = this.createTokenView(token);
         this.tokens.set(token.id, view);
@@ -874,6 +919,7 @@ export class CanvasEngine {
         this.styleTokenView(view, token);
       }
       view.token = token;
+      view.crowdScale = crowd;
       view.targetX = target.x;
       view.targetY = target.y;
       if (jump && !view.dragging) view.root.position.set(target.x, target.y);
@@ -937,7 +983,7 @@ export class CanvasEngine {
     label.anchor.set(0.5, 0);
     root.addChild(body, glyph, label);
     this.tokensC.addChild(root);
-    const view: TokenView = { root, body, glyph, label, token, targetX: 0, targetY: 0, dragging: false };
+    const view: TokenView = { root, body, glyph, label, token, targetX: 0, targetY: 0, dragging: false, crowdScale: 1 };
     this.styleTokenView(view, token);
     this.wireTokenDrag(view);
     return view;
@@ -961,6 +1007,9 @@ export class CanvasEngine {
     view.label.style.fontSize = size * 0.42;
     view.label.position.set(0, size * 1.12);
     view.root.alpha = token.kind === 'npc' && !token.playerVisible ? 0.75 : 1;
+    // Explicit grab target: hit-testing a bare Container depends on child
+    // geometry, which is fragile; a hitArea makes the whole disc grabbable.
+    view.root.hitArea = new Circle(0, 0, size * 1.25);
   }
 
   private wireTokenDrag(view: TokenView): void {
@@ -1208,8 +1257,12 @@ export class CanvasEngine {
       });
       return;
     }
+    const teleport = this.role === 'dm' && useUi.getState().altTeleport;
     useSession.getState().optimisticTokenMove(token.id, dropHex.q, dropHex.r);
-    send({ kind: 'token.move', tokenId: token.id, q: dropHex.q, r: dropHex.r });
+    send({ kind: 'token.move', tokenId: token.id, q: dropHex.q, r: dropHex.r, teleport });
+    if (teleport) {
+      useSession.getState().pushToast({ kind: 'info', title: 'Teleported', text: `${token.label || 'Token'} moved without leaving a trail.` });
+    }
   }
 
   // -- ticker ----------------------------------------------------------------

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -40,6 +40,8 @@ interface UiStore {
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
   dimUnexplored: boolean;
+  /** Held Alt/Option: a DM token drop teleports (no explored trail). */
+  altTeleport: boolean;
 
   set<K extends keyof UiStore>(key: K, value: UiStore[K]): void;
   setTool(tool: Tool): void;
@@ -67,6 +69,7 @@ export const useUi = create<UiStore>((set) => ({
   movingContentId: null,
   viewedMapId: null,
   dimUnexplored: false,
+  altTeleport: false,
 
   set: (key, value) => set({ [key]: value } as Partial<UiStore>),
   setTool: (tool) => set({ tool, measureStart: null }),

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -38,6 +38,9 @@ export function TableView({ campaignId }: { campaignId: string }) {
         if (!ui.spacePan) ui.set('spacePan', true);
         return;
       }
+      if (e.key === 'Alt') {
+        ui.set('altTeleport', true);
+      }
       if (e.key === 'Escape') {
         ui.set('contentDialogHex', null);
         ui.set('editingContentId', null);
@@ -57,8 +60,12 @@ export function TableView({ campaignId }: { campaignId: string }) {
     };
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === ' ' || e.code === 'Space') useUi.getState().set('spacePan', false);
+      if (e.key === 'Alt') useUi.getState().set('altTeleport', false);
     };
-    const onBlur = () => useUi.getState().set('spacePan', false);
+    const onBlur = () => {
+      useUi.getState().set('spacePan', false);
+      useUi.getState().set('altTeleport', false);
+    };
     window.addEventListener('keydown', onKey);
     window.addEventListener('keyup', onKeyUp);
     window.addEventListener('blur', onBlur);

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -111,6 +111,10 @@ function currentCharacterId(): string | null {
   return s.state?.seats.find((seat) => seat.id === s.seatId)?.characterId ?? null;
 }
 
+if (import.meta.env.DEV) {
+  (window as unknown as { __send: typeof send }).__send = (cmd) => send(cmd);
+}
+
 /** Fire a command at the server. Queued while disconnected. */
 export function send(cmd: CommandInput): void {
   const withId = { ...cmd, id: `cmd-${commandCounter++}` } as ClientCommand;

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -280,7 +280,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         },
       });
     }
-    executeTokenMove(ctx, token, cmd.q, cmd.r);
+    executeTokenMove(ctx, token, cmd.q, cmd.r, cmd.teleport && ctx.seat.role === 'dm');
   }) as Handler,
 
   'move.request': ((cmd: Extract<ClientCommand, { kind: 'move.request' }>, ctx: Ctx) => {
@@ -320,7 +320,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     if (!pending) throw new Error('No pending move for that token');
     rt.pendingMoves.delete(cmd.tokenId);
     if (cmd.approve) {
-      executeTokenMove(ctx, token, pending.toQ, pending.toR);
+      executeTokenMove(ctx, token, pending.toQ, pending.toR, cmd.teleport);
     }
     ctx.hub.sendTo(
       ctx.runtime,
@@ -624,14 +624,16 @@ function afterPartyMoved(ctx: Ctx, mapId: string, token: Token): void {
 }
 
 /** Execute a token move: traversed path becomes the explored trail, then sight + knowledge. */
-function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number): void {
+function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number, teleport = false): void {
   const from = { q: token.q, r: token.r };
   const moved = ctx.runtime.updateToken(token.mapId, token.id, { q, r });
   if (token.kind === 'pc') {
-    // Traversed hexes join the explored trail; the destination itself is
-    // where the party stands, so it becomes (or stays) visible.
-    const path = hexLine(from, { q, r }).filter((c) => !(c.q === q && c.r === r));
-    if (path.length) ctx.runtime.setFog(token.mapId, path, 'explored');
+    if (!teleport) {
+      // Traversed hexes join the explored trail; the destination itself is
+      // where the party stands, so it becomes (or stays) visible.
+      const path = hexLine(from, { q, r }).filter((c) => !(c.q === q && c.r === r));
+      if (path.length) ctx.runtime.setFog(token.mapId, path, 'explored');
+    }
     ctx.runtime.setFog(token.mapId, [{ q, r }], 'visible');
   }
   afterPartyMoved(ctx, token.mapId, moved);

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -192,6 +192,8 @@ export const TokenMoveCommand = z.object({
   tokenId: z.string(),
   q: z.number().int(),
   r: z.number().int(),
+  /** Teleport: no traversal — the explored trail is not drawn. */
+  teleport: z.boolean().default(false),
 });
 
 /** Player: request a move for DM approval (when the map requires it). */
@@ -209,6 +211,8 @@ export const MoveResolveCommand = z.object({
   kind: z.literal('move.resolve'),
   tokenId: z.string(),
   approve: z.boolean(),
+  /** Approve as a teleport (no explored trail along the path). */
+  teleport: z.boolean().default(false),
 });
 
 export const TokenDeleteCommand = z.object({


### PR DESCRIPTION
- Tokens sharing a hex spread into a ring and shrink so all stay visible; pairs use a larger scale than bigger groups.
- Teleport: Alt+drag as DM, or the ⚡ button on a pending move request, moves a token without drawing an explored trail.
- Fixes tokens being un-draggable: Pixi v8 hit-testing treats any Graphics covering the pointer as a search terminator even when non-interactive, so the fog/explored/highlight overlay layers were swallowing pointerdown before it reached tokens. All non-token layers are now `eventMode: 'none'` and token roots get an explicit circular hitArea.

Verified in-browser: drag moves the token without panning; teleport leaves fog untouched along the path; three tokens on one hex spread and re-spread as one is dragged away. Typecheck clean; 27 shared + 26 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)