### PR TITLE
Hex-targeted skill checks + encounter table enable/disable

### DIFF
--- a/packages/client/src/components/panels/EncountersTab.tsx
+++ b/packages/client/src/components/panels/EncountersTab.tsx
@@ -149,6 +149,8 @@ function CheckPanel() {
               skill,
               dc: dc && Number.isFinite(dcNum) ? Math.round(dcNum) : null,
               characterIds: [],
+              mapId: null,
+              hex: null,
             });
           }}
         >
@@ -181,17 +183,36 @@ function TablesPanel() {
       )}
       <div className="space-y-1.5">
         {tables.map((t) => (
-          <button
+          <div
             key={t.id}
-            className="w-full text-left bg-ink-850 border border-ink-700 rounded-md px-2.5 py-2 cursor-pointer hover:border-ink-600"
-            onClick={() => setEditing(t)}
+            className={cx(
+              'flex items-center bg-ink-850 border border-ink-700 rounded-md hover:border-ink-600',
+              !t.enabled && 'opacity-50',
+            )}
           >
-            <span className="text-sm text-ink-100 font-medium">{t.name}</span>
-            <span className="block text-xs text-ink-400 mt-0.5">
-              {t.die} · {t.entries.length} entries ·{' '}
-              {t.terrains.length ? t.terrains.map((x) => TERRAINS[x].label).join(', ') : 'any terrain'}
-            </span>
-          </button>
+            <button
+              className="flex-1 min-w-0 text-left px-2.5 py-2 cursor-pointer"
+              onClick={() => setEditing(t)}
+            >
+              <span className="text-sm text-ink-100 font-medium">{t.name}</span>
+              <span className="block text-xs text-ink-400 mt-0.5">
+                {t.die} · {t.entries.length} entries ·{' '}
+                {t.terrains.length ? t.terrains.map((x) => TERRAINS[x].label).join(', ') : 'any terrain'}
+                {!t.enabled && ' · disabled'}
+              </span>
+            </button>
+            <button
+              className="shrink-0 px-2.5 py-2 text-base cursor-pointer"
+              title={
+                t.enabled
+                  ? 'Active — terrain rolls can pick this table. Click to disable for this session.'
+                  : 'Disabled — terrain rolls skip this table. Click to enable.'
+              }
+              onClick={() => send({ kind: 'encounterTable.upsert', table: { ...t, enabled: !t.enabled } })}
+            >
+              {t.enabled ? '🟢' : '⚪'}
+            </button>
+          </div>
         ))}
       </div>
       {editing && (
@@ -237,7 +258,14 @@ function TableEditor({ table, onClose }: { table: EncounterTable | null; onClose
     }
     send({
       kind: 'encounterTable.upsert',
-      table: { id: table?.id ?? null, name: name.trim(), die, terrains, entries: parsed },
+      table: {
+        id: table?.id ?? null,
+        name: name.trim(),
+        die,
+        terrains,
+        entries: parsed,
+        enabled: table?.enabled ?? true,
+      },
     });
     onClose();
   };

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   CONTENT_TYPE_GLYPHS,
+  CORE_SKILLS,
   TERRAINS,
   isFullContent,
   describeGate,
@@ -160,12 +161,53 @@ export function InspectTab() {
         </div>
       </Section>
 
+      {(isDm || myCharacterId) && <SearchHex mapId={map.id} hex={hex} isDm={isDm} />}
+
       {!isDm && !myCharacterId && (
         <p className="text-xs text-ink-400 mt-4">
           Claim a character in the Party tab to make discoveries and move a token.
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * Active search: roll a chosen skill against this hex. The server compares
+ * the roll to the clue gates of content here (in range of the character) and
+ * reveals anything the roll beats — including active-only gates that never
+ * open passively.
+ */
+function SearchHex({ mapId, hex, isDm }: { mapId: string; hex: { q: number; r: number }; isDm: boolean }) {
+  const [skill, setSkill] = React.useState('perception');
+  return (
+    <Section title="Search this hex">
+      <p className="text-xs text-ink-400 mb-2">
+        {isDm
+          ? 'Rolls for every character with a token on the map; reveals clues the rolls beat.'
+          : 'Roll a check against this hex — you might notice something others missed.'}
+      </p>
+      <div className="flex gap-1.5">
+        <select
+          className="flex-1 bg-ink-900 border border-ink-600 rounded px-2 py-1 text-sm text-ink-100 cursor-pointer capitalize"
+          value={skill}
+          onChange={(e) => setSkill(e.target.value)}
+        >
+          {CORE_SKILLS.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={() => send({ kind: 'check.roll', skill, dc: null, characterIds: [], mapId, hex })}
+        >
+          🎲 Roll
+        </Button>
+      </div>
+    </Section>
   );
 }
 

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -89,6 +89,8 @@ function handleMessage(msg: ServerMessage): void {
         });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'narration') {
         session.pushToast({ kind: 'narration', title: 'The DM narrates', text: msg.entry.text });
+      } else if (msg.kind === 'log.appended' && msg.entry.kind === 'check') {
+        session.pushToast({ kind: 'info', title: 'Skill check', text: msg.entry.text });
       } else if (msg.kind === 'move.requested') {
         session.pushToast({
           kind: 'info',

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -199,6 +199,7 @@ function migrate(d: DB): void {
   // Grandfather pre-existing discoveries as locating: players who could see a
   // pin before the senses rework keep seeing it.
   ensureColumn(d, 'discovery', 'locates', 'INTEGER NOT NULL DEFAULT 1');
+  ensureColumn(d, 'enc_table', 'enabled', 'INTEGER NOT NULL DEFAULT 1');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/engine/encounters.ts
+++ b/packages/server/src/engine/encounters.ts
@@ -60,9 +60,10 @@ export function rollEncounter(
 
   let table: EncounterTable | null = null;
   if (opts.tableId) {
+    // An explicitly chosen table rolls even when disabled.
     table = runtime.encounterTables.get(opts.tableId) ?? null;
   } else {
-    const tables = [...runtime.encounterTables.values()];
+    const tables = [...runtime.encounterTables.values()].filter((t) => t.enabled);
     table =
       (terrain ? tables.find((t) => t.terrains.includes(terrain)) : undefined) ??
       tables.find((t) => t.terrains.length === 0) ??

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -569,3 +569,54 @@ describe('settlement clue generation', () => {
     expect(byTitle('Smallville').clues).toHaveLength(0);
   });
 });
+
+describe('hex-targeted skill checks', () => {
+  it('a player search rolls against clue gates and reveals matching clues', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 1, r: 0, type: 'cache', title: 'Hidden Cache', dmNotes: '', glyph: '',
+        clues: [
+          { id: null, text: 'Fresh-turned earth under a flat stone', gate: { kind: 'skill', skill: 'survival', dc: 2, maxDistance: 1, mode: 'active' }, sortOrder: 0 },
+          { id: null, text: 'Impossible to notice', gate: { kind: 'skill', skill: 'survival', dc: 39, maxDistance: 1, mode: 'active' }, sortOrder: 1 },
+          { id: null, text: 'Wrong sense entirely', gate: { kind: 'skill', skill: 'perception', dc: 2, maxDistance: 1, mode: 'active' }, sortOrder: 2 },
+        ],
+      },
+    } as never);
+    // Active gates never open passively.
+    expect(runtime.discoveries.size).toBe(0);
+
+    asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 1, r: 0 } } as never);
+    expect(runtime.discoveries.size).toBe(1);
+    const disc = [...runtime.discoveries.values()][0]!;
+    expect(disc.how.kind).toBe('roll');
+    expect(disc.locates).toBe(false); // searched from one hex away
+
+    // Re-rolling doesn't duplicate the discovery.
+    asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 1, r: 0 } } as never);
+    expect(runtime.discoveries.size).toBe(1);
+  });
+});
+
+describe('encounter table enable/disable', () => {
+  it('terrain matching skips disabled tables; explicit tableId still rolls', () => {
+    const mapId = activeMapId();
+    dm({ kind: 'terrain.paint', mapId, cells: [{ q: 0, r: 0 }], terrain: 'hills' } as never);
+    dm({
+      kind: 'encounterTable.upsert',
+      table: { id: 'tblA', name: 'Hills A', terrains: ['hills'], die: '1d4', entries: [{ min: 1, max: 4, text: 'wolves', quantity: '' }], enabled: true },
+    } as never);
+    const pick = () => rollEncounter(runtime, { mapId, q: 0, r: 0, tableId: null, skipCheck: true }, seededRng(3));
+    expect(pick().table?.id).toBe('tblA');
+
+    dm({
+      kind: 'encounterTable.upsert',
+      table: { id: 'tblA', name: 'Hills A', terrains: ['hills'], die: '1d4', entries: [{ min: 1, max: 4, text: 'wolves', quantity: '' }], enabled: false },
+    } as never);
+    expect(pick().table).toBeNull();
+    // Explicit choice overrides the disable.
+    const forced = rollEncounter(runtime, { mapId, q: 0, r: 0, tableId: 'tblA', skipCheck: true }, seededRng(3));
+    expect(forced.table?.id).toBe('tblA');
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -163,6 +163,7 @@ export class CampaignRuntime {
         terrains: safeJson(t.terrains as string, []) as TerrainId[],
         die: t.die as string,
         entries: safeJson(t.entries as string, []) as EncounterTable['entries'],
+        enabled: Boolean(t.enabled ?? 1),
       });
     }
     for (const dd of d
@@ -890,10 +891,18 @@ export class CampaignRuntime {
     this.encounterTables.set(table.id, table);
     this.db
       .prepare(
-        `INSERT INTO enc_table (id, campaign_id, name, terrains, die, entries) VALUES (?,?,?,?,?,?)
-         ON CONFLICT(id) DO UPDATE SET name=excluded.name, terrains=excluded.terrains, die=excluded.die, entries=excluded.entries`,
+        `INSERT INTO enc_table (id, campaign_id, name, terrains, die, entries, enabled) VALUES (?,?,?,?,?,?,?)
+         ON CONFLICT(id) DO UPDATE SET name=excluded.name, terrains=excluded.terrains, die=excluded.die, entries=excluded.entries, enabled=excluded.enabled`,
       )
-      .run(table.id, this.id, table.name, JSON.stringify(table.terrains), table.die, JSON.stringify(table.entries));
+      .run(
+        table.id,
+        this.id,
+        table.name,
+        JSON.stringify(table.terrains),
+        table.die,
+        JSON.stringify(table.entries),
+        table.enabled ? 1 : 0,
+      );
   }
 
   deleteEncounterTable(tableId: string): void {

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -562,10 +562,14 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
 
   // -- checks ----------------------------------------------------------------
   'check.roll': ((cmd: Extract<ClientCommand, { kind: 'check.roll' }>, ctx: Ctx) => {
-    requireDm(ctx);
     let targets = cmd.characterIds;
+    if (ctx.seat.role !== 'dm') {
+      // Players roll for their own character only.
+      if (!ctx.seat.characterId) throw new Error('Claim a character first');
+      targets = [ctx.seat.characterId];
+    }
     if (!targets.length) {
-      const mapId = ctx.runtime.campaign.activeMapId;
+      const mapId = cmd.mapId ?? ctx.runtime.campaign.activeMapId;
       const rt = mapId ? ctx.runtime.mapStates.get(mapId) : null;
       targets = rt
         ? [...rt.tokens.values()]
@@ -589,6 +593,67 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         };
       })
       .filter((r) => r !== null);
+    // Hex-targeted search: the roll is compared against the clue gates of
+    // content on that hex. A matching-skill clue opens when the character is
+    // within the gate's range and the roll beats the clue's own DC (active
+    // and passive gates alike — a deliberate search can find what passive
+    // senses missed).
+    let found = 0;
+    if (cmd.hex && cmd.mapId) {
+      const rt = ctx.runtime.mapStates.get(cmd.mapId);
+      const map = ctx.runtime.maps.get(cmd.mapId);
+      if (rt && map) {
+        const created: NewDiscovery[] = [];
+        for (const r of results) {
+          const token = [...rt.tokens.values()].find(
+            (t) => t.kind === 'pc' && t.characterId === r.characterId,
+          );
+          if (!token) continue;
+          const character = ctx.runtime.characters.get(r.characterId)!;
+          for (const content of rt.contents.values()) {
+            if (content.q !== cmd.hex.q || content.r !== cmd.hex.r) continue;
+            const distance = hexDistance({ q: token.q, r: token.r }, cmd.hex);
+            for (const clue of content.clues) {
+              if (clue.gate.kind !== 'skill' || clue.gate.skill !== cmd.skill) continue;
+              if (distance > clue.gate.maxDistance) continue;
+              if (r.total < clue.gate.dc) continue;
+              if (ctx.runtime.hasDiscovery(clue.id, r.characterId)) continue;
+              const direction =
+                clue.indicatesDirection && distance > 0
+                  ? compassDirection({ q: token.q, r: token.r }, cmd.hex, map.orientation)
+                  : null;
+              const discovery = {
+                id: nanoid(12),
+                clueId: clue.id,
+                characterId: r.characterId,
+                at: Date.now(),
+                how: {
+                  kind: 'roll' as const,
+                  skill: cmd.skill,
+                  roll: r.roll,
+                  modifier: r.modifier,
+                  total: r.total,
+                  dc: clue.gate.dc,
+                },
+                direction,
+                locates: distance === 0,
+              };
+              if (ctx.runtime.addDiscovery(discovery)) {
+                created.push({
+                  discovery,
+                  contentId: content.id,
+                  contentTitle: content.title,
+                  clueText: clue.text,
+                  characterName: character.name,
+                });
+              }
+            }
+          }
+        }
+        found = created.length;
+        deliverDiscoveries(ctx, created);
+      }
+    }
     const summary = results
       .map(
         (r) =>
@@ -597,10 +662,12 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
           }`,
       )
       .join(' · ');
+    const where = cmd.hex ? ` on hex ${cmd.hex.q},${cmd.hex.r}` : '';
+    const outcome = cmd.hex ? (found ? ` — ${found} clue(s) uncovered` : ' — nothing new found') : '';
     const entry = ctx.runtime.appendLog(
       'check',
-      `${capitalize(cmd.skill)}${cmd.dc !== null ? ` DC ${cmd.dc}` : ''}: ${summary || 'no targets'}`,
-      'dm',
+      `${capitalize(cmd.skill)}${cmd.dc !== null ? ` DC ${cmd.dc}` : ''}${where}: ${summary || 'no targets'}${outcome}`,
+      ctx.seat.role === 'dm' ? 'dm' : 'all',
       { skill: cmd.skill, dc: cmd.dc, results },
     );
     notifyLog(ctx, entry);
@@ -628,7 +695,11 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
 
   'encounterTable.upsert': ((cmd: Extract<ClientCommand, { kind: 'encounterTable.upsert' }>, ctx: Ctx) => {
     requireDm(ctx);
-    ctx.runtime.upsertEncounterTable({ ...cmd.table, id: cmd.table.id ?? nanoid(10) });
+    ctx.runtime.upsertEncounterTable({
+      ...cmd.table,
+      id: cmd.table.id ?? nanoid(10),
+      enabled: cmd.table.enabled ?? true,
+    });
   }) as Handler,
 
   'encounterTable.delete': ((cmd: Extract<ClientCommand, { kind: 'encounterTable.delete' }>, ctx: Ctx) => {

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -454,6 +454,8 @@ export const EncounterTableSchema = z.object({
   /** Dice rolled against the entries, e.g. "2d6" or "1d12". */
   die: z.string().default('1d12'),
   entries: z.array(EncounterEntrySchema),
+  /** Disabled tables are never picked by terrain matching (session curation). */
+  enabled: z.boolean().default(true),
 });
 export type EncounterTable = z.infer<typeof EncounterTableSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -379,6 +379,14 @@ export const CheckRollCommand = z.object({
   dc: z.number().int().min(1).max(40).nullable().default(null),
   /** Explicit character targets; empty = every character with a token on the active map. */
   characterIds: z.array(z.string()),
+  /**
+   * Search target: roll this check against the clue gates of content on this
+   * hex. Matching skill clues within their gate's range of the character are
+   * revealed when the roll beats the clue's own DC. Players may target their
+   * own character only.
+   */
+  mapId: z.string().nullable().default(null),
+  hex: z.object({ q: z.number().int(), r: z.number().int() }).nullable().default(null),
 });
 
 export const EncounterRollCommand = z.object({

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -121,7 +121,7 @@ function fullState(): CampaignState {
       { id: 'd2', clueId: 'cl3', characterId: 'char2', at: 1001, how: { kind: 'auto' }, direction: null, locates: true },
     ],
     senses: [],
-    encounterTables: [{ id: 'et1', name: 'Forest', terrains: ['forest'], die: '1d12', entries: [] }],
+    encounterTables: [{ id: 'et1', name: 'Forest', terrains: ['forest'], die: '1d12', entries: [], enabled: true }],
     log: [
       { id: 'l1', at: 1, kind: 'roll', text: 'dm secret roll', visibility: 'dm', data: {} },
       { id: 'l2', at: 2, kind: 'narration', text: 'you all see smoke', visibility: 'all', data: {} },


### PR DESCRIPTION
- **Search this hex** (Inspect tab): pick a skill and roll it against the selected hex. The server compares the roll to the clue gates of content on that hex — matching-skill clues within their gate's range of the character open when the roll beats the clue's own DC, including `mode: 'active'` gates that never open passively. Players roll for their own character (check.roll is no longer DM-only; players are locked to their claimed character); the DM's roll covers every PC on the map. Discoveries record `how: 'roll'` with the actual dice; the result toasts to the table and logs, including "nothing new found".
- **Encounter tables can be disabled**: terrain-matched wandering rolls skip disabled tables so only session-relevant tables (e.g. Serpent Hills while tracking Varram) fire; explicitly selected tables still roll. Toggled per row with 🟢/⚪.

Verified live (roll toast, in-range reveal, dedupe on re-roll) plus new server tests for both features. Typecheck clean; 30 shared + 24 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)