### PR TITLE
Directional clues: sensed compass bearing on discovery

### DIFF
--- a/mcp/hexcrawl-mcp.mjs
+++ b/mcp/hexcrawl-mcp.mjs
@@ -77,7 +77,15 @@ const TOOLS = [
           type: 'array',
           items: {
             type: 'object',
-            properties: { text: { type: 'string' }, gate: { type: 'object' } },
+            properties: {
+              text: { type: 'string' },
+              gate: { type: 'object' },
+              indicatesDirection: {
+                type: 'boolean',
+                description:
+                  'Append an auto-computed compass bearing (from the character toward this location) to the delivered clue text, e.g. "… — to the north-east"',
+              },
+            },
             required: ['text'],
           },
         },

--- a/packages/client/src/components/ContentDialog.tsx
+++ b/packages/client/src/components/ContentDialog.tsx
@@ -17,6 +17,7 @@ interface ClueDraft {
   id: string | null;
   text: string;
   gate: Gate;
+  indicatesDirection: boolean;
 }
 
 /** DM editor for hex content and its gated clues. */
@@ -42,7 +43,12 @@ export function ContentDialog() {
   const [scaleVisibility, setScaleVisibility] = useState(existing?.scaleVisibility ?? 1);
   const [wikiPage, setWikiPage] = useState(existing?.wikiPage ?? '');
   const [clues, setClues] = useState<ClueDraft[]>(
-    existing?.clues.map((c) => ({ id: c.id, text: c.text, gate: c.gate })) ?? [],
+    existing?.clues.map((c) => ({
+      id: c.id,
+      text: c.text,
+      gate: c.gate,
+      indicatesDirection: c.indicatesDirection,
+    })) ?? [],
   );
 
   const close = () => {
@@ -70,7 +76,13 @@ export function ContentDialog() {
         wikiPage: wikiPage.trim(),
         clues: clues
           .filter((c) => c.text.trim())
-          .map((c, i) => ({ id: c.id, text: c.text.trim(), gate: c.gate, sortOrder: i })),
+          .map((c, i) => ({
+            id: c.id,
+            text: c.text.trim(),
+            gate: c.gate,
+            sortOrder: i,
+            indicatesDirection: c.indicatesDirection,
+          })),
       },
     });
     close();
@@ -143,6 +155,7 @@ export function ContentDialog() {
                     id: null,
                     text: '',
                     gate: { kind: 'skill', skill: 'perception', dc: 12, maxDistance: 1, mode: 'passive' },
+                    indicatesDirection: false,
                   },
                 ])
               }
@@ -309,6 +322,18 @@ function ClueEditor({
             </select>
           </>
         )}
+        <button
+          onClick={() => onChange({ ...clue, indicatesDirection: !clue.indicatesDirection })}
+          className={cx(
+            'px-2 py-0.5 rounded-full text-[11px] cursor-pointer border',
+            clue.indicatesDirection
+              ? 'border-brass-500 bg-brass-500/15 text-brass-300'
+              : 'border-ink-700 text-ink-300 hover:bg-ink-700',
+          )}
+          title='Append the sensed compass bearing when delivered, e.g. "… — to the north-east" (computed from where the character stands toward this hex)'
+        >
+          🧭 direction
+        </button>
       </div>
     </div>
   );

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -1,5 +1,5 @@
 import type { ClientCommand, CommandInput, ServerMessage } from '@hexcrawl/shared';
-import { ServerMessageSchema } from '@hexcrawl/shared';
+import { ServerMessageSchema, withDirection } from '@hexcrawl/shared';
 import { useSession } from './stores/session.js';
 
 let socket: WebSocket | null = null;
