### PR TITLE
Senses: non-locating clues, triangulation, settlement clue generation

### DIFF
--- a/packages/client/src/components/SidePanel.tsx
+++ b/packages/client/src/components/SidePanel.tsx
@@ -9,6 +9,7 @@ import { TokensTab } from './panels/TokensTab.js';
 import { EncountersTab } from './panels/EncountersTab.js';
 import { LogTab } from './panels/LogTab.js';
 import { JournalTab } from './panels/JournalTab.js';
+import { SensesTab } from './panels/SensesTab.js';
 import { SettingsTab } from './panels/SettingsTab.js';
 
 const DM_TABS: { tab: PanelTab; icon: string; name: string }[] = [
@@ -23,6 +24,7 @@ const DM_TABS: { tab: PanelTab; icon: string; name: string }[] = [
 
 const PLAYER_TABS: { tab: PanelTab; icon: string; name: string }[] = [
   { tab: 'inspect', icon: '🔍', name: 'Inspect' },
+  { tab: 'senses', icon: '👁️', name: 'Senses' },
   { tab: 'characters', icon: '🧝', name: 'Party' },
   { tab: 'journal', icon: '📔', name: 'Journal' },
   { tab: 'log', icon: '📜', name: 'Log' },
@@ -59,6 +61,7 @@ export function SidePanel({ campaignId }: { campaignId: string }) {
         {active === 'maps' && <MapsTab campaignId={campaignId} />}
         {active === 'tokens' && <TokensTab />}
         {active === 'characters' && <CharactersTab />}
+        {active === 'senses' && <SensesTab />}
         {active === 'encounters' && <EncountersTab />}
         {active === 'log' && <LogTab />}
         {active === 'journal' && <JournalTab />}

--- a/packages/client/src/components/panels/MapsTab.tsx
+++ b/packages/client/src/components/panels/MapsTab.tsx
@@ -153,6 +153,15 @@ function MapSettings({ map, campaignId }: { map: MapInfo; campaignId: string }) 
             onChange={(v) => patch({ moveApproval: v })}
             label="DM approves player movement (turn-based travel)"
           />
+          <Button
+            size="sm"
+            variant="ghost"
+            className="w-full"
+            title="Add smoke/din/smell clues (with auto compass bearings) to every settlement on this map that doesn't have them. Safe to run again."
+            onClick={() => send({ kind: 'clues.generateSettlements', mapId: map.id })}
+          >
+            🏘️ Generate settlement sensory clues
+          </Button>
         </div>
       </Section>
 

--- a/packages/client/src/components/panels/SensesTab.tsx
+++ b/packages/client/src/components/panels/SensesTab.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import type { Sense } from '@hexcrawl/shared';
+import { useSession } from '../../stores/session.js';
+import { useUi } from '../../stores/ui.js';
+import { EmptyNote, Section, cx } from '../../ui/kit.js';
+
+/**
+ * The character's sensed clues: what they can observe right now, and past
+ * observations. Clicking a clue highlights every visited hex it can be
+ * sensed from, so the party can triangulate the source.
+ */
+export function SensesTab() {
+  const senses = useSession((s) => s.state?.senses ?? []);
+  const current = senses.filter((s) => s.inRange);
+  const past = senses.filter((s) => !s.inRange);
+
+  return (
+    <div>
+      <Section title="You currently sense">
+        {current.length === 0 && (
+          <EmptyNote>Nothing beyond the ordinary, from where you stand.</EmptyNote>
+        )}
+        <div className="space-y-1.5">
+          {current.map((s) => (
+            <SenseRow key={s.clueId} sense={s} />
+          ))}
+        </div>
+      </Section>
+      <Section title="Past observations">
+        {past.length === 0 && <EmptyNote>Nothing yet — explore, and pay attention.</EmptyNote>}
+        <div className="space-y-1.5">
+          {past.map((s) => (
+            <SenseRow key={s.clueId} sense={s} />
+          ))}
+        </div>
+      </Section>
+      <p className="text-[11px] text-ink-400 mt-2">
+        Click a clue to highlight every hex you've visited where it can be sensed — walk the edges
+        of that area to triangulate the source.
+      </p>
+    </div>
+  );
+}
+
+function SenseRow({ sense }: { sense: Sense }) {
+  const highlighted = useUi((u) => u.senseHighlight?.clueId === sense.clueId);
+  const toggle = () => {
+    const ui = useUi.getState();
+    ui.set(
+      'senseHighlight',
+      highlighted ? null : { clueId: sense.clueId, cells: sense.observableFrom },
+    );
+  };
+  return (
+    <button
+      onClick={toggle}
+      className={cx(
+        'w-full text-left rounded-md border px-2.5 py-2 cursor-pointer transition-colors',
+        highlighted
+          ? 'border-brass-500 bg-brass-500/10'
+          : 'border-ink-700 bg-ink-850 hover:border-ink-500',
+      )}
+      title={
+        highlighted
+          ? 'Hide the sensing area'
+          : `Show the ${sense.observableFrom.length} visited hex(es) this can be sensed from`
+      }
+    >
+      <span className="block text-sm text-ink-100">
+        {sense.text}
+        {sense.direction && <span className="text-brass-300"> — to the {sense.direction}</span>}
+      </span>
+      <span className="block text-[11px] text-ink-400 mt-0.5">
+        {sense.located && sense.contentTitle ? (
+          <>
+            Source found: <span className="text-ink-200">{sense.contentTitle}</span>
+          </>
+        ) : sense.inRange ? (
+          'Sensing it now'
+        ) : (
+          'Observed earlier'
+        )}
+        {highlighted && ' · highlighted on map'}
+      </span>
+    </button>
+  );
+}

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -87,6 +87,7 @@ export class CanvasEngine {
   private pinsC = new Container();
   private tokensC = new Container();
   private pendingC = new Container();
+  private senseG = new Graphics();
   private highlightG = new Graphics();
 
   private tokens = new Map<string, TokenView>();
@@ -162,6 +163,7 @@ export class CanvasEngine {
     this.viewport.addChild(this.pendingC);
     this.viewport.addChild(this.exploredC);
     this.viewport.addChild(this.fogC);
+    this.viewport.addChild(this.senseG);
     this.viewport.addChild(this.highlightG);
 
     // Every layer except tokensC must be event-transparent: Pixi treats any
@@ -176,6 +178,7 @@ export class CanvasEngine {
       this.pendingC,
       this.exploredC,
       this.fogC,
+      this.senseG,
       this.highlightG,
     ]) {
       layer.eventMode = 'none';
@@ -222,6 +225,9 @@ export class CanvasEngine {
       }
       if (u.dimUnexplored !== prev.dimUnexplored) {
         this.drawPins();
+      }
+      if (u.senseHighlight !== prev.senseHighlight) {
+        this.drawSenseHighlight();
       }
       if (
         u.tool !== prev.tool ||
@@ -326,6 +332,9 @@ export class CanvasEngine {
     if (layoutChanged && this.lastMapIdForCenter !== map.id) {
       this.lastMapIdForCenter = map.id;
       this.recenter();
+      // Sense-highlight cells belong to the previous map.
+      useUi.getState().set('senseHighlight', null);
+      this.drawSenseHighlight();
     }
   }
 
@@ -338,6 +347,7 @@ export class CanvasEngine {
     this.fogSheetG.clear();
     this.fogEraseG.clear();
     this.exploredG.clear();
+    this.senseG.clear();
     this.highlightG.clear();
     this.pinsC.removeChildren().forEach((c) => c.destroy({ children: true }));
     this.tokensReset();
@@ -624,6 +634,26 @@ export class CanvasEngine {
     for (const view of this.tokens.values()) {
       view.root.scale.set(tokenScale * view.crowdScale);
     }
+  }
+
+  /** Brass wash over the visited hexes a clicked sense can be observed from. */
+  private drawSenseHighlight(): void {
+    const g = this.senseG;
+    g.clear();
+    if (!this.layout) return;
+    const highlight = useUi.getState().senseHighlight;
+    if (!highlight) return;
+    const corners = this.corners();
+    for (const cell of highlight.cells) {
+      const center = hexToPixel(this.layout, cell);
+      g.poly(this.polyPoints(center, corners));
+    }
+    g.fill({ color: 0xd9b44f, alpha: 0.22 });
+    for (const cell of highlight.cells) {
+      const center = hexToPixel(this.layout, cell);
+      g.poly(this.polyPoints(center, corners));
+    }
+    g.stroke({ width: 1.5 / this.viewport.scale.x, color: 0xd9b44f, alpha: 0.55 });
   }
 
   private drawHighlight(): void {

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -9,6 +9,7 @@ export type PanelTab =
   | 'characters'
   | 'tokens'
   | 'encounters'
+  | 'senses'
   | 'log'
   | 'journal'
   | 'settings';
@@ -38,6 +39,8 @@ interface UiStore {
   movingContentId: string | null;
   /** Armed "click a destination hex to send this token there" mode. */
   movingTokenId: string | null;
+  /** Sense triangulation: visited hexes a clicked clue is observable from. */
+  senseHighlight: { clueId: string; cells: HexCoord[] } | null;
   /** Player-chosen map for this session (null = follow the DM default). */
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
@@ -70,6 +73,7 @@ export const useUi = create<UiStore>((set) => ({
   currentScale: 0,
   movingContentId: null,
   movingTokenId: null,
+  senseHighlight: null,
   viewedMapId: null,
   dimUnexplored: false,
   altTeleport: false,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -47,6 +47,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.selectHex(null);
         ui.set('measureStart', null);
         ui.set('movingTokenId', null);
+        ui.set('senseHighlight', null);
         return;
       }
       if (useSession.getState().role !== 'dm') return;

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -196,6 +196,9 @@ function migrate(d: DB): void {
   ensureColumn(d, 'token', 'party_id', 'TEXT');
   ensureColumn(d, 'clue', 'indicates_direction', 'INTEGER NOT NULL DEFAULT 0');
   ensureColumn(d, 'discovery', 'direction', 'TEXT');
+  // Grandfather pre-existing discoveries as locating: players who could see a
+  // pin before the senses rework keep seeing it.
+  ensureColumn(d, 'discovery', 'locates', 'INTEGER NOT NULL DEFAULT 1');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/engine/knowledge.ts
+++ b/packages/server/src/engine/knowledge.ts
@@ -43,7 +43,12 @@ export function evaluateKnowledge(
     for (const content of rt.contents.values()) {
       const distance = hexDistance(pos, { q: content.q, r: content.r });
       for (const clue of content.clues) {
-        if (runtime.hasDiscovery(clue.id, characterId)) continue;
+        if (runtime.hasDiscovery(clue.id, characterId)) {
+          // Reaching the source upgrades an earlier at-a-distance discovery:
+          // the character now knows exactly where it came from.
+          if (distance === 0) runtime.markDiscoveryLocated(clue.id, characterId);
+          continue;
+        }
         const evaluation = gateOpensPassively(clue.gate, character, distance);
         if (!evaluation.opens) continue;
         const direction = clue.indicatesDirection
@@ -90,5 +95,13 @@ function buildDiscovery(
           distance,
         }
       : { kind: 'auto' };
-  return { id: nanoid(12), clueId, characterId: character.id, at: Date.now(), how, direction };
+  return {
+    id: nanoid(12),
+    clueId,
+    characterId: character.id,
+    at: Date.now(),
+    how,
+    direction,
+    locates: distance === 0,
+  };
 }

--- a/packages/server/src/engine/settlements.ts
+++ b/packages/server/src/engine/settlements.ts
@@ -1,0 +1,120 @@
+import { nanoid } from 'nanoid';
+import type { Clue, Content } from '@hexcrawl/shared';
+import type { CampaignRuntime } from '../state/runtime.js';
+
+/**
+ * Sensory clue templates for settlements, scaled by pin prominence
+ * (scaleVisibility: 2 = major city, 1 = town, 0 = village/hamlet).
+ * All are distance-sensed, directional, and never locate the source —
+ * players triangulate from where they've sensed them.
+ */
+const TEMPLATES: Record<
+  number,
+  { text: string; skill: string; dc: number; maxDistance: number }[]
+> = {
+  2: [
+    {
+      text: 'A brown haze of a thousand chimneys smudges the sky',
+      skill: 'perception',
+      dc: 8,
+      maxDistance: 6,
+    },
+    {
+      text: 'The distant din of a great city — bells, wheels, and countless voices',
+      skill: 'perception',
+      dc: 12,
+      maxDistance: 3,
+    },
+    {
+      text: 'Woodsmoke, dung, and cookfires ride the wind',
+      skill: 'survival',
+      dc: 10,
+      maxDistance: 4,
+    },
+  ],
+  1: [
+    {
+      text: 'Threads of chimney smoke rise above the treeline',
+      skill: 'perception',
+      dc: 10,
+      maxDistance: 4,
+    },
+    {
+      text: 'Faint sounds of livestock and working folk',
+      skill: 'perception',
+      dc: 13,
+      maxDistance: 2,
+    },
+    {
+      text: 'The smell of hearthfires and tilled earth',
+      skill: 'survival',
+      dc: 11,
+      maxDistance: 3,
+    },
+  ],
+  0: [
+    {
+      text: 'A thin wisp of hearth smoke curls into the sky',
+      skill: 'perception',
+      dc: 12,
+      maxDistance: 3,
+    },
+    {
+      text: 'A dog barks somewhere; a cock crows',
+      skill: 'perception',
+      dc: 14,
+      maxDistance: 1,
+    },
+    {
+      text: 'A whiff of woodsmoke and cooking',
+      skill: 'survival',
+      dc: 13,
+      maxDistance: 2,
+    },
+  ],
+};
+
+/**
+ * Add the standard sensory clues to every settlement on the map that doesn't
+ * already carry them (matched by text, so re-running is safe). Returns the
+ * touched contents with their prior clue lists for undo.
+ */
+export function generateSettlementClues(
+  runtime: CampaignRuntime,
+  mapId: string,
+): { content: Content; priorClues: Clue[] }[] {
+  const rt = runtime.mapStates.get(mapId);
+  if (!rt) return [];
+  const touched: { content: Content; priorClues: Clue[] }[] = [];
+  for (const content of rt.contents.values()) {
+    if (content.type !== 'settlement') continue;
+    const templates = TEMPLATES[content.scaleVisibility] ?? TEMPLATES[1]!;
+    const existingTexts = new Set(content.clues.map((c) => c.text));
+    const fresh = templates.filter((t) => !existingTexts.has(t.text));
+    if (!fresh.length) continue;
+    const priorClues = [...content.clues];
+    const next: Content = {
+      ...content,
+      clues: [
+        ...content.clues,
+        ...fresh.map((t, i) => ({
+          id: nanoid(10),
+          contentId: content.id,
+          text: t.text,
+          gate: {
+            kind: 'skill' as const,
+            skill: t.skill,
+            dc: t.dc,
+            maxDistance: t.maxDistance,
+            mode: 'passive' as const,
+          },
+          sortOrder: content.clues.length + i,
+          indicatesDirection: true,
+        })),
+      ],
+    };
+    runtime.upsertContent(next);
+    touched.push({ content: next, priorClues });
+  }
+  return touched;
+}

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import type { Content, ImageLayer } from '@hexcrawl/shared';
 import { ContentTypeSchema, GateSchema, pixelToHex } from '@hexcrawl/shared';
 import { evaluateKnowledge } from '../engine/knowledge.js';
+import { generateSettlementClues } from '../engine/settlements.js';
 import { MAX_UPLOAD_BYTES, UPLOADS_DIR } from '../config.js';
 import type { Store } from '../state/store.js';
 import type { CampaignRuntime, SeatRecord } from '../state/runtime.js';
@@ -305,6 +306,19 @@ export function createApp(store: Store, hub: Hub): Hono {
     evaluateKnowledge(runtime, input.mapId);
     hub.scheduleSync(runtime);
     return c.json({ contentId: id, q, r, updated: Boolean(existing) });
+  });
+
+  /** Generate the standard sensory clues for every settlement on a map. */
+  app.post('/api/integration/campaigns/:id/generate-settlement-clues', async (c) => {
+    const runtime = integrationAuth(c);
+    if (!runtime) return c.json({ error: 'Unauthorized' }, 401);
+    const body = (await c.req.json().catch(() => ({}))) as { mapId?: string };
+    const mapId = body.mapId;
+    if (!mapId || !runtime.maps.has(mapId)) return c.json({ error: 'Map not found' }, 404);
+    const touched = generateSettlementClues(runtime, mapId);
+    evaluateKnowledge(runtime, mapId);
+    hub.scheduleSync(runtime);
+    return c.json({ settlements: touched.length, titles: touched.map((t) => t.content.title) });
   });
 
   app.delete('/api/integration/campaigns/:id/content/:contentId', (c) => {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -480,10 +480,27 @@ describe('directional clues', () => {
     const view = filterStateForViewer(runtime.buildFullState(), {
       seatId: playerSeat.id, role: 'player', characterId: charId,
     });
-    const camp = view.mapState!.contents.find((c) => c.title === 'Bandit Camp')!;
-    expect((camp as { discoveredClues: { text: string }[] }).discoveredClues[0]!.text).toBe(
-      'You smell woodsmoke — to the east',
+    // Sensed from afar: the pin is NOT revealed — the clue lives in senses.
+    expect(view.mapState!.contents.find((c) => c.title === 'Bandit Camp')).toBeUndefined();
+    const sense = view.senses.find((s) => s.text === 'You smell woodsmoke')!;
+    expect(sense.direction).toBe('east');
+    expect(sense.inRange).toBe(true);
+    expect(sense.located).toBe(false);
+    expect(sense.contentTitle).toBeNull();
+    // Triangulation cells: only hexes the character has been to.
+    const visited = new Set(
+      view.mapState!.fog.map((f) => `${f.q},${f.r}`),
     );
+    expect(sense.observableFrom.length).toBeGreaterThan(0);
+    for (const c of sense.observableFrom) expect(visited.has(`${c.q},${c.r}`)).toBe(true);
+
+    // Walking onto the hex locates the source and reveals the pin.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 4, r: -2 } as never);
+    const after = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(after.mapState!.contents.find((c) => c.title === 'Bandit Camp')).toBeDefined();
+    expect(after.senses.find((s) => s.text === 'You smell woodsmoke')!.located).toBe(true);
   });
 
   it('leaves direction null when the flag is off', () => {
@@ -505,5 +522,46 @@ describe('directional clues', () => {
     asSeat(playerSeat, { kind: 'token.move', tokenId, q: 0, r: 0 } as never);
     const disc = [...runtime.discoveries.values()][0]!;
     expect(disc.direction).toBeNull();
+  });
+});
+
+describe('settlement clue generation', () => {
+  it('adds scaled sensory clues to settlements, idempotently', () => {
+    const mapId = activeMapId();
+    dm({
+      kind: 'content.upsert',
+      content: { id: null, mapId, q: 3, r: 0, type: 'settlement', title: 'Bigtown', dmNotes: '', glyph: '', scaleVisibility: 2, clues: [] },
+    } as never);
+    dm({
+      kind: 'content.upsert',
+      content: { id: null, mapId, q: 9, r: 0, type: 'settlement', title: 'Smallville', dmNotes: '', glyph: '', scaleVisibility: 0, clues: [] },
+    } as never);
+    dm({
+      kind: 'content.upsert',
+      content: { id: null, mapId, q: 6, r: 6, type: 'ruin', title: 'Old Fort', dmNotes: '', glyph: '', clues: [] },
+    } as never);
+
+    dm({ kind: 'clues.generateSettlements', mapId } as never);
+    const rt = runtime.requireMap(mapId);
+    const byTitle = (t: string) => [...rt.contents.values()].find((c) => c.title === t)!;
+    expect(byTitle('Bigtown').clues).toHaveLength(3);
+    expect(byTitle('Smallville').clues).toHaveLength(3);
+    expect(byTitle('Old Fort').clues).toHaveLength(0);
+    // City clues reach farther than village clues.
+    const cityMax = Math.max(...byTitle('Bigtown').clues.map((c) => (c.gate.kind === 'skill' ? c.gate.maxDistance : 0)));
+    const villageMax = Math.max(...byTitle('Smallville').clues.map((c) => (c.gate.kind === 'skill' ? c.gate.maxDistance : 0)));
+    expect(cityMax).toBeGreaterThan(villageMax);
+    expect(byTitle('Bigtown').clues.every((c) => c.indicatesDirection)).toBe(true);
+
+    // Re-running adds nothing.
+    dm({ kind: 'clues.generateSettlements', mapId } as never);
+    expect(byTitle('Bigtown').clues).toHaveLength(3);
+
+    // Undo strips the generated clues.
+    dm({ kind: 'undo' } as never);
+    // (second run touched nothing, so this undoes the log entry-less no-op? — the
+    // no-op run pushes no undo entry; this pops the first generation)
+    expect(byTitle('Bigtown').clues).toHaveLength(0);
+    expect(byTitle('Smallville').clues).toHaveLength(0);
   });
 });

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -175,6 +175,7 @@ export class CampaignRuntime {
         at: dd.at as number,
         how: safeJson(dd.how as string, { kind: 'manual' }) as Discovery['how'],
         direction: (dd.direction as string | null) ?? null,
+        locates: Boolean(dd.locates),
       };
       this.discoveries.set(disc.id, disc);
       this.discoveredByClueChar.add(`${disc.clueId}|${disc.characterId}`);
@@ -341,6 +342,7 @@ export class CampaignRuntime {
       maps: [...this.maps.values()].sort((a, b) => a.sortOrder - b.sortOrder),
       mapState: this.mapState(mapId),
       discoveries: [...this.discoveries.values()],
+      senses: [],
       encounterTables: [...this.encounterTables.values()],
       log: this.log,
     };
@@ -848,7 +850,7 @@ export class CampaignRuntime {
     this.discoveredByClueChar.add(`${discovery.clueId}|${discovery.characterId}`);
     this.db
       .prepare(
-        'INSERT INTO discovery (id, campaign_id, clue_id, character_id, at, how, direction) VALUES (?,?,?,?,?,?,?)',
+        'INSERT INTO discovery (id, campaign_id, clue_id, character_id, at, how, direction, locates) VALUES (?,?,?,?,?,?,?,?)',
       )
       .run(
         discovery.id,
@@ -858,8 +860,19 @@ export class CampaignRuntime {
         discovery.at,
         JSON.stringify(discovery.how),
         discovery.direction,
+        discovery.locates ? 1 : 0,
       );
     return true;
+  }
+
+  /** Upgrade an at-a-distance discovery: the character reached the source. */
+  markDiscoveryLocated(clueId: string, characterId: string): void {
+    for (const disc of this.discoveries.values()) {
+      if (disc.clueId === clueId && disc.characterId === characterId && !disc.locates) {
+        disc.locates = true;
+        this.db.prepare('UPDATE discovery SET locates = 1 WHERE id = ?').run(disc.id);
+      }
+    }
   }
 
   revokeDiscovery(discoveryId: string): Discovery | null {

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -23,6 +23,7 @@ import type { CampaignRuntime, SeatRecord } from '../state/runtime.js';
 import type { Hub } from './hub.js';
 import { applyAutoReveal } from '../engine/fog.js';
 import { evaluateKnowledge, type NewDiscovery } from '../engine/knowledge.js';
+import { generateSettlementClues } from '../engine/settlements.js';
 import { rollEncounter } from '../engine/encounters.js';
 
 export interface Ctx {
@@ -478,6 +479,34 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     throw new Error('view.map is connection-scoped');
   }) as Handler,
 
+  'clues.generateSettlements': ((
+    cmd: Extract<ClientCommand, { kind: 'clues.generateSettlements' }>,
+    ctx: Ctx,
+  ) => {
+    requireDm(ctx);
+    const touched = generateSettlementClues(ctx.runtime, cmd.mapId);
+    if (touched.length) {
+      ctx.runtime.pushUndo({
+        at: Date.now(),
+        kind: 'clues.generate',
+        description: `remove generated clues from ${touched.length} settlement(s)`,
+        run: (runtime) => {
+          for (const t of touched) {
+            const current = runtime.mapStates.get(cmd.mapId)?.contents.get(t.content.id);
+            if (current) runtime.upsertContent({ ...current, clues: t.priorClues });
+          }
+        },
+      });
+      deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, cmd.mapId));
+    }
+    const entry = ctx.runtime.appendLog(
+      'note',
+      `Generated sensory clues for ${touched.length} settlement(s).`,
+      'dm',
+    );
+    notifyLog(ctx, entry);
+  }) as Handler,
+
   'content.delete': ((cmd: Extract<ClientCommand, { kind: 'content.delete' }>, ctx: Ctx) => {
     requireDm(ctx);
     const removed = ctx.runtime.deleteContent(cmd.contentId);
@@ -510,6 +539,8 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         at: Date.now(),
         how: { kind: 'manual' as const },
         direction: clueDirectionFor(ctx, clue, content, characterId),
+        // A deliberate DM reveal tells the player where it is.
+        locates: true,
       };
       if (ctx.runtime.addDiscovery(discovery)) {
         created.push({

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -406,6 +406,12 @@ export const DiscoverySchema = z.object({
   how: DiscoveryHowSchema,
   /** Compass bearing sensed at discovery time (clue's indicatesDirection). */
   direction: z.string().nullable().default(null),
+  /**
+   * Whether this discovery pins down the source's location (made on the hex
+   * itself, or DM-revealed). Distance discoveries start false and upgrade
+   * when the character later reaches the hex.
+   */
+  locates: z.boolean().default(false),
 });
 export type Discovery = z.infer<typeof DiscoverySchema>;
 
@@ -488,6 +494,31 @@ export const MapStateSchema = z.object({
 });
 export type MapState = z.infer<typeof MapStateSchema>;
 
+/**
+ * A player's sensed clue on the current map: the information itself, without
+ * the source's location. `observableFrom` is the set of hexes the character
+ * has already visited from which this clue can be sensed — the raw material
+ * for triangulating the source.
+ */
+export const SenseSchema = z.object({
+  clueId: z.string(),
+  /** Raw clue text (direction is carried separately). */
+  text: z.string(),
+  /** Bearing toward the source: live while in range, else the discovery snapshot. */
+  direction: z.string().nullable(),
+  /** Whether the clue is observable from the character's current hex. */
+  inRange: z.boolean(),
+  /** When it was first discovered (epoch ms). */
+  at: z.number(),
+  /** Visited hexes from which this clue can be sensed. */
+  observableFrom: z.array(z.object({ q: z.number().int(), r: z.number().int() })),
+  /** True once the source itself has been located (pin shown on the map). */
+  located: z.boolean(),
+  /** Source title, revealed only once located. */
+  contentTitle: z.string().nullable(),
+});
+export type Sense = z.infer<typeof SenseSchema>;
+
 export const CampaignStateSchema = z.object({
   campaign: CampaignSchema,
   seats: z.array(SeatPublicSchema),
@@ -496,6 +527,8 @@ export const CampaignStateSchema = z.object({
   mapState: MapStateSchema.nullable(),
   /** DM: all; player: own character's. */
   discoveries: z.array(DiscoverySchema),
+  /** Player only: sensed clues on the viewed map; empty for the DM. */
+  senses: z.array(SenseSchema).default([]),
   /** DM only; empty for players. */
   encounterTables: z.array(EncounterTableSchema),
   log: z.array(LogEntrySchema),

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -339,6 +339,17 @@ export const ViewMapCommand = z.object({
   mapId: z.string(),
 });
 
+/**
+ * DM: auto-generate sensory clues (smoke, din, smells) for every settlement
+ * on a map that doesn't already have them. Scaled by the pin's
+ * scaleVisibility (2 = city, 1 = town, 0 = village).
+ */
+export const CluesGenerateCommand = z.object({
+  ...base,
+  kind: z.literal('clues.generateSettlements'),
+  mapId: z.string(),
+});
+
 export const ContentDeleteCommand = z.object({
   ...base,
   kind: z.literal('content.delete'),
@@ -440,6 +451,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   ContentUpsertCommand,
   ContentMoveCommand,
   ViewMapCommand,
+  CluesGenerateCommand,
   ContentDeleteCommand,
   ClueRevealCommand,
   DiscoveryRevokeCommand,

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -2,13 +2,16 @@ import type {
   CampaignState,
   Content,
   ContentPlayerView,
+  Discovery,
   FogState,
   SeatRole,
+  Sense,
   Token,
 } from '../domain.js';
 import { isFullContent } from '../domain.js';
-import { hexKey } from '../hex/coords.js';
-import { withDirection } from '../hex/direction.js';
+import { hexDistance, hexKey, hexRange } from '../hex/coords.js';
+import { compassDirection, withDirection } from '../hex/direction.js';
+import type { HexOrientation } from '../hex/layout.js';
 
 export interface Viewer {
   seatId: string;
@@ -23,7 +26,7 @@ export interface Viewer {
  * same rules). Pure function; unit-tested.
  */
 export function filterStateForViewer(full: CampaignState, viewer: Viewer): CampaignState {
-  if (viewer.role === 'dm') return full;
+  if (viewer.role === 'dm') return { ...full, senses: [] };
 
   const mapState = full.mapState;
   const filteredMapState = mapState
@@ -56,6 +59,7 @@ export function filterStateForViewer(full: CampaignState, viewer: Viewer): Campa
     discoveries: viewer.characterId
       ? full.discoveries.filter((d) => d.characterId === viewer.characterId)
       : [],
+    senses: computeSenses(full, viewer.characterId),
     encounterTables: [],
     log: full.log.filter((e) => e.visibility === 'all' || e.visibility === viewer.seatId),
   };
@@ -68,8 +72,18 @@ export function tokenVisibleToPlayers(token: Token, fogAtToken: FogState): boole
 }
 
 /**
- * A player's view of a content entry: present only if their character has
- * discovered at least one clue; carries only discovered clue texts.
+ * Does this discovery pin down the source's location? Discoveries made on
+ * the hex itself (or DM-revealed) do; sensing something from afar does not —
+ * those clues live in the senses panel until the character actually reaches
+ * the place, which upgrades the discovery.
+ */
+export function discoveryLocates(d: Discovery): boolean {
+  return d.locates;
+}
+
+/**
+ * A player's view of a content entry: present only once their character has
+ * LOCATED it (not merely sensed a clue from afar); carries discovered clues.
  */
 export function contentPlayerView(
   content: Content,
@@ -81,7 +95,7 @@ export function contentPlayerView(
   const mine = full.discoveries.filter(
     (d) => d.characterId === characterId && clueIds.has(d.clueId),
   );
-  if (mine.length === 0) return null;
+  if (!mine.some(discoveryLocates)) return null;
   const clueText = new Map(content.clues.map((c) => [c.id, c.text]));
   return {
     id: content.id,
@@ -102,4 +116,57 @@ export function contentPlayerView(
         at: d.at,
       })),
   };
+}
+
+/**
+ * The character's sensed clues on the viewed map: every discovered clue with
+ * a live bearing while in range, plus the visited hexes it can be sensed
+ * from (for triangulation). Never leaks the source hex of unlocated content.
+ */
+function computeSenses(full: CampaignState, characterId: string | null): Sense[] {
+  const mapState = full.mapState;
+  if (!mapState || !characterId) return [];
+  const mine = new Map(
+    full.discoveries.filter((d) => d.characterId === characterId).map((d) => [d.clueId, d]),
+  );
+  if (mine.size === 0) return [];
+
+  const orientation: HexOrientation =
+    full.maps.find((m) => m.id === full.campaign.activeMapId)?.orientation ?? 'flat';
+  const myToken = mapState.tokens.find((t) => t.kind === 'pc' && t.characterId === characterId);
+  const visited = new Set(
+    mapState.fog.filter((f) => f.state !== 'hidden').map((f) => hexKey(f.q, f.r)),
+  );
+
+  const senses: Sense[] = [];
+  for (const content of mapState.contents) {
+    if (!isFullContent(content)) continue;
+    const located = content.clues.some((clue) => {
+      const d = mine.get(clue.id);
+      return d ? discoveryLocates(d) : false;
+    });
+    for (const clue of content.clues) {
+      const d = mine.get(clue.id);
+      if (!d) continue;
+      const src = { q: content.q, r: content.r };
+      const radius = clue.gate.kind === 'skill' ? clue.gate.maxDistance : 0;
+      const here = myToken ? { q: myToken.q, r: myToken.r } : null;
+      const inRange = here ? hexDistance(here, src) <= radius : false;
+      const liveDirection =
+        inRange && here && clue.indicatesDirection
+          ? compassDirection(here, src, orientation)
+          : null;
+      senses.push({
+        clueId: clue.id,
+        text: clue.text,
+        direction: liveDirection ?? d.direction,
+        inRange,
+        at: d.at,
+        observableFrom: hexRange(src, radius).filter((c) => visited.has(hexKey(c.q, c.r))),
+        located,
+        contentTitle: located ? content.title : null,
+      });
+    }
+  }
+  return senses.sort((a, b) => Number(b.inRange) - Number(a.inRange) || b.at - a.at);
 }

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -117,9 +117,10 @@ function fullState(): CampaignState {
       pendingMoves: [],
     },
     discoveries: [
-      { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' }, direction: null },
-      { id: 'd2', clueId: 'cl3', characterId: 'char2', at: 1001, how: { kind: 'auto' }, direction: null },
+      { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' }, direction: null, locates: true },
+      { id: 'd2', clueId: 'cl3', characterId: 'char2', at: 1001, how: { kind: 'auto' }, direction: null, locates: true },
     ],
+    senses: [],
     encounterTables: [{ id: 'et1', name: 'Forest', terrains: ['forest'], die: '1d12', entries: [] }],
     log: [
       { id: 'l1', at: 1, kind: 'roll', text: 'dm secret roll', visibility: 'dm', data: {} },
@@ -133,9 +134,11 @@ function fullState(): CampaignState {
 describe('filterStateForViewer', () => {
   const viewer = { seatId: 's1', role: 'player' as const, characterId: 'char1' };
 
-  it('passes DM state through untouched', () => {
+  it('passes DM state through untouched (senses stay player-only)', () => {
     const full = fullState();
-    expect(filterStateForViewer(full, { seatId: 'dm', role: 'dm', characterId: null })).toBe(full);
+    const dm = filterStateForViewer(full, { seatId: 'dm', role: 'dm', characterId: null });
+    expect(dm).toEqual({ ...full, senses: [] });
+    expect(dm.mapState).toBe(full.mapState);
   });
 
   it('strips hidden hexes, fog, dm-only layers', () => {


### PR DESCRIPTION
- Sensing a clue from afar no longer reveals the source's map pin — the clue is pure information. A discovery only locates its content when made standing on the hex (or DM-revealed); walking to the source later upgrades earlier at-range discoveries. Existing discoveries are grandfathered as locating so nobody loses pins they already had.
- New player **Senses** tab: current observations (with live compass bearing) and past ones. Clicking a clue paints a brass wash over every *visited* hex the clue can be sensed from, letting the party triangulate the source without ever being shown it.
- The player snapshot gains a `senses` channel computed inside `filterStateForViewer` — it never leaks unvisited hexes or unlocated source positions.
- DM tooling: **Generate settlement sensory clues** (Maps tab + `clues.generateSettlements` + integration endpoint) adds sight/sound/smell clues with auto-computed bearings to every settlement, scaled city/town/village via scaleVisibility. Idempotent and undoable.

Verified live with a real player seat: settlement pin hidden, senses panel shows the clue with live bearing, click highlights the sensing area over visited hexes only, and the located Dragon Lair shows its source. Typecheck clean; 30 shared + 22 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)