### PR TITLE
Send-to-hex: click a destination instead of dragging

### DIFF
--- a/packages/client/src/components/SendTokenButton.tsx
+++ b/packages/client/src/components/SendTokenButton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useSession } from '../stores/session.js';
+import { useUi } from '../stores/ui.js';
+import { cx } from '../ui/kit.js';
+
+/**
+ * Arms "click the map to send this token there" mode — a long-distance
+ * alternative to dragging. Clicking again (or Escape) cancels.
+ */
+export function SendTokenButton({ tokenId, name }: { tokenId: string; name: string }) {
+  const armed = useUi((s) => s.movingTokenId === tokenId);
+  return (
+    <button
+      className={cx(
+        'shrink-0 px-2 py-1 mr-1.5 rounded text-sm cursor-pointer transition-colors',
+        armed ? 'bg-brass-500/25 text-brass-300' : 'text-ink-400 hover:text-brass-300',
+      )}
+      title={
+        armed
+          ? 'Click the map where they should go — Esc cancels'
+          : `Send ${name} somewhere: click this, then click the destination hex`
+      }
+      onClick={(e) => {
+        e.stopPropagation();
+        const ui = useUi.getState();
+        if (armed) {
+          ui.set('movingTokenId', null);
+          return;
+        }
+        ui.set('movingTokenId', tokenId);
+        useSession.getState().pushToast({
+          kind: 'info',
+          title: `Send ${name}`,
+          text: 'Click the destination hex on the map — Esc cancels.',
+        });
+      }}
+    >
+      🎯
+    </button>
+  );
+}