@@ -85,7 +85,7 @@ function handleMessage(msg: ServerMessage): void {
         session.pushToast({
           kind: 'discovery',
           title: mine ? 'You notice something…' : `${msg.characterName} noticed something`,
-          text: msg.clueText,
+          text: withDirection(msg.clueText, msg.discovery.direction),
         });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'narration') {
         session.pushToast({ kind: 'narration', title: 'The DM narrates', text: msg.entry.text });

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -194,6 +194,8 @@ function migrate(d: DB): void {
   ensureColumn(d, 'image_layer', 'visible', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'map', 'move_approval', 'INTEGER NOT NULL DEFAULT 0');
   ensureColumn(d, 'token', 'party_id', 'TEXT');
+  ensureColumn(d, 'clue', 'indicates_direction', 'INTEGER NOT NULL DEFAULT 0');
+  ensureColumn(d, 'discovery', 'direction', 'TEXT');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/engine/knowledge.ts
+++ b/packages/server/src/engine/knowledge.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 import type { Character, Discovery } from '@hexcrawl/shared';
-import { gateOpensPassively, hexDistance } from '@hexcrawl/shared';
+import { compassDirection, gateOpensPassively, hexDistance } from '@hexcrawl/shared';
 import type { CampaignRuntime } from '../state/runtime.js';
 
 export interface NewDiscovery {
@@ -25,6 +25,7 @@ export function evaluateKnowledge(
 ): NewDiscovery[] {
   const rt = runtime.mapStates.get(mapId);
   if (!rt) return [];
+  const orientation = runtime.maps.get(mapId)?.orientation ?? 'flat';
 
   // Character -> position of their PC token on this map.
   const positions = new Map<string, { q: number; r: number }>();
@@ -45,7 +46,17 @@ export function evaluateKnowledge(
         if (runtime.hasDiscovery(clue.id, characterId)) continue;
         const evaluation = gateOpensPassively(clue.gate, character, distance);
         if (!evaluation.opens) continue;
-        const discovery = buildDiscovery(clue.id, character, clue.gate, distance, evaluation.passive);
+        const direction = clue.indicatesDirection
+          ? compassDirection(pos, { q: content.q, r: content.r }, orientation)
+          : null;
+        const discovery = buildDiscovery(
+          clue.id,
+          character,
+          clue.gate,
+          distance,
+          evaluation.passive,
+          direction,
+        );
         if (runtime.addDiscovery(discovery)) {
           results.push({
             discovery,
@@ -67,6 +78,7 @@ function buildDiscovery(
   gate: { kind: string; skill?: string; dc?: number },
   distance: number,
   passive: number | undefined,
+  direction: string | null,
 ): Discovery {
   const how: Discovery['how'] =
     gate.kind === 'skill'
@@ -78,5 +90,5 @@ function buildDiscovery(
           distance,
         }
       : { kind: 'auto' };
-  return { id: nanoid(12), clueId, characterId: character.id, at: Date.now(), how };
+  return { id: nanoid(12), clueId, characterId: character.id, at: Date.now(), how, direction };
 }

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -239,7 +239,13 @@ export function createApp(store: Store, hub: Hub): Hono {
     showLabel: z.boolean().default(false),
     scaleVisibility: z.number().int().min(0).max(2).default(1),
     clues: z
-      .array(z.object({ text: z.string().min(1).max(2000), gate: GateSchema.default({ kind: 'auto' }) }))
+      .array(
+        z.object({
+          text: z.string().min(1).max(2000),
+          gate: GateSchema.default({ kind: 'auto' }),
+          indicatesDirection: z.boolean().default(false),
+        }),
+      )
       .default([]),
   });
 
@@ -285,7 +291,14 @@ export function createApp(store: Store, hub: Hub): Hono {
       scaleVisibility: input.scaleVisibility,
       wikiPage: input.wikiPage || existing?.wikiPage || '',
       clues: input.clues.length
-        ? input.clues.map((cl, i) => ({ id: nanoid(10), contentId: id, text: cl.text, gate: cl.gate, sortOrder: i }))
+        ? input.clues.map((cl, i) => ({
+            id: nanoid(10),
+            contentId: id,
+            text: cl.text,
+            gate: cl.gate,
+            sortOrder: i,
+            indicatesDirection: cl.indicatesDirection,
+          }))
         : (existing?.clues ?? []),
     };
     runtime.upsertContent(content);

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -453,3 +453,57 @@ describe('move undo restores fog', () => {
     expect(Object.fromEntries(rt.fog)).toEqual(Object.fromEntries(before));
   });
 });
+
+describe('directional clues', () => {
+  it('stores the sensed bearing on discovery and appends it to the player view', () => {
+    const { mapId, charId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 4, r: -2, type: 'camp', title: 'Bandit Camp', dmNotes: '', glyph: '',
+        clues: [
+          {
+            id: null,
+            text: 'You smell woodsmoke',
+            gate: { kind: 'skill', skill: 'survival', dc: 10, maxDistance: 6, mode: 'passive' },
+            sortOrder: 0,
+            indicatesDirection: true,
+          },
+        ],
+      },
+    } as never);
+    // Scout starts at (0,0); survival passive 12 >= 10 within 6 → immediate discovery.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 0, r: 0 } as never);
+    const disc = [...runtime.discoveries.values()][0]!;
+    expect(disc.direction).toBe('east');
+
+    const view = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    const camp = view.mapState!.contents.find((c) => c.title === 'Bandit Camp')!;
+    expect((camp as { discoveredClues: { text: string }[] }).discoveredClues[0]!.text).toBe(
+      'You smell woodsmoke — to the east',
+    );
+  });
+
+  it('leaves direction null when the flag is off', () => {
+    const { mapId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 4, r: -2, type: 'camp', title: 'Quiet Camp', dmNotes: '', glyph: '',
+        clues: [
+          {
+            id: null,
+            text: 'Something is near',
+            gate: { kind: 'skill', skill: 'survival', dc: 10, maxDistance: 6, mode: 'passive' },
+            sortOrder: 0,
+          },
+        ],
+      },
+    } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 0, r: 0 } as never);
+    const disc = [...runtime.discoveries.values()][0]!;
+    expect(disc.direction).toBeNull();
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -174,6 +174,7 @@ export class CampaignRuntime {
         characterId: dd.character_id as string,
         at: dd.at as number,
         how: safeJson(dd.how as string, { kind: 'manual' }) as Discovery['how'],
+        direction: (dd.direction as string | null) ?? null,
       };
       this.discoveries.set(disc.id, disc);
       this.discoveredByClueChar.add(`${disc.clueId}|${disc.characterId}`);
@@ -259,6 +260,7 @@ export class CampaignRuntime {
         text: cl.text as string,
         gate: GateSchema.parse(safeJson(cl.gate as string)),
         sortOrder: cl.sort_order as number,
+        indicatesDirection: Boolean(cl.indicates_direction),
       }));
       rt.contents.set(c.id as string, {
         id: c.id as string,
@@ -777,11 +779,18 @@ export class CampaignRuntime {
         }
       }
       const put = this.db.prepare(
-        `INSERT INTO clue (id, content_id, text, gate, sort_order) VALUES (?,?,?,?,?)
-         ON CONFLICT(id) DO UPDATE SET text=excluded.text, gate=excluded.gate, sort_order=excluded.sort_order`,
+        `INSERT INTO clue (id, content_id, text, gate, sort_order, indicates_direction) VALUES (?,?,?,?,?,?)
+         ON CONFLICT(id) DO UPDATE SET text=excluded.text, gate=excluded.gate, sort_order=excluded.sort_order, indicates_direction=excluded.indicates_direction`,
       );
       for (const clue of content.clues) {
-        put.run(clue.id, content.id, clue.text, JSON.stringify(clue.gate), clue.sortOrder);
+        put.run(
+          clue.id,
+          content.id,
+          clue.text,
+          JSON.stringify(clue.gate),
+          clue.sortOrder,
+          clue.indicatesDirection ? 1 : 0,
+        );
       }
     });
     tx();
@@ -838,8 +847,18 @@ export class CampaignRuntime {
     this.discoveries.set(discovery.id, discovery);
     this.discoveredByClueChar.add(`${discovery.clueId}|${discovery.characterId}`);
     this.db
-      .prepare('INSERT INTO discovery (id, campaign_id, clue_id, character_id, at, how) VALUES (?,?,?,?,?,?)')
-      .run(discovery.id, this.id, discovery.clueId, discovery.characterId, discovery.at, JSON.stringify(discovery.how));
+      .prepare(
+        'INSERT INTO discovery (id, campaign_id, clue_id, character_id, at, how, direction) VALUES (?,?,?,?,?,?,?)',
+      )
+      .run(
+        discovery.id,
+        this.id,
+        discovery.clueId,
+        discovery.characterId,
+        discovery.at,
+        JSON.stringify(discovery.how),
+        discovery.direction,
+      );
     return true;
   }
 

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 import type {
   ClientCommand,
+  Clue,
   Content,
   LogEntry,
   MapInfo,
@@ -8,6 +9,7 @@ import type {
   Token,
 } from '@hexcrawl/shared';
 import {
+  compassDirection,
   EncounterCheckConfigSchema,
   GridStyleSchema,
   hexDistance,
@@ -445,6 +447,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         text: c.text,
         gate: c.gate,
         sortOrder: i,
+        indicatesDirection: c.indicatesDirection ?? false,
       })),
     };
     ctx.runtime.upsertContent(content);
