### PR TITLE
Issues #37, #39, #40, #41, #42: sync, toasts, explored fix, gated items, quest staging

### DIFF
--- a/packages/client/src/components/ContentDialog.tsx
+++ b/packages/client/src/components/ContentDialog.tsx
@@ -18,6 +18,7 @@ interface ClueDraft {
   text: string;
   gate: Gate;
   indicatesDirection: boolean;
+  revealsLocation: boolean;
 }
 
 /** DM editor for hex content and its gated clues. */
@@ -42,12 +43,15 @@ export function ContentDialog() {
   const [showLabel, setShowLabel] = useState(existing?.showLabel ?? false);
   const [scaleVisibility, setScaleVisibility] = useState(existing?.scaleVisibility ?? 1);
   const [wikiPage, setWikiPage] = useState(existing?.wikiPage ?? '');
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [quest, setQuest] = useState(existing?.quest ?? '');
   const [clues, setClues] = useState<ClueDraft[]>(
     existing?.clues.map((c) => ({
       id: c.id,
       text: c.text,
       gate: c.gate,
       indicatesDirection: c.indicatesDirection,
+      revealsLocation: c.revealsLocation,
     })) ?? [],
   );
 
@@ -74,6 +78,8 @@ export function ContentDialog() {
         showLabel,
         scaleVisibility,
         wikiPage: wikiPage.trim(),
+        enabled,
+        quest: quest.trim(),
         clues: clues
           .filter((c) => c.text.trim())
           .map((c, i) => ({
@@ -82,6 +88,7 @@ export function ContentDialog() {
             gate: c.gate,
             sortOrder: i,
             indicatesDirection: c.indicatesDirection,
+            revealsLocation: c.revealsLocation,
           })),
       },
     });
@@ -119,6 +126,16 @@ export function ContentDialog() {
           <input type="checkbox" checked={showLabel} onChange={(e) => setShowLabel(e.target.checked)} />
           Always show the name on the map (major towns and the like)
         </label>
+        <div className="grid grid-cols-2 gap-2 items-end">
+          <label className="flex items-center gap-2 text-sm text-ink-200 cursor-pointer pb-1.5">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+            Enabled
+            <span className="text-xs text-ink-400">(off = doesn't exist for players yet)</span>
+          </label>
+          <Field label="Quest tag (group for bulk enable/disable)">
+            <Input value={quest} onChange={(e) => setQuest(e.target.value)} placeholder="varram-hunt" maxLength={120} />
+          </Field>
+        </div>
         <div className="grid grid-cols-2 gap-2">
           <Field label="Visible at hex scales">
             <Select
@@ -156,6 +173,7 @@ export function ContentDialog() {
                     text: '',
                     gate: { kind: 'skill', skill: 'perception', dc: 12, maxDistance: 1, mode: 'passive' },
                     indicatesDirection: false,
+                    revealsLocation: true,
                   },
                 ])
               }