--- a/packages/client/src/components/panels/CharactersTab.tsx
+++ b/packages/client/src/components/panels/CharactersTab.tsx
@@ -3,6 +3,7 @@ import { CORE_SKILLS, passiveScore, type Character } from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { Button, EmptyNote, Field, Input, Section, cx } from '../../ui/kit.js';
+import { SendTokenButton } from '../SendTokenButton.js';
 
 const CHARACTER_COLORS = [
   '#e05555', '#e08f3c', '#c9a24b', '#6fa06b', '#4a9d9c', '#5b8dd9', '#8b7fd4', '#c56bb8',
@@ -18,6 +19,7 @@ export function CharactersTab() {
   if (!state) return null;
   const mySeat = state.seats.find((s) => s.id === seatId);
   const isDm = role === 'dm';
+  const mapTokens = state.mapState?.tokens ?? [];
 
   return (
     <div>
@@ -40,29 +42,34 @@ export function CharactersTab() {
             const isMine = mySeat?.characterId === ch.id;
             const canEdit = isDm || isMine;
             const open = expanded === ch.id;
+            const token = mapTokens.find((t) => t.characterId === ch.id);
+            const canCommand = token && (isDm || isMine);
             return (
               <div key={ch.id} className="bg-ink-850 border border-ink-700 rounded-lg">
-                <button
-                  className="w-full flex items-center gap-2.5 p-2.5 cursor-pointer text-left"
-                  onClick={() => setExpanded(open ? null : ch.id)}
-                >
-                  <span
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-sm shrink-0 border border-white/20"
-                    style={{ background: ch.color }}
+                <div className="flex items-center">
+                  <button
+                    className="min-w-0 flex-1 flex items-center gap-2.5 p-2.5 cursor-pointer text-left"
+                    onClick={() => setExpanded(open ? null : ch.id)}
                   >
-                    {ch.glyph || ch.name.slice(0, 1).toUpperCase()}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-sm font-medium text-ink-100 truncate">
-                      {ch.name} {isMine && <span className="text-brass-400">(you)</span>}
+                    <span
+                      className="w-8 h-8 rounded-full flex items-center justify-center text-sm shrink-0 border border-white/20"
+                      style={{ background: ch.color }}
+                    >
+                      {ch.glyph || ch.name.slice(0, 1).toUpperCase()}
                     </span>
-                    <span className="block text-xs text-ink-400 truncate">
-                      {claimedBy ? `Played by ${claimedBy.name}` : 'Unclaimed'} · Passive Perception{' '}
-                      {passiveScore(ch.skills, 'perception')}
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium text-ink-100 truncate">
+                        {ch.name} {isMine && <span className="text-brass-400">(you)</span>}
+                      </span>
+                      <span className="block text-xs text-ink-400 truncate">
+                        {claimedBy ? `Played by ${claimedBy.name}` : 'Unclaimed'} · Passive Perception{' '}
+                        {passiveScore(ch.skills, 'perception')}
+                      </span>
                     </span>
-                  </span>
-                  <span className="text-ink-400 text-xs">{open ? '▲' : '▼'}</span>
-                </button>
+                    <span className="text-ink-400 text-xs">{open ? '▲' : '▼'}</span>
+                  </button>
+                  {canCommand && <SendTokenButton tokenId={token.id} name={ch.name} />}
+                </div>
                 {open && (
                   <div className="border-t border-ink-700 p-2.5">
                     {!claimedBy && !isDm && !mySeat?.characterId && (

--- a/packages/client/src/components/panels/TokensTab.tsx
+++ b/packages/client/src/components/panels/TokensTab.tsx
@@ -4,6 +4,7 @@ import { activeMap, useSession } from '../../stores/session.js';
 import { useUi } from '../../stores/ui.js';
 import { send } from '../../ws.js';
 import { Button, EmptyNote, Field, Input, Section, Toggle } from '../../ui/kit.js';
+import { SendTokenButton } from '../SendTokenButton.js';
 
 export function TokensTab() {
   const state = useSession((s) => s.state);
@@ -134,6 +135,7 @@ function TokenRow({ token }: { token: Token }) {
           {token.q},{token.r}
         </span>
       </button>
+      <SendTokenButton tokenId={token.id} name={token.label || 'token'} />
       <button
         className={`text-xs cursor-pointer ${token.partyId ? '' : 'opacity-35 grayscale'}`}
         title={

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -214,8 +214,8 @@ export class CanvasEngine {
         this.updateDragMode();
         this.viewport.cursor = u.spacePan ? 'grab' : 'default';
       }
-      if (u.movingContentId !== prev.movingContentId) {
-        this.viewport.cursor = u.movingContentId ? 'crosshair' : 'default';
+      if (u.movingContentId !== prev.movingContentId || u.movingTokenId !== prev.movingTokenId) {
+        this.viewport.cursor = u.movingContentId || u.movingTokenId ? 'crosshair' : 'default';
       }
       if (u.scaleLock !== prev.scaleLock) {
         this.updateScaleLevel();
@@ -1088,6 +1088,20 @@ export class CanvasEngine {
         return;
       }
 
+      // Armed "send token here" mode (from the sidebar): next click is the
+      // destination — same rules as a drag, without the long mouse travel.
+      if (ui.movingTokenId) {
+        const view = this.tokens.get(ui.movingTokenId);
+        useUi.getState().set('movingTokenId', null);
+        this.viewport.cursor = 'default';
+        if (view && this.canMove(view.token)) {
+          if (!(hex.q === view.token.q && hex.r === view.token.r)) {
+            this.dispatchMove(view.token, hex);
+          }
+        }
+        return;
+      }
+
       switch (ui.tool) {
         case 'select':
           this.panning = true;
@@ -1225,42 +1239,45 @@ export class CanvasEngine {
       y: drag.view.root.position.y,
     });
     const token = drag.view.token;
-    if (dropHex.q === token.q && dropHex.r === token.r) {
+    const outcome =
+      dropHex.q === token.q && dropHex.r === token.r
+        ? 'denied'
+        : this.dispatchMove(token, dropHex);
+    if (outcome !== 'moved') {
+      // Snap home: the move became a request (ghost shows the destination)
+      // or didn't happen at all.
       const p = hexToPixel(this.layout, token);
       drag.view.targetX = p.x;
       drag.view.targetY = p.y;
-      return;
     }
+  }
+
+  /**
+   * Send `token` toward a destination hex, honoring the same rules as a drag:
+   * players on approval maps declare a request, step-mode limits players to
+   * one hex, and a DM holding Alt teleports (no explored trail).
+   */
+  private dispatchMove(token: Token, dropHex: HexCoord): 'moved' | 'requested' | 'denied' {
     const map = this.lastMap;
-    // DM-approved travel: the drag becomes a request; the token snaps home
-    // and a ghost shows the declared destination until the DM resolves it.
+    // DM-approved travel: the move becomes a request; a ghost shows the
+    // declared destination until the DM resolves it.
     if (this.role !== 'dm' && map?.moveApproval) {
-      const p = hexToPixel(this.layout, token);
-      drag.view.targetX = p.x;
-      drag.view.targetY = p.y;
       send({ kind: 'move.request', tokenId: token.id, q: dropHex.q, r: dropHex.r });
       useSession.getState().pushToast({
         kind: 'info',
         title: 'Travel declared',
         text: 'Waiting for the DM to resolve your move.',
       });
-      return;
+      return 'requested';
     }
     // Step-mode limit for players (server validates too).
-    if (
-      this.role !== 'dm' &&
-      map?.moveMode === 'step' &&
-      hexDistance(token, dropHex) > 1
-    ) {
-      const p = hexToPixel(this.layout, token);
-      drag.view.targetX = p.x;
-      drag.view.targetY = p.y;
+    if (this.role !== 'dm' && map?.moveMode === 'step' && hexDistance(token, dropHex) > 1) {
       useSession.getState().pushToast({
         kind: 'info',
         title: 'One hex at a time',
         text: 'This map only allows single-hex steps.',
       });
-      return;
+      return 'denied';
     }
     const teleport = this.role === 'dm' && useUi.getState().altTeleport;
     useSession.getState().optimisticTokenMove(token.id, dropHex.q, dropHex.r);
@@ -1280,6 +1297,7 @@ export class CanvasEngine {
     if (teleport) {
       useSession.getState().pushToast({ kind: 'info', title: 'Teleported', text: `${token.label || 'Token'} moved without leaving a trail.` });
     }
+    return 'moved';
   }
 
   // -- ticker ----------------------------------------------------------------

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -36,6 +36,8 @@ interface UiStore {
   currentScale: 0 | 1 | 2;
   /** DM armed "click to move this content" mode. */
   movingContentId: string | null;
+  /** Armed "click a destination hex to send this token there" mode. */
+  movingTokenId: string | null;
   /** Player-chosen map for this session (null = follow the DM default). */
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
@@ -67,6 +69,7 @@ export const useUi = create<UiStore>((set) => ({
   scaleLock: 'auto',
   currentScale: 0,
   movingContentId: null,
+  movingTokenId: null,
   viewedMapId: null,
   dimUnexplored: false,
   altTeleport: false,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -46,6 +46,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.set('editingContentId', null);
         ui.selectHex(null);
         ui.set('measureStart', null);
+        ui.set('movingTokenId', null);
         return;
       }
       if (useSession.getState().role !== 'dm') return;


### PR DESCRIPTION
Adds a 🎯 button on token rows (Tokens tab) and character cards (Party tab — visible to the DM and to the player who claimed the character, whenever the character has a token on the current map). Clicking it arms a one-shot "send" mode: the next click on the map is the destination. Same rules as dragging — approval maps turn it into a move request, step mode still limits players to one hex, and Alt+click teleports for the DM. Crosshair cursor while armed; Esc or a second click on the button cancels.

Verified live: armed from the sidebar, one click moved the token a long distance with the explored trail drawn, and undo restored it. Typecheck clean; 27 shared + 29 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)