@@ -506,6 +509,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         characterId,
         at: Date.now(),
         how: { kind: 'manual' as const },
+        direction: clueDirectionFor(ctx, clue, content, characterId),
       };
       if (ctx.runtime.addDiscovery(discovery)) {
         created.push({
@@ -662,6 +666,28 @@ function restoreFogDelta(runtime: CampaignRuntime, mapId: string, delta: FogDelt
     byState.set(state, list);
   }
   for (const [state, cells] of byState) runtime.setFog(mapId, cells, state);
+}
+
+/**
+ * Bearing from a character's PC token toward a content hex, for clues that
+ * indicate direction. Null when the clue doesn't, or the character has no
+ * token on that map, or they stand on the hex itself.
+ */
+function clueDirectionFor(
+  ctx: Ctx,
+  clue: Clue,
+  content: Content,
+  characterId: string,
+): string | null {
+  if (!clue.indicatesDirection) return null;
+  const rt = ctx.runtime.mapStates.get(content.mapId);
+  if (!rt) return null;
+  const token = [...rt.tokens.values()].find(
+    (t) => t.kind === 'pc' && t.characterId === characterId,
+  );
+  if (!token) return null;
+  const orientation = ctx.runtime.maps.get(content.mapId)?.orientation ?? 'flat';
+  return compassDirection({ q: token.q, r: token.r }, { q: content.q, r: content.r }, orientation);
 }
 
 /** All tokens moving together with `token` — just the token itself unless it's in a party. */

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -350,6 +350,11 @@ export const ClueSchema = z.object({
   text: z.string().min(1).max(2000),
   gate: GateSchema,
   sortOrder: z.number().int().default(0),
+  /**
+   * Append an auto-computed compass bearing (from the discovering character
+   * toward this content's hex) to the delivered text: "… — to the north-east".
+   */
+  indicatesDirection: z.boolean().default(false),
 });
 export type Clue = z.infer<typeof ClueSchema>;
 
@@ -399,6 +404,8 @@ export const DiscoverySchema = z.object({
   characterId: z.string(),
   at: z.number(), // epoch ms
   how: DiscoveryHowSchema,
+  /** Compass bearing sensed at discovery time (clue's indicatesDirection). */
+  direction: z.string().nullable().default(null),
 });
 export type Discovery = z.infer<typeof DiscoverySchema>;
 

--- a/packages/shared/src/hex/direction.test.ts
+++ b/packages/shared/src/hex/direction.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { compassDirection, withDirection } from './direction.js';
+
+describe('compassDirection (flat-top)', () => {
+  it('names the eight bearings', () => {
+    expect(compassDirection({ q: 0, r: 0 }, { q: 0, r: -2 })).toBe('north');
+    expect(compassDirection({ q: 0, r: 0 }, { q: 0, r: 2 })).toBe('south');
+    expect(compassDirection({ q: 0, r: 0 }, { q: 2, r: -1 })).toBe('east');
+    expect(compassDirection({ q: 0, r: 0 }, { q: -2, r: 1 })).toBe('west');
+    expect(compassDirection({ q: 0, r: 0 }, { q: 2, r: -3 })).toBe('north-east');
+    expect(compassDirection({ q: 0, r: 0 }, { q: 2, r: 1 })).toBe('south-east');
+    expect(compassDirection({ q: 0, r: 0 }, { q: -2, r: 3 })).toBe('south-west');
+    expect(compassDirection({ q: 0, r: 0 }, { q: -2, r: -1 })).toBe('north-west');
+  });
+
+  it('is null on the same hex', () => {
+    expect(compassDirection({ q: 3, r: -1 }, { q: 3, r: -1 })).toBeNull();
+  });
+});
+
+describe('withDirection', () => {
+  it('appends the bearing when present', () => {
+    expect(withDirection('You smell woodsmoke', 'north-east')).toBe(
+      'You smell woodsmoke — to the north-east',
+    );
+    expect(withDirection('You smell woodsmoke', null)).toBe('You smell woodsmoke');
+  });
+});

--- a/packages/shared/src/hex/direction.ts
+++ b/packages/shared/src/hex/direction.ts
@@ -1,0 +1,38 @@
+import type { HexCoord } from './coords.js';
+import { hexToPixel, type HexOrientation } from './layout.js';
+
+export const COMPASS_DIRECTIONS = [
+  'north',
+  'north-east',
+  'east',
+  'south-east',
+  'south',
+  'south-west',
+  'west',
+  'north-west',
+] as const;
+export type CompassDirection = (typeof COMPASS_DIRECTIONS)[number];
+
+/**
+ * Compass bearing from one hex toward another as seen on the rendered map
+ * (screen up = north). Null when the hexes coincide.
+ */
+export function compassDirection(
+  from: HexCoord,
+  to: HexCoord,
+  orientation: HexOrientation = 'flat',
+): CompassDirection | null {
+  if (from.q === to.q && from.r === to.r) return null;
+  const layout = { orientation, size: 1, origin: { x: 0, y: 0 } };
+  const a = hexToPixel(layout, from);
+  const b = hexToPixel(layout, to);
+  // Screen y grows south; 0° = north, clockwise.
+  const deg = (Math.atan2(b.x - a.x, -(b.y - a.y)) * 180) / Math.PI;
+  const idx = ((Math.round(deg / 45) % 8) + 8) % 8;
+  return COMPASS_DIRECTIONS[idx]!;
+}
+
+/** Player-facing clue text with its sensed bearing appended, when known. */
+export function withDirection(text: string, direction: string | null | undefined): string {
+  return direction ? `${text} — to the ${direction}` : text;
+}

--- a/packages/shared/src/hex/index.ts
+++ b/packages/shared/src/hex/index.ts
@@ -1,3 +1,4 @@
 export * from './coords.js';
+export * from './direction.js';
 export * from './layout.js';
 export * from './super.js';

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -8,6 +8,7 @@ import type {
 } from '../domain.js';
 import { isFullContent } from '../domain.js';
 import { hexKey } from '../hex/coords.js';
+import { withDirection } from '../hex/direction.js';
 
 export interface Viewer {
   seatId: string;
@@ -95,6 +96,10 @@ export function contentPlayerView(
     wikiPage: content.wikiPage,
     discoveredClues: mine
       .sort((a, b) => a.at - b.at)
-      .map((d) => ({ clueId: d.clueId, text: clueText.get(d.clueId) ?? '', at: d.at })),
+      .map((d) => ({
+        clueId: d.clueId,
+        text: withDirection(clueText.get(d.clueId) ?? '', d.direction),
+        at: d.at,
+      })),
   };
 }

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -105,20 +105,20 @@ function fullState(): CampaignState {
         {
           id: 'ct1', mapId: 'm1', q: 1, r: 0, type: 'lair', title: 'Dragon Lair', dmNotes: 'secret', glyph: '🐉', showLabel: false, scaleVisibility: 1, wikiPage: '',
           clues: [
-            { id: 'cl1', contentId: 'ct1', text: 'Dead vegetation', gate: { kind: 'auto' }, sortOrder: 0 },
-            { id: 'cl2', contentId: 'ct1', text: 'Acid scars', gate: { kind: 'manual' }, sortOrder: 1 },
+            { id: 'cl1', contentId: 'ct1', text: 'Dead vegetation', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false },
+            { id: 'cl2', contentId: 'ct1', text: 'Acid scars', gate: { kind: 'manual' }, sortOrder: 1, indicatesDirection: false },
           ],
         },
         {
           id: 'ct2', mapId: 'm1', q: 2, r: 0, type: 'cache', title: 'Buried gold', dmNotes: '', glyph: '', showLabel: false, scaleVisibility: 1, wikiPage: '',
-          clues: [{ id: 'cl3', contentId: 'ct2', text: 'Disturbed earth', gate: { kind: 'auto' }, sortOrder: 0 }],
+          clues: [{ id: 'cl3', contentId: 'ct2', text: 'Disturbed earth', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false }],
         },
       ],
       pendingMoves: [],
     },
     discoveries: [
-      { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' } },
-      { id: 'd2', clueId: 'cl3', characterId: 'char2', at: 1001, how: { kind: 'auto' } },
+      { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' }, direction: null },
+      { id: 'd2', clueId: 'cl3', characterId: 'char2', at: 1001, how: { kind: 'auto' }, direction: null },
     ],
     encounterTables: [{ id: 'et1', name: 'Forest', terrains: ['forest'], die: '1d12', entries: [] }],
     log: [


### PR DESCRIPTION
Clues get an **indicates direction** flag (🧭 chip in the clue editor; also exposed in the integration API and MCP server). When a flagged clue opens for a character — passively at distance, automatically on arrival, or via DM reveal — the server computes the compass bearing (8-wind rose, map-orientation aware) from the character's token toward the content hex and stores it on the discovery. Player-facing text then reads "You smell woodsmoke — to the north-east" in the discovery toast, journal, and hex inspector. The bearing is a snapshot of where the character stood when they sensed it.

New `compassDirection`/`withDirection` helpers in shared hex math with unit tests, plus end-to-end server tests (bearing stored, player view text composed, flag-off leaves it null). Typecheck clean; 30 shared + 31 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)