@@ -333,6 +351,18 @@ function ClueEditor({
           title='Append the sensed compass bearing when delivered, e.g. "… — to the north-east" (computed from where the character stands toward this hex)'
         >
           🧭 direction
+        </button>
+        <button
+          onClick={() => onChange({ ...clue, revealsLocation: !clue.revealsLocation })}
+          className={cx(
+            'px-2 py-0.5 rounded-full text-[11px] cursor-pointer border',
+            clue.revealsLocation
+              ? 'border-brass-500 bg-brass-500/15 text-brass-300'
+              : 'border-ink-700 text-ink-300 hover:bg-ink-700',
+          )}
+          title="On: discovering this clue on the hex reveals the pin. Off: info-only — the item stays hidden until some location-revealing clue (or check) finds it."
+        >
+          📍 location
         </button>
       </div>
     </div>

--- a/packages/client/src/components/SelectionBar.tsx
+++ b/packages/client/src/components/SelectionBar.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { useSession } from '../stores/session.js';
+import { useUi } from '../stores/ui.js';
+import { send } from '../ws.js';
+
+/**
+ * Floating action bar for box-selected content (Shift+drag with the select
+ * tool): bulk enable/disable and quest tagging.
+ */
+export function SelectionBar() {
+  const selection = useUi((s) => s.contentSelection);
+  const [quest, setQuest] = useState('');
+  const pushToast = useSession((s) => s.pushToast);
+
+  if (!selection || selection.length === 0) return null;
+
+  const clear = () => useUi.getState().set('contentSelection', null);
+  const setEnabled = (enabled: boolean) => {
+    send({ kind: 'content.setEnabled', contentIds: selection, enabled });
+    pushToast({
+      kind: 'info',
+      title: enabled ? 'Enabled' : 'Disabled',
+      text: `${selection.length} item(s) ${enabled ? 'now live for players' : 'hidden from players'}.`,
+    });
+    clear();
+  };
+  const applyQuest = () => {
+    send({ kind: 'content.setQuest', contentIds: selection, quest: quest.trim() });
+    pushToast({
+      kind: 'info',
+      title: 'Quest tagged',
+      text: `${selection.length} item(s) → "${quest.trim() || '(none)'}"`,
+    });
+    clear();
+  };
+
+  return (
+    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-40 bg-ink-900/95 border border-brass-500/50 rounded-lg shadow-xl backdrop-blur px-3 py-2 flex items-center gap-2">
+      <span className="text-sm text-ink-100 font-medium whitespace-nowrap">
+        {selection.length} item{selection.length === 1 ? '' : 's'}
+      </span>
+      <button
+        className="px-2.5 py-1 rounded text-xs cursor-pointer bg-brass-500/20 text-brass-300 border border-brass-500/50"
+        onClick={() => setEnabled(true)}
+      >
+        🟢 Enable
+      </button>
+      <button
+        className="px-2.5 py-1 rounded text-xs cursor-pointer text-ink-200 border border-ink-600 hover:bg-ink-700"
+        onClick={() => setEnabled(false)}
+      >
+        ⚪ Disable
+      </button>
+      <input
+        className="w-32 bg-ink-950 border border-ink-600 rounded px-2 py-1 text-xs text-ink-100"
+        placeholder="Quest tag…"
+        value={quest}
+        maxLength={120}
+        onChange={(e) => setQuest(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && applyQuest()}
+      />
+      <button
+        className="px-2 py-1 rounded text-xs cursor-pointer text-ink-200 border border-ink-600 hover:bg-ink-700"
+        onClick={applyQuest}
+        title="Assign this quest tag to the selection (empty clears the tag)"
+      >
+        Tag
+      </button>
+      <button className="text-ink-400 hover:text-ink-100 cursor-pointer px-1" onClick={clear}>
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/packages/client/src/components/panels/CharactersTab.tsx
+++ b/packages/client/src/components/panels/CharactersTab.tsx
@@ -131,7 +131,7 @@ function NewCharacterForm({ onDone }: { onDone: () => void }) {
     if (!name.trim()) return;
     send({
       kind: 'character.create',
-      character: { name: name.trim(), color, glyph: '', speed: 30, skills: {} },
+      character: { name: name.trim(), color, glyph: '', speed: 30, skills: {}, ddbId: null },
     });
     onDone();
   };
@@ -171,6 +171,62 @@ function NewCharacterForm({ onDone }: { onDone: () => void }) {
   );
 }
 
+/**
+ * One-click skill sync from a PUBLIC D&D Beyond sheet. The URL/id persists on
+ * the character so future syncs are a single click.
+ */
+function DdbSync({ character }: { character: Character }) {
+  const [value, setValue] = useState(character.ddbId ?? '');
+  const [busy, setBusy] = useState(false);
+  const campaignId = useSession((s) => s.state?.campaign.id);
+
+  const sync = async () => {
+    if (!value.trim() || !campaignId || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/campaigns/${campaignId}/characters/${character.id}/sync-ddb`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ddbId: value.trim() }),
+        },
+      );
+      const data = (await res.json()) as { error?: string; name?: string; classes?: string };
+      if (!res.ok) throw new Error(data.error ?? 'Sync failed');
+      useSession.getState().pushToast({
+        kind: 'info',
+        title: 'Synced from D&D Beyond',
+        text: `${data.name} (${data.classes}) — skill modifiers updated.`,
+      });
+    } catch (err) {
+      useSession.getState().pushToast({
+        kind: 'error',
+        title: 'D&D Beyond sync failed',
+        text: err instanceof Error ? err.message : 'Unknown error',
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Field label="D&D Beyond (public sheet URL or id)">
+      <div className="flex gap-1.5">
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="https://www.dndbeyond.com/characters/…"
+          className="!text-xs"
+        />
+        <Button size="sm" onClick={sync} disabled={!value.trim() || busy}>
+          {busy ? '…' : '⟳ Sync'}
+        </Button>
+      </div>
+    </Field>
+  );
+}
+
 function CharacterEditor({ character, readOnly }: { character: Character; readOnly: boolean }) {
   const [customName, setCustomName] = useState('');
   const patch = (p: Partial<Character>) =>
@@ -202,6 +258,7 @@ function CharacterEditor({ character, readOnly }: { character: Character; readOn
           </Field>
         </div>
       )}
+      {!readOnly && <DdbSync character={character} />}
       <div>
         <p className="text-[11px] uppercase tracking-wider text-ink-400 mb-1.5">
           Skill modifiers <span className="normal-case">(passive = 10 + mod)</span>

--- a/packages/client/src/components/panels/MapsTab.tsx
+++ b/packages/client/src/components/panels/MapsTab.tsx
@@ -65,6 +65,7 @@ export function MapsTab({ campaignId }: { campaignId: string }) {
       </Section>
 
       {map ? <MapSettings key={map.id} map={map} campaignId={campaignId} /> : <EmptyNote>Create a map to begin.</EmptyNote>}
+      {map && <QuestsPanel />}
     </div>
   );
 }
@@ -398,5 +399,61 @@ function MiniNum({
         }}
       />
     </label>
+  );
+}
+
+
+/**
+ * Quest staging: distinct quest tags on the viewed map with bulk
+ * enable/disable. Tag content via its dialog, or box-select on the map
+ * (Shift+drag with the select tool).
+ */
+function QuestsPanel() {
+  const state = useSession((s) => s.state);
+  const contents = (state?.mapState?.contents ?? []).filter(
+    (c): c is Extract<typeof c, { quest: string }> => 'quest' in c,
+  );
+  const byQuest = new Map<string, { ids: string[]; enabled: number }>();
+  for (const c of contents) {
+    if (!c.quest) continue;
+    const g = byQuest.get(c.quest) ?? { ids: [], enabled: 0 };
+    g.ids.push(c.id);
+    if (c.enabled) g.enabled++;
+    byQuest.set(c.quest, g);
+  }
+
+  return (
+    <Section title="Quests">
+      {byQuest.size === 0 && (
+        <EmptyNote>
+          Tag content with a quest (in its dialog, or Shift+drag a box on the map) to stage whole
+          quests on and off.
+        </EmptyNote>
+      )}
+      <div className="space-y-1.5">
+        {[...byQuest.entries()].map(([quest, g]) => (
+          <div key={quest} className="flex items-center gap-2 bg-ink-850 border border-ink-700 rounded-md px-2.5 py-1.5">
+            <span className="flex-1 min-w-0 truncate text-sm text-ink-100">
+              {quest}
+              <span className="text-xs text-ink-400 ml-1.5">
+                {g.enabled}/{g.ids.length} live
+              </span>
+            </span>
+            <button
+              className="text-xs px-2 py-0.5 rounded cursor-pointer bg-brass-500/20 text-brass-300 border border-brass-500/50"
+              onClick={() => send({ kind: 'content.setEnabled', contentIds: g.ids, enabled: true })}
+            >
+              Enable all
+            </button>
+            <button
+              className="text-xs px-2 py-0.5 rounded cursor-pointer text-ink-200 border border-ink-600 hover:bg-ink-700"
+              onClick={() => send({ kind: 'content.setEnabled', contentIds: g.ids, enabled: false })}
+            >
+              Disable all
+            </button>
+          </div>
+        ))}
+      </div>
+    </Section>
   );
 }

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -121,6 +121,9 @@ export class CanvasEngine {
     null;
   private drag: { view: TokenView } | null = null;
   private panning = false;
+  /** DM shift+drag rubber band (world coords) for bulk content selection. */
+  private boxSelect: { start: { x: number; y: number }; end: { x: number; y: number } } | null =
+    null;
 
   async init(host: HTMLElement): Promise<void> {
     this.host = host;
@@ -715,6 +718,25 @@ export class CanvasEngine {
       g.stroke({ width: lineW * 1.5, color: 0x8b7fd4, alpha: 0.9 });
     }
 
+    // Shift+drag rubber band for content selection.
+    if (this.boxSelect) {
+      const b = this.boxSelect;
+      g.rect(
+        Math.min(b.start.x, b.end.x),
+        Math.min(b.start.y, b.end.y),
+        Math.abs(b.end.x - b.start.x),
+        Math.abs(b.end.y - b.start.y),
+      );
+      g.fill({ color: 0xd9b44f, alpha: 0.08 });
+      g.rect(
+        Math.min(b.start.x, b.end.x),
+        Math.min(b.start.y, b.end.y),
+        Math.abs(b.end.x - b.start.x),
+        Math.abs(b.end.y - b.start.y),
+      );
+      g.stroke({ width: lineW * 1.5, color: 0xd9b44f, alpha: 0.9 });
+    }
+
     // Trail tool: preview the path being drawn.
     if (ui.tool === 'trail' && ui.trailDraft.length) {
       const pts = ui.trailDraft.map((c) => hexToPixel(this.layout!, c));
@@ -840,6 +862,7 @@ export class CanvasEngine {
             'clues' in content && content.clues.some((cl) => discoveredClues.has(cl.id));
           pin.alpha *= known ? 1 : 0.25;
         }
+        if ('enabled' in content && content.enabled === false) pin.alpha *= 0.3;
         this.pinsC.addChild(pin);
         continue;
       }
@@ -863,6 +886,7 @@ export class CanvasEngine {
           'clues' in content && content.clues.some((cl) => discoveredClues.has(cl.id));
         pin.alpha *= known ? 1 : 0.25;
       }
+      if ('enabled' in content && content.enabled === false) pin.alpha *= 0.3;
       this.pinsC.addChild(pin);
     }
 
@@ -1221,6 +1245,15 @@ export class CanvasEngine {
       if (!hex) return;
       const isDm = this.role === 'dm';
 
+      // DM shift+drag with the select tool: rubber-band content selection.
+      if (isDm && ui.tool === 'select' && e.shiftKey) {
+        const world = this.viewport.toWorld(e.global.x, e.global.y);
+        this.boxSelect = { start: { x: world.x, y: world.y }, end: { x: world.x, y: world.y } };
+        this.viewport.plugins.pause('drag');
+        this.drawHighlight();
+        return;
+      }
+
       // Armed "move content" mode: next click relocates the entry.
       if (ui.movingContentId && isDm) {
         send({ kind: 'content.move', contentId: ui.movingContentId, q: hex.q, r: hex.r });
@@ -1301,6 +1334,11 @@ export class CanvasEngine {
     });
 
     this.viewport.on('pointermove', (e) => {
+      if (this.boxSelect) {
+        const world = this.viewport.toWorld(e.global.x, e.global.y);
+        this.boxSelect.end = { x: world.x, y: world.y };
+        this.drawHighlight();
+      }
       const hex = this.worldHex(e);
       const ui = useUi.getState();
       if (
@@ -1320,9 +1358,30 @@ export class CanvasEngine {
       this.panning = false;
       if (this.stroke) this.endStroke();
       if (this.drag) this.endTokenDrag();
+      if (this.boxSelect) this.endBoxSelect();
     };
     this.viewport.on('pointerup', finish);
     this.viewport.on('pointerupoutside', finish);
+  }
+
+  /** Resolve the rubber band into a bulk content selection. */
+  private endBoxSelect(): void {
+    const box = this.boxSelect;
+    this.boxSelect = null;
+    this.updateDragMode();
+    this.drawHighlight();
+    if (!box || !this.layout) return;
+    const minX = Math.min(box.start.x, box.end.x);
+    const maxX = Math.max(box.start.x, box.end.x);
+    const minY = Math.min(box.start.y, box.end.y);
+    const maxY = Math.max(box.start.y, box.end.y);
+    if (maxX - minX < 4 && maxY - minY < 4) return; // just a shift-click
+    const ids: string[] = [];
+    for (const content of this.lastContents) {
+      const p = hexToPixel(this.layout, { q: content.q, r: content.r });
+      if (p.x >= minX && p.x <= maxX && p.y >= minY && p.y <= maxY) ids.push(content.id);
+    }
+    useUi.getState().set('contentSelection', ids.length ? ids : null);
   }
 
   private beginStroke(mode: 'paint' | 'fog', hex: HexCoord): void {
@@ -1521,7 +1580,8 @@ function contentsEqual(
       c.glyph === o.glyph &&
       c.type === o.type &&
       c.title === o.title &&
-      c.showLabel === o.showLabel
+      c.showLabel === o.showLabel &&
+      ('enabled' in c ? c.enabled : true) === ('enabled' in o ? o.enabled : true)
     );
   });
 }

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -43,6 +43,8 @@ interface UiStore {
   senseHighlight: { clueId: string; cells: HexCoord[] } | null;
   /** DM trail tool: cells of the trail being drawn, in click order. */
   trailDraft: HexCoord[];
+  /** DM box-select: content ids selected for bulk enable/disable/quest. */
+  contentSelection: string[] | null;
   /** Player-chosen map for this session (null = follow the DM default). */
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
@@ -77,6 +79,7 @@ export const useUi = create<UiStore>((set) => ({
   movingTokenId: null,
   senseHighlight: null,
   trailDraft: [],
+  contentSelection: null,
   viewedMapId: null,
   dimUnexplored: false,
   altTeleport: false,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -10,6 +10,7 @@ import { Toasts } from '../components/Toasts.js';
 import { ContentDialog } from '../components/ContentDialog.js';
 import { EmptyMapHint, HexReadout } from '../components/StatusOverlays.js';
 import { PendingMoves } from '../components/PendingMoves.js';
+import { SelectionBar } from '../components/SelectionBar.js';
 
 export function TableView({ campaignId }: { campaignId: string }) {
   const hostRef = useRef<HTMLDivElement>(null);
@@ -49,6 +50,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.set('movingTokenId', null);
         ui.set('senseHighlight', null);
         ui.set('trailDraft', []);
+        ui.set('contentSelection', null);
         return;
       }
       if (useSession.getState().role !== 'dm') return;
@@ -101,6 +103,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         <HexReadout />
         <PendingMoves />
         {role === 'dm' && <Toolbar />}
+        {role === 'dm' && <SelectionBar />}
         {panelOpen && <SidePanel campaignId={campaignId} />}
         {!hasState && (
           <div className="absolute inset-0 flex items-center justify-center bg-ink-950/70 pointer-events-none">

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -91,6 +91,13 @@ function handleMessage(msg: ServerMessage): void {
         session.pushToast({ kind: 'narration', title: 'The DM narrates', text: msg.entry.text });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'check') {
         session.pushToast({ kind: 'info', title: 'Skill check', text: msg.entry.text });
+      } else if (msg.kind === 'log.appended' && msg.entry.kind === 'encounter') {
+        const triggered = msg.entry.data?.triggered !== false;
+        session.pushToast({
+          kind: triggered ? 'discovery' : 'info',
+          title: triggered ? '⚔️ Encounter!' : 'No encounter',
+          text: msg.entry.text,
+        });
       } else if (msg.kind === 'trail.found') {
         const mine = msg.characterId === currentCharacterId();
         const dirs = [

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -222,6 +222,10 @@ function migrate(d: DB): void {
   // pin before the senses rework keep seeing it.
   ensureColumn(d, 'discovery', 'locates', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'enc_table', 'enabled', 'INTEGER NOT NULL DEFAULT 1');
+  ensureColumn(d, 'character', 'ddb_id', 'TEXT');
+  ensureColumn(d, 'clue', 'reveals_location', 'INTEGER NOT NULL DEFAULT 1');
+  ensureColumn(d, 'content', 'enabled', 'INTEGER NOT NULL DEFAULT 1');
+  ensureColumn(d, 'content', 'quest', "TEXT NOT NULL DEFAULT ''");
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/engine/ddb.ts
+++ b/packages/server/src/engine/ddb.ts
@@ -1,0 +1,99 @@
+/**
+ * D&D Beyond character sync: fetch a PUBLIC character sheet's JSON and
+ * compute skill modifiers. Validated against real sheets; known gaps:
+ * half-proficiency (Jack of All Trades), item overrides, custom bonuses.
+ */
+
+const ABILITIES = ['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'];
+
+const SKILLS: Record<string, string> = {
+  acrobatics: 'dexterity',
+  'animal-handling': 'wisdom',
+  arcana: 'intelligence',
+  athletics: 'strength',
+  deception: 'charisma',
+  history: 'intelligence',
+  insight: 'wisdom',
+  intimidation: 'charisma',
+  investigation: 'intelligence',
+  medicine: 'wisdom',
+  nature: 'intelligence',
+  perception: 'wisdom',
+  performance: 'charisma',
+  persuasion: 'charisma',
+  religion: 'intelligence',
+  'sleight-of-hand': 'dexterity',
+  stealth: 'dexterity',
+  survival: 'wisdom',
+};
+
+export interface DdbSync {
+  name: string;
+  level: number;
+  classes: string;
+  skills: Record<string, number>;
+}
+
+/** Accepts a raw id or any dndbeyond.com character URL; null if unparseable. */
+export function parseDdbId(input: string): string | null {
+  const m = input.trim().match(/(?:characters\/)?(\d{4,})/);
+  return m ? m[1]! : null;
+}
+
+export async function fetchDdbCharacter(ddbId: string): Promise<DdbSync> {
+  const res = await fetch(
+    `https://character-service.dndbeyond.com/character/v5/character/${ddbId}`,
+    { headers: { 'User-Agent': 'Mozilla/5.0 (HexCrawl VTT sync)' } },
+  );
+  if (res.status === 403 || res.status === 401) {
+    throw new Error('That D&D Beyond character is private — set its privacy to Public and retry.');
+  }
+  if (!res.ok) throw new Error(`D&D Beyond returned ${res.status} for character ${ddbId}`);
+  const payload = (await res.json()) as { success?: boolean; data?: Record<string, unknown> };
+  const d = payload.data;
+  if (!payload.success || !d) {
+    throw new Error('That D&D Beyond character is private or does not exist.');
+  }
+
+  const classes = (d.classes as { level: number; definition: { name: string } }[]) ?? [];
+  const level = classes.reduce((s, c) => s + c.level, 0) || 1;
+  const prof = Math.ceil(level / 4) + 1;
+
+  const base: Record<string, number> = {};
+  (d.stats as { value: number }[]).forEach((s, i) => {
+    base[ABILITIES[i]!] = s.value;
+  });
+  const allMods = Object.values(
+    (d.modifiers as Record<string, { type: string; subType: string; value: number | null }[]>) ??
+      {},
+  ).flat();
+  for (const m of allMods) {
+    if (!m.subType?.endsWith('-score') || !m.value) continue;
+    const ab = m.subType.replace('-score', '');
+    if (base[ab] === undefined) continue;
+    if (m.type === 'bonus') base[ab] += m.value;
+    if (m.type === 'set' && m.value > base[ab]!) base[ab] = m.value;
+  }
+  const abMod = (v: number) => Math.floor((v - 10) / 2);
+
+  const profs = new Set<string>();
+  const expertise = new Set<string>();
+  for (const m of allMods) {
+    if (m.type === 'proficiency' && SKILLS[m.subType]) profs.add(m.subType);
+    if (m.type === 'expertise' && SKILLS[m.subType]) expertise.add(m.subType);
+  }
+
+  const skills: Record<string, number> = {};
+  for (const [sk, ab] of Object.entries(SKILLS)) {
+    const mod =
+      abMod(base[ab]!) + (expertise.has(sk) ? 2 * prof : profs.has(sk) ? prof : 0);
+    skills[sk.replace(/-/g, ' ')] = Math.max(-10, Math.min(20, mod));
+  }
+
+  return {
+    name: (d.name as string) ?? 'Unknown',
+    level,
+    classes: classes.map((c) => `${c.definition.name} ${c.level}`).join('/'),
+    skills,
+  };
+}

--- a/packages/server/src/engine/knowledge.ts
+++ b/packages/server/src/engine/knowledge.ts
@@ -41,12 +41,16 @@ export function evaluateKnowledge(
     const character = runtime.characters.get(characterId);
     if (!character) continue;
     for (const content of rt.contents.values()) {
+      if (!content.enabled) continue;
       const distance = hexDistance(pos, { q: content.q, r: content.r });
       for (const clue of content.clues) {
         if (runtime.hasDiscovery(clue.id, characterId)) {
           // Reaching the source upgrades an earlier at-a-distance discovery:
-          // the character now knows exactly where it came from.
-          if (distance === 0) runtime.markDiscoveryLocated(clue.id, characterId);
+          // the character now knows exactly where it came from. Info-only
+          // clues never reveal the pin.
+          if (distance === 0 && clue.revealsLocation) {
+            runtime.markDiscoveryLocated(clue.id, characterId);
+          }
           continue;
         }
         const evaluation = gateOpensPassively(clue.gate, character, distance);
@@ -61,6 +65,7 @@ export function evaluateKnowledge(
           distance,
           evaluation.passive,
           direction,
+          clue.revealsLocation,
         );
         if (runtime.addDiscovery(discovery)) {
           results.push({
@@ -84,6 +89,7 @@ function buildDiscovery(
   distance: number,
   passive: number | undefined,
   direction: string | null,
+  revealsLocation: boolean,
 ): Discovery {
   const how: Discovery['how'] =
     gate.kind === 'skill'
@@ -102,6 +108,6 @@ function buildDiscovery(
     at: Date.now(),
     how,
     direction,
-    locates: distance === 0,
+    locates: distance === 0 && revealsLocation,
   };
 }

--- a/packages/server/src/engine/settlements.ts
+++ b/packages/server/src/engine/settlements.ts
@@ -110,6 +110,7 @@ export function generateSettlementClues(
           },
           sortOrder: content.clues.length + i,
           indicatesDirection: true,
+          revealsLocation: true,
         })),
       ],
     };

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -8,6 +8,7 @@ import type { Content, ImageLayer } from '@hexcrawl/shared';
 import { ContentTypeSchema, GateSchema, pixelToHex } from '@hexcrawl/shared';
 import { evaluateKnowledge } from '../engine/knowledge.js';
 import { evaluateTrails } from '../engine/trails.js';
+import { fetchDdbCharacter, parseDdbId } from '../engine/ddb.js';
 import { generateSettlementClues } from '../engine/settlements.js';
 import { MAX_UPLOAD_BYTES, UPLOADS_DIR } from '../config.js';
 import type { Store } from '../state/store.js';
@@ -128,6 +129,33 @@ export function createApp(store: Store, hub: Hub): Hono {
     return c.json({ seatId: seat.id, role: seat.role, name: seat.name, characterId: seat.characterId });
   });
 
+  /**
+   * Sync a character's skills from their PUBLIC D&D Beyond sheet.
+   * DM or the seat that claimed the character.
+   */
+  app.post('/api/campaigns/:id/characters/:charId/sync-ddb', async (c) => {
+    const runtime = store.getCampaign(c.req.param('id'));
+    if (!runtime) return c.json({ error: 'Campaign not found' }, 404);
+    const seat = getSeat(c, runtime);
+    const charId = c.req.param('charId');
+    const character = runtime.characters.get(charId);
+    if (!character) return c.json({ error: 'Character not found' }, 404);
+    if (!seat || (seat.role !== 'dm' && seat.characterId !== charId)) {
+      return c.json({ error: 'Only the DM or the claiming player can sync' }, 403);
+    }
+    const body = (await c.req.json().catch(() => ({}))) as { ddbId?: string };
+    const ddbId = body.ddbId ? parseDdbId(body.ddbId) : character.ddbId;
+    if (!ddbId) return c.json({ error: 'No D&D Beyond character id or URL given' }, 400);
+    try {
+      const sync = await fetchDdbCharacter(ddbId);
+      runtime.upsertCharacter({ ...character, skills: sync.skills, ddbId });
+      hub.scheduleSync(runtime);
+      return c.json({ name: sync.name, classes: sync.classes, level: sync.level, skills: sync.skills });
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : 'Sync failed' }, 502);
+    }
+  });
+
   // -- image upload ----------------------------------------------------------
 
   app.post('/api/campaigns/:id/maps/:mapId/images', async (c) => {
@@ -240,12 +268,15 @@ export function createApp(store: Store, hub: Hub): Hono {
     wikiPage: z.string().max(300).default(''),
     showLabel: z.boolean().default(false),
     scaleVisibility: z.number().int().min(0).max(2).default(1),
+    enabled: z.boolean().default(true),
+    quest: z.string().max(120).default(''),
     clues: z
       .array(
         z.object({
           text: z.string().min(1).max(2000),
           gate: GateSchema.default({ kind: 'auto' }),
           indicatesDirection: z.boolean().default(false),
+          revealsLocation: z.boolean().default(true),
         }),
       )
       .default([]),
@@ -292,6 +323,8 @@ export function createApp(store: Store, hub: Hub): Hono {
       showLabel: input.showLabel,
       scaleVisibility: input.scaleVisibility,
       wikiPage: input.wikiPage || existing?.wikiPage || '',
+      enabled: input.enabled ?? existing?.enabled ?? true,
+      quest: input.quest || existing?.quest || '',
       clues: input.clues.length
         ? input.clues.map((cl, i) => ({
             id: nanoid(10),
@@ -300,6 +333,7 @@ export function createApp(store: Store, hub: Hub): Hono {
             gate: cl.gate,
             sortOrder: i,
             indicatesDirection: cl.indicatesDirection,
+            revealsLocation: cl.revealsLocation,
           }))
         : (existing?.clues ?? []),
     };

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -134,7 +134,7 @@ describe('fog auto-reveal', () => {
 
     dm({ kind: 'map.update', mapId, patch: { fogDecay: true } } as never);
     asSeat(playerSeat, { kind: 'token.move', tokenId, q: 3, r: 0 } as never);
-    expect(rt.fog.get(hexKey(3, 0))).toBe('visible');
+    expect(rt.fog.get(hexKey(3, 0))).toBe('explored'); // standing hex is walked
     expect(rt.fog.get(hexKey(0, 0))).toBe('explored');
 
     // player snapshot: explored hexes visible but npc-free; hidden hexes absent
@@ -272,13 +272,14 @@ describe('seat recovery', () => {
 });
 
 describe('move approval + explored trail', () => {
-  it('trail: traversed path becomes explored, destination visible', () => {
+  it('trail: the whole walked path, destination included, becomes explored', () => {
     const { mapId, tokenId, playerSeat } = setupPartyWithScout();
     asSeat(playerSeat, { kind: 'token.move', tokenId, q: 4, r: 0 } as never);
     const rt = runtime.requireMap(mapId);
     expect(rt.fog.get(hexKey(0, 0))).toBe('explored'); // origin traversed
     expect(rt.fog.get(hexKey(2, 0))).toBe('explored'); // path traversed
-    expect(rt.fog.get(hexKey(4, 0))).toBe('visible'); // standing here
+    expect(rt.fog.get(hexKey(4, 0))).toBe('explored'); // standing here — walked too
+    expect(rt.fog.get(hexKey(5, 0))).toBe('visible'); // sight ring stays visible
   });
 
   it('approval mode: player moves become requests the DM resolves', () => {
@@ -304,7 +305,7 @@ describe('move approval + explored trail', () => {
     dm({ kind: 'move.resolve', tokenId, approve: true } as never);
     expect(runtime.findToken(tokenId)).toMatchObject({ q: 3, r: 0 });
     expect(rt.fog.get(hexKey(1, 0))).toBe('explored');
-    expect(rt.fog.get(hexKey(3, 0))).toBe('visible');
+    expect(rt.fog.get(hexKey(3, 0))).toBe('explored');
     // Players cannot resolve.
     asSeat(playerSeat, { kind: 'move.request', tokenId, q: 5, r: 0 } as never);
     expect(() => asSeat(playerSeat, { kind: 'move.resolve', tokenId, approve: true } as never)).toThrow(/DM/);
@@ -446,7 +447,7 @@ describe('move undo restores fog', () => {
 
     dm({ kind: 'token.move', tokenId, q: 4, r: 0, teleport: false } as never);
     expect(rt.fog.get(hexKey(2, 0))).toBe('explored');
-    expect(rt.fog.get(hexKey(4, 0))).toBe('visible');
+    expect(rt.fog.get(hexKey(4, 0))).toBe('explored');
 
     dm({ kind: 'undo' } as never);
     expect(rt.tokens.get(tokenId)!.q).toBe(0);
@@ -682,5 +683,86 @@ describe('trails', () => {
     const sign = view.mapState!.trailSigns.find((s) => s.q === 2)!;
     expect(sign.forward).toBeNull();
     expect(sign.backward).toBe('north-west');
+  });
+});
+
+describe('skill-gated items (issue #41)', () => {
+  it('a content with no auto clue stays hidden until a check on its hex reveals it', () => {
+    const { mapId, charId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 3, r: 0, type: 'dungeon', title: 'Goblin Cave', dmNotes: '', glyph: '',
+        clues: [
+          { id: null, text: 'Goblin tracks crisscross the area', gate: { kind: 'skill', skill: 'perception', dc: 12, maxDistance: 2, mode: 'passive' }, sortOrder: 0, indicatesDirection: true, revealsLocation: false },
+          { id: null, text: 'A brush-hidden cave mouth in the rocks', gate: { kind: 'skill', skill: 'survival', dc: 2, maxDistance: 0, mode: 'active' }, sortOrder: 1 },
+        ],
+      },
+    } as never);
+
+    const playerView = () => filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+
+    // Approach within perception range: tracks sensed, but no pin.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    expect(playerView().senses.some((s) => s.text.includes('Goblin tracks'))).toBe(true);
+    expect(playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave')).toBeUndefined();
+
+    // Standing ON the hex still reveals nothing — the cave gate is an active check.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 3, r: 0 } as never);
+    expect(playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave')).toBeUndefined();
+
+    // A Survival search on the hex finds the cave and reveals the item.
+    asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 3, r: 0 } } as never);
+    const cave = playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave');
+    expect(cave).toBeDefined();
+  });
+});
+
+describe('content enable/disable + quests (issue #42)', () => {
+  it('disabled content produces no discoveries and no player pin; enabling wakes it', () => {
+    const { mapId, charId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 1, r: 0, type: 'ruin', title: 'Future Ruin', dmNotes: '', glyph: '',
+        enabled: false, quest: 'act2',
+        clues: [{ id: null, text: 'Old stones', gate: { kind: 'auto' }, sortOrder: 0 }],
+      },
+    } as never);
+    const ruin = [...runtime.requireMap(mapId).contents.values()].find((c) => c.title === 'Future Ruin')!;
+
+    // Walk onto it: nothing fires, nothing shows.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    expect(runtime.discoveries.size).toBe(0);
+    const view1 = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(view1.mapState!.contents).toHaveLength(0);
+
+    // Enable while the character stands there: the auto clue fires immediately.
+    dm({ kind: 'content.setEnabled', contentIds: [ruin.id], enabled: true } as never);
+    expect(runtime.discoveries.size).toBe(1);
+    const view2 = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(view2.mapState!.contents.find((c) => c.title === 'Future Ruin')).toBeDefined();
+
+    // Disable again: pin vanishes for players (discovery kept for later).
+    dm({ kind: 'content.setEnabled', contentIds: [ruin.id], enabled: false } as never);
+    const view3 = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(view3.mapState!.contents).toHaveLength(0);
+    expect(runtime.discoveries.size).toBe(1);
+
+    // Undo restores the previous enabled state.
+    dm({ kind: 'undo' } as never);
+    expect(runtime.requireMap(mapId).contents.get(ruin.id)!.enabled).toBe(true);
+
+    // Quest tagging.
+    dm({ kind: 'content.setQuest', contentIds: [ruin.id], quest: 'act3' } as never);
+    expect(runtime.requireMap(mapId).contents.get(ruin.id)!.quest).toBe('act3');
   });
 });

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -134,6 +134,7 @@ export class CampaignRuntime {
         glyph: c.glyph as string,
         speed: c.speed as number,
         skills: SkillsSchema.parse(safeJson(c.skills as string)),
+        ddbId: (c.ddb_id as string | null) ?? null,
       });
     }
     for (const m of d
@@ -295,6 +296,7 @@ export class CampaignRuntime {
         gate: GateSchema.parse(safeJson(cl.gate as string)),
         sortOrder: cl.sort_order as number,
         indicatesDirection: Boolean(cl.indicates_direction),
+        revealsLocation: Boolean(cl.reveals_location ?? 1),
       }));
       rt.contents.set(c.id as string, {
         id: c.id as string,
@@ -308,6 +310,8 @@ export class CampaignRuntime {
         showLabel: Boolean(c.show_label),
         scaleVisibility: (c.scale_visibility as number) ?? 1,
         wikiPage: (c.wiki_page as string) ?? '',
+        enabled: Boolean(c.enabled ?? 1),
+        quest: (c.quest as string) ?? '',
         clues,
       });
     }
@@ -447,8 +451,8 @@ export class CampaignRuntime {
     this.characters.set(character.id, character);
     this.db
       .prepare(
-        `INSERT INTO character (id, campaign_id, name, color, glyph, speed, skills) VALUES (?,?,?,?,?,?,?)
-         ON CONFLICT(id) DO UPDATE SET name=excluded.name, color=excluded.color, glyph=excluded.glyph, speed=excluded.speed, skills=excluded.skills`,
+        `INSERT INTO character (id, campaign_id, name, color, glyph, speed, skills, ddb_id) VALUES (?,?,?,?,?,?,?,?)
+         ON CONFLICT(id) DO UPDATE SET name=excluded.name, color=excluded.color, glyph=excluded.glyph, speed=excluded.speed, skills=excluded.skills, ddb_id=excluded.ddb_id`,
       )
       .run(
         character.id,
@@ -458,6 +462,7 @@ export class CampaignRuntime {
         character.glyph,
         character.speed,
         JSON.stringify(character.skills),
+        character.ddbId,
       );
   }
 
@@ -807,10 +812,10 @@ export class CampaignRuntime {
     const tx = this.db.transaction(() => {
       this.db
         .prepare(
-          `INSERT INTO content (id, map_id, q, r, type, title, dm_notes, glyph, show_label, scale_visibility, wiki_page) VALUES (?,?,?,?,?,?,?,?,?,?,?)
-           ON CONFLICT(id) DO UPDATE SET q=excluded.q, r=excluded.r, type=excluded.type, title=excluded.title, dm_notes=excluded.dm_notes, glyph=excluded.glyph, show_label=excluded.show_label, scale_visibility=excluded.scale_visibility, wiki_page=excluded.wiki_page`,
+          `INSERT INTO content (id, map_id, q, r, type, title, dm_notes, glyph, show_label, scale_visibility, wiki_page, enabled, quest) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+           ON CONFLICT(id) DO UPDATE SET q=excluded.q, r=excluded.r, type=excluded.type, title=excluded.title, dm_notes=excluded.dm_notes, glyph=excluded.glyph, show_label=excluded.show_label, scale_visibility=excluded.scale_visibility, wiki_page=excluded.wiki_page, enabled=excluded.enabled, quest=excluded.quest`,
         )
-        .run(content.id, content.mapId, content.q, content.r, content.type, content.title, content.dmNotes, content.glyph, content.showLabel ? 1 : 0, content.scaleVisibility, content.wikiPage);
+        .run(content.id, content.mapId, content.q, content.r, content.type, content.title, content.dmNotes, content.glyph, content.showLabel ? 1 : 0, content.scaleVisibility, content.wikiPage, content.enabled ? 1 : 0, content.quest);
       const keep = new Set(content.clues.map((c) => c.id));
       if (existing) {
         for (const old of existing.clues) {
@@ -818,8 +823,8 @@ export class CampaignRuntime {
         }
       }
       const put = this.db.prepare(
-        `INSERT INTO clue (id, content_id, text, gate, sort_order, indicates_direction) VALUES (?,?,?,?,?,?)
-         ON CONFLICT(id) DO UPDATE SET text=excluded.text, gate=excluded.gate, sort_order=excluded.sort_order, indicates_direction=excluded.indicates_direction`,
+        `INSERT INTO clue (id, content_id, text, gate, sort_order, indicates_direction, reveals_location) VALUES (?,?,?,?,?,?,?)
+         ON CONFLICT(id) DO UPDATE SET text=excluded.text, gate=excluded.gate, sort_order=excluded.sort_order, indicates_direction=excluded.indicates_direction, reveals_location=excluded.reveals_location`,
       );
       for (const clue of content.clues) {
         put.run(
@@ -829,6 +834,7 @@ export class CampaignRuntime {
           JSON.stringify(clue.gate),
           clue.sortOrder,
           clue.indicatesDirection ? 1 : 0,
+          clue.revealsLocation ? 1 : 0,
         );
       }
     });

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -443,6 +443,8 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       showLabel: cmd.content.showLabel ?? false,
       scaleVisibility: cmd.content.scaleVisibility ?? 1,
       wikiPage: cmd.content.wikiPage ?? '',
+      enabled: cmd.content.enabled ?? true,
+      quest: cmd.content.quest ?? '',
       clues: cmd.content.clues.map((c, i) => ({
         id: c.id ?? nanoid(10),
         contentId: id,
@@ -450,10 +452,57 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         gate: c.gate,
         sortOrder: i,
         indicatesDirection: c.indicatesDirection ?? false,
+        revealsLocation: c.revealsLocation ?? true,
       })),
     };
     ctx.runtime.upsertContent(content);
     deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, content.mapId));
+  }) as Handler,
+
+  'content.setEnabled': ((cmd: Extract<ClientCommand, { kind: 'content.setEnabled' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const prior: { content: Content; enabled: boolean }[] = [];
+    const touchedMaps = new Set<string>();
+    for (const id of cmd.contentIds) {
+      let found: Content | null = null;
+      for (const rt of ctx.runtime.mapStates.values()) {
+        const c = rt.contents.get(id);
+        if (c) { found = c; break; }
+      }
+      if (!found || found.enabled === cmd.enabled) continue;
+      prior.push({ content: found, enabled: found.enabled });
+      ctx.runtime.upsertContent({ ...found, enabled: cmd.enabled });
+      touchedMaps.add(found.mapId);
+    }
+    if (prior.length) {
+      ctx.runtime.pushUndo({
+        at: Date.now(),
+        kind: 'content.setEnabled',
+        description: `${cmd.enabled ? 'disable' : 'enable'} ${prior.length} item(s) again`,
+        run: (runtime) => {
+          for (const p of prior) {
+            const current = runtime.mapStates.get(p.content.mapId)?.contents.get(p.content.id);
+            if (current) runtime.upsertContent({ ...current, enabled: p.enabled });
+          }
+        },
+      });
+      // Newly-enabled content may open clues immediately.
+      if (cmd.enabled) {
+        for (const mapId of touchedMaps) {
+          deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, mapId));
+        }
+      }
+    }
+  }) as Handler,
+
+  'content.setQuest': ((cmd: Extract<ClientCommand, { kind: 'content.setQuest' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    for (const id of cmd.contentIds) {
+      for (const rt of ctx.runtime.mapStates.values()) {
+        const c = rt.contents.get(id);
+        if (c) { ctx.runtime.upsertContent({ ...c, quest: cmd.quest }); break; }
+      }
+    }
   }) as Handler,
 
   'content.move': ((cmd: Extract<ClientCommand, { kind: 'content.move' }>, ctx: Ctx) => {
@@ -554,8 +603,8 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         at: Date.now(),
         how: { kind: 'manual' as const },
         direction: clueDirectionFor(ctx, clue, content, characterId),
-        // A deliberate DM reveal tells the player where it is.
-        locates: true,
+        // A deliberate DM reveal locates unless the clue is info-only.
+        locates: clue.revealsLocation,
       };
       if (ctx.runtime.addDiscovery(discovery)) {
         created.push({
@@ -626,6 +675,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
           if (!token) continue;
           const character = ctx.runtime.characters.get(r.characterId)!;
           for (const content of rt.contents.values()) {
+            if (!content.enabled) continue;
             if (content.q !== cmd.hex.q || content.r !== cmd.hex.r) continue;
             const distance = hexDistance({ q: token.q, r: token.r }, cmd.hex);
             for (const clue of content.clues) {
@@ -651,7 +701,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
                   dc: clue.gate.dc,
                 },
                 direction,
-                locates: distance === 0,
+                locates: distance === 0 && clue.revealsLocation,
               };
               if (ctx.runtime.addDiscovery(discovery)) {
                 created.push({
@@ -884,13 +934,10 @@ function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number, teleport
   const moved = ctx.runtime.updateToken(token.mapId, token.id, { q, r });
   const delta: FogDelta = [];
   if (token.kind === 'pc') {
-    if (!teleport) {
-      // Traversed hexes join the explored trail; the destination itself is
-      // where the party stands, so it becomes (or stays) visible.
-      const path = hexLine(from, { q, r }).filter((c) => !(c.q === q && c.r === r));
-      if (path.length) delta.push(...ctx.runtime.setFog(token.mapId, path, 'explored'));
-    }
-    delta.push(...ctx.runtime.setFog(token.mapId, [{ q, r }], 'visible'));
+    // Every walked hex — the traversed path AND the hex they end on — joins
+    // the explored trail. A teleport marks only the destination.
+    const path = teleport ? [{ q, r }] : hexLine(from, { q, r });
+    delta.push(...ctx.runtime.setFog(token.mapId, path, 'explored'));
   }
   delta.push(...afterPartyMoved(ctx, token.mapId, moved));
   return delta;

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -118,6 +118,8 @@ export const CharacterSchema = z.object({
   glyph: z.string().max(8),
   speed: z.number().int().min(0).max(120).default(30),
   skills: SkillsSchema,
+  /** D&D Beyond character id, for one-click skill sync (public sheets only). */
+  ddbId: z.string().nullable().default(null),
 });
 export type Character = z.infer<typeof CharacterSchema>;
 
@@ -357,6 +359,12 @@ export const ClueSchema = z.object({
    * toward this content's hex) to the delivered text: "… — to the north-east".
    */
   indicatesDirection: z.boolean().default(false),
+  /**
+   * Whether discovering this clue on the hex pins down the content's
+   * location. Info-only clues (tracks, rumors) never reveal the pin, so an
+   * item can stay hidden until a specific check finds it.
+   */
+  revealsLocation: z.boolean().default(true),
 });
 export type Clue = z.infer<typeof ClueSchema>;
 
@@ -373,6 +381,10 @@ export const ContentSchema = z.object({
   showLabel: z.boolean().default(false),
   /** Coarsest hex scale the pin is visible at: 0=fine only, 1=+mid, 2=all. */
   scaleVisibility: z.number().int().min(0).max(2).default(1),
+  /** Disabled content doesn't exist yet for players: no clues, no pin. */
+  enabled: z.boolean().default(true),
+  /** Free-form quest tag for grouping (enable/disable a whole quest). */
+  quest: z.string().max(120).default(''),
   /** Wiki page title (or full URL) players can read for more information. */
   wikiPage: z.string().max(300).default(''),
   clues: z.array(ClueSchema),

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -46,6 +46,7 @@ const CharacterPatchSchema = z
     glyph: z.string().max(8),
     speed: z.number().int().min(0).max(120),
     skills: z.record(z.string(), z.number().int().min(-10).max(20)),
+    ddbId: z.string().nullable(),
   })
   .partial();
 
@@ -316,12 +317,30 @@ export const ContentUpsertCommand = z.object({
     showLabel: z.boolean().default(false),
     scaleVisibility: z.number().int().min(0).max(2).default(1),
     wikiPage: z.string().max(300).default(''),
+    enabled: z.boolean().default(true),
+    quest: z.string().max(120).default(''),
     clues: z.array(
       ClueSchema.omit({ id: true, contentId: true }).extend({
         id: z.string().nullable().default(null),
       }),
     ),
   }),
+});
+
+/** DM: bulk enable/disable content (quest staging). */
+export const ContentSetEnabledCommand = z.object({
+  ...base,
+  kind: z.literal('content.setEnabled'),
+  contentIds: z.array(z.string()).min(1).max(2000),
+  enabled: z.boolean(),
+});
+
+/** DM: bulk-assign a quest tag to content. */
+export const ContentSetQuestCommand = z.object({
+  ...base,
+  kind: z.literal('content.setQuest'),
+  contentIds: z.array(z.string()).min(1).max(2000),
+  quest: z.string().max(120),
 });
 
 /** DM: relocate a content entry to another hex. */
@@ -473,6 +492,8 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   SeatReleaseCharacterCommand,
   SeatDeleteCommand,
   ContentUpsertCommand,
+  ContentSetEnabledCommand,
+  ContentSetQuestCommand,
   ContentMoveCommand,
   ViewMapCommand,
   TrailUpsertCommand,

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -137,7 +137,7 @@ export function contentPlayerView(
   characterId: string | null,
   full: CampaignState,
 ): ContentPlayerView | null {
-  if (!characterId) return null;
+  if (!characterId || !content.enabled) return null;
   const clueIds = new Set(content.clues.map((c) => c.id));
   const mine = full.discoveries.filter(
     (d) => d.characterId === characterId && clueIds.has(d.clueId),
@@ -192,7 +192,7 @@ function computeSenses(full: CampaignState, characterId: string | null): Sense[]
 
   const senses: Sense[] = [];
   for (const content of mapState.contents) {
-    if (!isFullContent(content)) continue;
+    if (!isFullContent(content) || !content.enabled) continue;
     const located = content.clues.some((clue) => {
       const d = mine.get(clue.id);
       return d ? discoveryLocates(d) : false;

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -39,6 +39,7 @@ const scout: Character = {
   glyph: '🏹',
   speed: 30,
   skills: { perception: 4, survival: 2 },
+  ddbId: null,
 };
 
 describe('gates', () => {
@@ -103,15 +104,15 @@ function fullState(): CampaignState {
       ],
       contents: [
         {
-          id: 'ct1', mapId: 'm1', q: 1, r: 0, type: 'lair', title: 'Dragon Lair', dmNotes: 'secret', glyph: '🐉', showLabel: false, scaleVisibility: 1, wikiPage: '',
+          id: 'ct1', mapId: 'm1', q: 1, r: 0, type: 'lair', title: 'Dragon Lair', dmNotes: 'secret', glyph: '🐉', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, quest: '',
           clues: [
-            { id: 'cl1', contentId: 'ct1', text: 'Dead vegetation', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false },
-            { id: 'cl2', contentId: 'ct1', text: 'Acid scars', gate: { kind: 'manual' }, sortOrder: 1, indicatesDirection: false },
+            { id: 'cl1', contentId: 'ct1', text: 'Dead vegetation', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false, revealsLocation: true },
+            { id: 'cl2', contentId: 'ct1', text: 'Acid scars', gate: { kind: 'manual' }, sortOrder: 1, indicatesDirection: false, revealsLocation: true },
           ],
         },
         {
-          id: 'ct2', mapId: 'm1', q: 2, r: 0, type: 'cache', title: 'Buried gold', dmNotes: '', glyph: '', showLabel: false, scaleVisibility: 1, wikiPage: '',
-          clues: [{ id: 'cl3', contentId: 'ct2', text: 'Disturbed earth', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false }],
+          id: 'ct2', mapId: 'm1', q: 2, r: 0, type: 'cache', title: 'Buried gold', dmNotes: '', glyph: '', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, quest: '',
+          clues: [{ id: 'cl3', contentId: 'ct2', text: 'Disturbed earth', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false, revealsLocation: true }],
         },
       ],
       pendingMoves: [],


### PR DESCRIPTION
Issue sweep, simplest to most complex:

- **#40** — the hex a character ends on joins the explored trail; sight-ring cells stay visible-only; content reveal untouched.
- **#39** — encounter rolls toast at the sidebar bottom: '⚔️ Encounter!' with the roll breakdown, or 'No encounter'.
- **#37** — D&D Beyond skill sync on character cards (public sheet URL/id + ⟳ Sync; server-side fetch; persisted ddbId; friendly private-sheet error; DM or claiming player).
- **#41** — clues gain a 📍 **reveals location** flag (default on). Info-only clues (tracks/rumors) never expose the pin; hidden items reveal only via a location-revealing clue opening on the hex (e.g. an active Survival search). Goblin-cave scenario covered by a test.
- **#42** — content **enable/disable + quest tags**: disabled content doesn't exist for players (discoveries kept for re-enable) and renders dimmed for the DM. Shift+drag box-select with a bulk action bar; Quests panel (Maps tab) with enable-all/disable-all; undoable; enabling re-evaluates clues immediately.

Typecheck clean; 30 shared + 28 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)