### PR TITLE
Party token groups + fog-restoring move undo

### DIFF
--- a/packages/client/src/components/panels/TokensTab.tsx
+++ b/packages/client/src/components/panels/TokensTab.tsx
@@ -134,6 +134,23 @@ function TokenRow({ token }: { token: Token }) {
           {token.q},{token.r}
         </span>
       </button>
+      <button
+        className={`text-xs cursor-pointer ${token.partyId ? '' : 'opacity-35 grayscale'}`}
+        title={
+          token.partyId
+            ? 'In the party — moves with the group. Click to detach.'
+            : 'Solo — click to add to the party (party members move together).'
+        }
+        onClick={() =>
+          send({
+            kind: 'token.update',
+            tokenId: token.id,
+            patch: { partyId: token.partyId ? null : 'party' },
+          })
+        }
+      >
+        🧭
+      </button>
       {token.kind === 'npc' && (
         <button
           className="text-xs cursor-pointer"

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -999,6 +999,11 @@ export class CanvasEngine {
       view.body.circle(0, 0, size);
       view.body.stroke({ width: size * 0.09, color: 0xd96c4f, alpha: 0.9 });
     }
+    if (token.partyId) {
+      // Halo marking a party member — the group moves as one.
+      view.body.circle(0, 0, size * 1.18);
+      view.body.stroke({ width: size * 0.07, color: 0xd9b44f, alpha: 0.75 });
+    }
     const text = token.glyph || initials(token.label);
     view.glyph.text = text;
     view.glyph.style.fontSize = size * (token.glyph ? 1.0 : 0.75);
@@ -1259,6 +1264,18 @@ export class CanvasEngine {
     }
     const teleport = this.role === 'dm' && useUi.getState().altTeleport;
     useSession.getState().optimisticTokenMove(token.id, dropHex.q, dropHex.r);
+    // Party members shift by the same offset; the server moves them for real.
+    if (token.partyId) {
+      const dq = dropHex.q - token.q;
+      const dr = dropHex.r - token.r;
+      for (const other of this.tokens.values()) {
+        if (other.token.id !== token.id && other.token.partyId === token.partyId) {
+          useSession
+            .getState()
+            .optimisticTokenMove(other.token.id, other.token.q + dq, other.token.r + dr);
+        }
+      }
+    }
     send({ kind: 'token.move', tokenId: token.id, q: dropHex.q, r: dropHex.r, teleport });
     if (teleport) {
       useSession.getState().pushToast({ kind: 'info', title: 'Teleported', text: `${token.label || 'Token'} moved without leaving a trail.` });
@@ -1353,7 +1370,8 @@ function visualChanged(a: Token, b: Token): boolean {
     a.color !== b.color ||
     a.glyph !== b.glyph ||
     a.kind !== b.kind ||
-    a.playerVisible !== b.playerVisible
+    a.playerVisible !== b.playerVisible ||
+    a.partyId !== b.partyId
   );
 }
 

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -193,6 +193,7 @@ function migrate(d: DB): void {
   ensureColumn(d, 'content', 'wiki_page', "TEXT NOT NULL DEFAULT ''");
   ensureColumn(d, 'image_layer', 'visible', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'map', 'move_approval', 'INTEGER NOT NULL DEFAULT 0');
+  ensureColumn(d, 'token', 'party_id', 'TEXT');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/engine/fog.ts
+++ b/packages/server/src/engine/fog.ts
@@ -14,7 +14,7 @@ import type { CampaignRuntime } from '../state/runtime.js';
 export function applyAutoReveal(
   runtime: CampaignRuntime,
   map: MapInfo,
-): { q: number; r: number; state: FogState }[] {
+): { q: number; r: number; state: FogState; prev: FogState }[] {
   if (map.fogMode !== 'auto') return [];
   const rt = runtime.requireMap(map.id);
 

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -399,3 +399,57 @@ describe('narration', () => {
     expect(state.log.every((l) => l.visibility !== 'dm')).toBe(true);
   });
 });
+
+describe('party movement', () => {
+  it('moving one party member shifts the whole party by the same offset', () => {
+    const mapId = activeMapId();
+    dm({ kind: 'token.create', mapId, q: 0, r: 0, tokenKind: 'pc', characterId: null, label: 'A', color: '#e05555', glyph: '', playerVisible: true } as never);
+    dm({ kind: 'token.create', mapId, q: 1, r: 0, tokenKind: 'pc', characterId: null, label: 'B', color: '#e05555', glyph: '', playerVisible: true } as never);
+    dm({ kind: 'token.create', mapId, q: 5, r: 5, tokenKind: 'pc', characterId: null, label: 'Solo', color: '#e05555', glyph: '', playerVisible: true } as never);
+    const tokens = [...runtime.requireMap(mapId).tokens.values()];
+    const a = tokens.find((t) => t.label === 'A')!;
+    const b = tokens.find((t) => t.label === 'B')!;
+    const solo = tokens.find((t) => t.label === 'Solo')!;
+    dm({ kind: 'token.update', tokenId: a.id, patch: { partyId: 'party' } } as never);
+    dm({ kind: 'token.update', tokenId: b.id, patch: { partyId: 'party' } } as never);
+
+    dm({ kind: 'token.move', tokenId: a.id, q: 3, r: -1, teleport: false } as never);
+    const after = runtime.requireMap(mapId);
+    expect([after.tokens.get(a.id)!.q, after.tokens.get(a.id)!.r]).toEqual([3, -1]);
+    expect([after.tokens.get(b.id)!.q, after.tokens.get(b.id)!.r]).toEqual([4, -1]);
+    expect([after.tokens.get(solo.id)!.q, after.tokens.get(solo.id)!.r]).toEqual([5, 5]);
+
+    // Undo restores every member.
+    dm({ kind: 'undo' } as never);
+    expect([after.tokens.get(a.id)!.q, after.tokens.get(a.id)!.r]).toEqual([0, 0]);
+    expect([after.tokens.get(b.id)!.q, after.tokens.get(b.id)!.r]).toEqual([1, 0]);
+  });
+
+  it('a player moving their own token brings the party along', () => {
+    const { mapId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'token.create', mapId, q: 0, r: 1, tokenKind: 'pc', characterId: null, label: 'Friend', color: '#e05555', glyph: '', playerVisible: true } as never);
+    const friend = [...runtime.requireMap(mapId).tokens.values()].find((t) => t.label === 'Friend')!;
+    dm({ kind: 'token.update', tokenId, patch: { partyId: 'party' } } as never);
+    dm({ kind: 'token.update', tokenId: friend.id, patch: { partyId: 'party' } } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 2, r: 0 } as never);
+    const rt = runtime.requireMap(mapId);
+    expect([rt.tokens.get(tokenId)!.q, rt.tokens.get(tokenId)!.r]).toEqual([2, 0]);
+    expect([rt.tokens.get(friend.id)!.q, rt.tokens.get(friend.id)!.r]).toEqual([2, 1]);
+  });
+});
+
+describe('move undo restores fog', () => {
+  it('undoing a movement reverts the explored trail and auto-revealed cells', () => {
+    const { mapId, tokenId } = setupPartyWithScout();
+    const rt = runtime.requireMap(mapId);
+    const before = new Map(rt.fog);
+
+    dm({ kind: 'token.move', tokenId, q: 4, r: 0, teleport: false } as never);
+    expect(rt.fog.get(hexKey(2, 0))).toBe('explored');
+    expect(rt.fog.get(hexKey(4, 0))).toBe('visible');
+
+    dm({ kind: 'undo' } as never);
+    expect(rt.tokens.get(tokenId)!.q).toBe(0);
+    expect(Object.fromEntries(rt.fog)).toEqual(Object.fromEntries(before));
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -230,6 +230,7 @@ export class CampaignRuntime {
         color: t.color as string,
         glyph: t.glyph as string,
         playerVisible: Boolean(t.player_visible),
+        partyId: (t.party_id as string | null) ?? null,
       });
     }
     for (const m of d.prepare('SELECT * FROM marker WHERE map_id = ?').all(mapId) as Array<
@@ -664,7 +665,7 @@ export class CampaignRuntime {
     rt.tokens.set(token.id, token);
     this.db
       .prepare(
-        'INSERT INTO token (id, map_id, q, r, kind, character_id, label, color, glyph, player_visible) VALUES (?,?,?,?,?,?,?,?,?,?)',
+        'INSERT INTO token (id, map_id, q, r, kind, character_id, label, color, glyph, player_visible, party_id) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
       )
       .run(
         token.id,
@@ -677,6 +678,7 @@ export class CampaignRuntime {
         token.color,
         token.glyph,
         token.playerVisible ? 1 : 0,
+        token.partyId,
       );
   }
 
@@ -687,7 +689,9 @@ export class CampaignRuntime {
     const updated: Token = { ...token, ...patch, id: token.id, mapId: token.mapId };
     rt.tokens.set(tokenId, updated);
     this.db
-      .prepare('UPDATE token SET q=?, r=?, character_id=?, label=?, color=?, glyph=?, player_visible=? WHERE id=?')
+      .prepare(
+        'UPDATE token SET q=?, r=?, character_id=?, label=?, color=?, glyph=?, player_visible=?, party_id=? WHERE id=?',
+      )
       .run(
         updated.q,
         updated.r,
@@ -696,6 +700,7 @@ export class CampaignRuntime {
         updated.color,
         updated.glyph,
         updated.playerVisible ? 1 : 0,
+        updated.partyId,
         tokenId,
       );
     return updated;

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -230,6 +230,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       color: cmd.color,
       glyph: cmd.glyph,
       playerVisible: cmd.playerVisible,
+      partyId: null,
     };
     if (token.characterId) {
       const character = ctx.runtime.characters.get(token.characterId);
@@ -266,21 +267,24 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     if (ctx.seat.role !== 'dm' && map.moveApproval) {
       throw new Error('This map uses DM-approved movement — your move was sent as a request');
     }
-    const prevQ = token.q;
-    const prevR = token.r;
+    const prior = partyMembers(ctx, token).map((m) => ({ id: m.id, q: m.q, r: m.r }));
+    const label = token.label || 'token';
+    const fromQ = token.q;
+    const fromR = token.r;
+    const fogDelta = executePartyMove(ctx, token, cmd.q, cmd.r, cmd.teleport && ctx.seat.role === 'dm');
     if (ctx.seat.role === 'dm') {
       ctx.runtime.pushUndo({
         at: Date.now(),
         kind: 'token.move',
-        description: `move ${token.label || 'token'} back to ${prevQ},${prevR}`,
+        description: `move ${label} back to ${fromQ},${fromR}`,
         run: (runtime) => {
-          if (runtime.findToken(cmd.tokenId)) {
-            runtime.updateToken(token.mapId, cmd.tokenId, { q: prevQ, r: prevR });
+          for (const p of prior) {
+            if (runtime.findToken(p.id)) runtime.updateToken(token.mapId, p.id, { q: p.q, r: p.r });
           }
+          restoreFogDelta(runtime, token.mapId, fogDelta);
         },
       });
     }
-    executeTokenMove(ctx, token, cmd.q, cmd.r, cmd.teleport && ctx.seat.role === 'dm');
   }) as Handler,
 
   'move.request': ((cmd: Extract<ClientCommand, { kind: 'move.request' }>, ctx: Ctx) => {
@@ -320,7 +324,19 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     if (!pending) throw new Error('No pending move for that token');
     rt.pendingMoves.delete(cmd.tokenId);
     if (cmd.approve) {
-      executeTokenMove(ctx, token, pending.toQ, pending.toR, cmd.teleport);
+      const prior = partyMembers(ctx, token).map((m) => ({ id: m.id, q: m.q, r: m.r }));
+      const fogDelta = executePartyMove(ctx, token, pending.toQ, pending.toR, cmd.teleport);
+      ctx.runtime.pushUndo({
+        at: Date.now(),
+        kind: 'token.move',
+        description: `undo ${pending.label}'s approved move`,
+        run: (runtime) => {
+          for (const p of prior) {
+            if (runtime.findToken(p.id)) runtime.updateToken(token.mapId, p.id, { q: p.q, r: p.r });
+          }
+          restoreFogDelta(runtime, token.mapId, fogDelta);
+        },
+      });
     }
     ctx.hub.sendTo(
       ctx.runtime,
@@ -612,31 +628,79 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
 };
 
 /** Fog auto-reveal + knowledge evaluation after a PC token appears or moves. */
-function afterPartyMoved(ctx: Ctx, mapId: string, token: Token): void {
+function afterPartyMoved(ctx: Ctx, mapId: string, token: Token): FogDelta {
   const map = ctx.runtime.maps.get(mapId);
-  if (!map) return;
+  if (!map) return [];
+  let revealed: FogDelta = [];
   if (token.kind === 'pc') {
-    applyAutoReveal(ctx.runtime, map);
+    revealed = applyAutoReveal(ctx.runtime, map);
   }
   if (token.characterId) {
     deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, mapId, [token.characterId]));
   }
+  return revealed;
+}
+
+/** Fog cells changed by an operation, with their prior state for undo. */
+type FogDelta = { q: number; r: number; state: FogState; prev: FogState }[];
+
+/**
+ * Undo helper: restore every touched cell to its earliest recorded prior
+ * state (the first change per cell holds the true pre-move value).
+ */
+function restoreFogDelta(runtime: CampaignRuntime, mapId: string, delta: FogDelta): void {
+  const prior = new Map<string, FogState>();
+  for (const c of delta) {
+    const key = `${c.q},${c.r}`;
+    if (!prior.has(key)) prior.set(key, c.prev);
+  }
+  const byState = new Map<FogState, { q: number; r: number }[]>();
+  for (const [key, state] of prior) {
+    const [q, r] = key.split(',').map(Number);
+    const list = byState.get(state) ?? [];
+    list.push({ q: q!, r: r! });
+    byState.set(state, list);
+  }
+  for (const [state, cells] of byState) runtime.setFog(mapId, cells, state);
+}
+
+/** All tokens moving together with `token` — just the token itself unless it's in a party. */
+function partyMembers(ctx: Ctx, token: Token): Token[] {
+  if (!token.partyId) return [token];
+  const rt = ctx.runtime.requireMap(token.mapId);
+  return [...rt.tokens.values()].filter((t) => t.partyId === token.partyId);
+}
+
+/**
+ * Move `token` to (q, r) and shift every other member of its party by the
+ * same offset, so the group travels as a unit while keeping formation.
+ */
+function executePartyMove(ctx: Ctx, token: Token, q: number, r: number, teleport = false): FogDelta {
+  const dq = q - token.q;
+  const dr = r - token.r;
+  const delta: FogDelta = [];
+  for (const member of partyMembers(ctx, token)) {
+    delta.push(...executeTokenMove(ctx, member, member.q + dq, member.r + dr, teleport));
+  }
+  return delta;
 }
 
 /** Execute a token move: traversed path becomes the explored trail, then sight + knowledge. */
-function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number, teleport = false): void {
+function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number, teleport = false): FogDelta {
   const from = { q: token.q, r: token.r };
   const moved = ctx.runtime.updateToken(token.mapId, token.id, { q, r });
+  const delta: FogDelta = [];
   if (token.kind === 'pc') {
     if (!teleport) {
       // Traversed hexes join the explored trail; the destination itself is
       // where the party stands, so it becomes (or stays) visible.
       const path = hexLine(from, { q, r }).filter((c) => !(c.q === q && c.r === r));
-      if (path.length) ctx.runtime.setFog(token.mapId, path, 'explored');
+      if (path.length) delta.push(...ctx.runtime.setFog(token.mapId, path, 'explored'));
     }
-    ctx.runtime.setFog(token.mapId, [{ q, r }], 'visible');
+    delta.push(...ctx.runtime.setFog(token.mapId, [{ q, r }], 'visible'));
   }
-  afterPartyMoved(ctx, token.mapId, moved);
+  delta.push(...afterPartyMoved(ctx, token.mapId, moved));
+  return delta;
 }
 
 function capitalize(s: string): string {

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -232,6 +232,8 @@ export const TokenSchema = z.object({
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
   glyph: z.string().max(8),
   playerVisible: z.boolean().default(true),
+  /** Tokens sharing a partyId move together; any member's move shifts the group. */
+  partyId: z.string().nullable().default(null),
 });
 export type Token = z.infer<typeof TokenSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -182,6 +182,7 @@ export const TokenUpdateCommand = z.object({
       glyph: z.string().max(8),
       playerVisible: z.boolean(),
       characterId: z.string().nullable(),
+      partyId: z.string().nullable(),
     })
     .partial(),
 });

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -91,10 +91,10 @@ function fullState(): CampaignState {
         { q: 1, r: 0, state: 'explored' },
       ],
       tokens: [
-        { id: 't1', mapId: 'm1', q: 0, r: 0, kind: 'pc', characterId: 'char1', label: 'Scout', color: '#00ff00', glyph: '', playerVisible: true },
-        { id: 't2', mapId: 'm1', q: 0, r: 0, kind: 'npc', characterId: null, label: 'Ogre', color: '#ff0000', glyph: '', playerVisible: true },
-        { id: 't3', mapId: 'm1', q: 1, r: 0, kind: 'npc', characterId: null, label: 'Ghost', color: '#ffffff', glyph: '', playerVisible: true },
-        { id: 't4', mapId: 'm1', q: 0, r: 0, kind: 'npc', characterId: null, label: 'Hidden', color: '#000000', glyph: '', playerVisible: false },
+        { id: 't1', mapId: 'm1', q: 0, r: 0, kind: 'pc', characterId: 'char1', label: 'Scout', color: '#00ff00', glyph: '', playerVisible: true, partyId: null },
+        { id: 't2', mapId: 'm1', q: 0, r: 0, kind: 'npc', characterId: null, label: 'Ogre', color: '#ff0000', glyph: '', playerVisible: true, partyId: null },
+        { id: 't3', mapId: 'm1', q: 1, r: 0, kind: 'npc', characterId: null, label: 'Ghost', color: '#ffffff', glyph: '', playerVisible: true, partyId: null },
+        { id: 't4', mapId: 'm1', q: 0, r: 0, kind: 'npc', characterId: null, label: 'Hidden', color: '#000000', glyph: '', playerVisible: false, partyId: null },
       ],
       markers: [
         { id: 'mk1', mapId: 'm1', q: 0, r: 0, glyph: '🔥', label: 'Fire', dmOnly: false },


### PR DESCRIPTION
- `token.partyId` groups tokens into a party: any member's move (player drag, DM drag, or approved move request) shifts the whole group by the same offset, keeping formation. Toggled per token via the 🧭 button in the Tokens panel; members render with a gold halo.
- Undoing a movement now also reverts its fog effects — explored trail, destination reveal, and auto-reveal — captured as per-cell prior states at move time.

Verified live in-browser (party drag moves both tokens, undo returns tokens and trail) plus new server tests. Typecheck clean; 27 shared + 29 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)