### PR TITLE
Triangulation highlights only explored hexes

### DIFF
--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -487,12 +487,16 @@ describe('directional clues', () => {
     expect(sense.inRange).toBe(true);
     expect(sense.located).toBe(false);
     expect(sense.contentTitle).toBeNull();
-    // Triangulation cells: only hexes the character has been to.
-    const visited = new Set(
-      view.mapState!.fog.map((f) => `${f.q},${f.r}`),
+    // Triangulation cells: only hexes the character has actually walked
+    // (explored trail + current hex) — never merely-visible cells.
+    const walked = new Set(
+      view.mapState!.fog.filter((f) => f.state === 'explored').map((f) => `${f.q},${f.r}`),
     );
+    walked.add('0,0'); // where the character currently stands
     expect(sense.observableFrom.length).toBeGreaterThan(0);
-    for (const c of sense.observableFrom) expect(visited.has(`${c.q},${c.r}`)).toBe(true);
+    for (const c of sense.observableFrom) expect(walked.has(`${c.q},${c.r}`)).toBe(true);
+    // The sight-radius 'visible' ring around the token must NOT be included.
+    expect(sense.observableFrom.some((c) => c.q === 1 && c.r === 0)).toBe(false);
 
     // Walking onto the hex locates the source and reveals the pin.
     asSeat(playerSeat, { kind: 'token.move', tokenId, q: 4, r: -2 } as never);

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -134,9 +134,14 @@ function computeSenses(full: CampaignState, characterId: string | null): Sense[]
   const orientation: HexOrientation =
     full.maps.find((m) => m.id === full.campaign.activeMapId)?.orientation ?? 'flat';
   const myToken = mapState.tokens.find((t) => t.kind === 'pc' && t.characterId === characterId);
+  // Hexes the party has actually been to: the explored trail plus wherever
+  // the character stands right now. Merely-visible cells (e.g. a map opened
+  // up wholesale by the DM) don't count — you can't triangulate from a hex
+  // you never walked.
   const visited = new Set(
-    mapState.fog.filter((f) => f.state !== 'hidden').map((f) => hexKey(f.q, f.r)),
+    mapState.fog.filter((f) => f.state === 'explored').map((f) => hexKey(f.q, f.r)),
   );
+  if (myToken) visited.add(hexKey(myToken.q, myToken.r));
 
   const senses: Sense[] = [];
   for (const content of mapState.contents) {


### PR DESCRIPTION
Clicking a clue was shading every cell of the sensing disc on maps the DM had set to visible wholesale — revealing the source outline. The visited set now counts only `explored` fog (the walked trail) plus the character's current hex.

Verified live: the same clue that highlighted ~109 cells now highlights 3 (two explored trail hexes in range + the current hex). Typecheck clean; 30 shared + 22 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)