### PR TITLE
DM pin action popup

### DIFF
--- a/packages/client/src/components/PinActions.tsx
+++ b/packages/client/src/components/PinActions.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { hexKey, isFullContent, CONTENT_TYPE_GLYPHS, type FogState } from '@hexcrawl/shared';
+import { activeMap, useSession } from '../stores/session.js';
+import { useUi } from '../stores/ui.js';
+import { send } from '../ws.js';
+import { cx } from '../ui/kit.js';
+import { wikiHref } from './panels/InspectTab.js';
+
+/**
+ * DM quick actions floating above a clicked pin: enable/disable, fog state,
+ * move, wiki. Tracks the hex as the map pans and zooms.
+ */
+export function PinActions() {
+  const role = useSession((s) => s.role);
+  const state = useSession((s) => s.state);
+  const hex = useUi((s) => s.selectedHex);
+  const pos = useUi((s) => s.pinPopup);
+  const map = activeMap(state);
+
+  if (role !== 'dm' || !hex || !pos || !map || !state?.mapState) return null;
+  const contents = state.mapState.contents
+    .filter(isFullContent)
+    .filter((c) => c.q === hex.q && c.r === hex.r);
+  if (contents.length === 0) return null;
+
+  const key = hexKey(hex.q, hex.r);
+  const fog: FogState = state.mapState.fog.find((f) => hexKey(f.q, f.r) === key)?.state ?? 'hidden';
+  const wikiBase = state.campaign.settings.wikiBaseUrl ?? '';
+
+  return (
+    <div
+      className="absolute z-30 -translate-x-1/2 -translate-y-full flex flex-col items-center gap-1 pointer-events-none"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      {contents.map((c) => (
+        <div
+          key={c.id}
+          className="pointer-events-auto bg-ink-900/95 border border-ink-700 rounded-lg shadow-xl backdrop-blur px-1.5 py-1 flex items-center gap-1"
+        >
+          <span className="text-xs text-ink-300 max-w-28 truncate pl-1" title={c.title}>
+            {c.glyph || CONTENT_TYPE_GLYPHS[c.type]} {c.title}
+          </span>
+          <button
+            className={cx(
+              'px-1.5 py-0.5 rounded text-xs cursor-pointer',
+              c.enabled ? 'text-brass-300 hover:bg-ink-700' : 'text-ink-400 hover:bg-ink-700',
+            )}
+            title={c.enabled ? 'Live for players — click to disable' : 'Disabled — click to enable'}
+            onClick={() =>
+              send({ kind: 'content.setEnabled', contentIds: [c.id], enabled: !c.enabled })
+            }
+          >
+            {c.enabled ? '🟢' : '⚪'}
+          </button>
+          <span className="w-px h-4 bg-ink-700" />
+          {(['visible', 'explored', 'hidden'] as FogState[]).map((s) => (
+            <button
+              key={s}
+              className={cx(
+                'px-1.5 py-0.5 rounded text-[11px] capitalize cursor-pointer',
+                fog === s ? 'bg-brass-500/25 text-brass-300' : 'text-ink-300 hover:bg-ink-700',
+              )}
+              title={`Set this hex's fog to ${s}`}
+              onClick={() => send({ kind: 'fog.set', mapId: map.id, cells: [hex], state: s })}
+            >
+              {s === 'visible' ? '👁' : s === 'explored' ? '🥾' : '🌫'}
+            </button>
+          ))}
+          <span className="w-px h-4 bg-ink-700" />
+          <button
+            className="px-1.5 py-0.5 rounded text-xs cursor-pointer text-ink-300 hover:bg-ink-700"
+            title="Move: click the destination hex"
+            onClick={() => {
+              useUi.getState().set('movingContentId', c.id);
+              useSession.getState().pushToast({
+                kind: 'info',
+                title: `Moving ${c.title}`,
+                text: 'Click the destination hex — Esc cancels.',
+              });
+            }}
+          >
+            🎯
+          </button>
+          {c.wikiPage ? (
+            <a
+              className="px-1.5 py-0.5 rounded text-xs cursor-pointer text-arcane-500 hover:bg-ink-700"
+              href={wikiHref(c.wikiPage, wikiBase)}
+              target="_blank"
+              rel="noreferrer"
+              title={`Open wiki: ${c.wikiPage}`}
+            >
+              📖
+            </a>
+          ) : (
+            <span className="px-1.5 py-0.5 text-xs text-ink-600" title="No wiki page set">
+              📖
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -235,7 +235,7 @@ function MarkerLabel({
   );
 }
 
-function wikiHref(page: string, baseUrl: string): string {
+export function wikiHref(page: string, baseUrl: string): string {
   if (/^https?:\/\//.test(page)) return page;
   return baseUrl + encodeURIComponent(page.replace(/ /g, '_'));
 }

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -193,6 +193,7 @@ export class CanvasEngine {
 
     this.viewport.on('moved', () => {
       this.viewDirty = true;
+      this.updatePinPopupPos();
     });
     this.app.renderer.on('resize', (w: number, h: number) => {
       this.viewport.resize(w, h);
@@ -235,6 +236,9 @@ export class CanvasEngine {
       }
       if (u.senseHighlight !== prev.senseHighlight) {
         this.drawSenseHighlight();
+      }
+      if (u.selectedHex !== prev.selectedHex) {
+        this.updatePinPopupPos();
       }
       if (
         u.tool !== prev.tool ||
@@ -340,6 +344,7 @@ export class CanvasEngine {
     }
 
     this.drawHighlight();
+    this.updatePinPopupPos();
 
     if (layoutChanged && this.lastMapIdForCenter !== map.id) {
       this.lastMapIdForCenter = map.id;
@@ -668,6 +673,19 @@ export class CanvasEngine {
       g.poly(this.polyPoints(center, corners));
     }
     g.stroke({ width: 1.5 / this.viewport.scale.x, color: 0xd9b44f, alpha: 0.55 });
+  }
+
+  /** Keep the DM pin-action popup glued above the selected hex. */
+  private updatePinPopupPos(): void {
+    const ui = useUi.getState();
+    if (this.role !== 'dm' || !this.layout || !ui.selectedHex) {
+      if (ui.pinPopup) ui.set('pinPopup', null);
+      return;
+    }
+    const p = hexToPixel(this.layout, ui.selectedHex);
+    const sp = this.viewport.toScreen(p.x, p.y);
+    const zoom = this.viewport.scale.x;
+    ui.set('pinPopup', { x: sp.x, y: sp.y - this.layout.size * zoom * 0.95 });
   }
 
   private drawHighlight(): void {

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -45,6 +45,8 @@ interface UiStore {
   trailDraft: HexCoord[];
   /** DM box-select: content ids selected for bulk enable/disable/quest. */
   contentSelection: string[] | null;
+  /** Screen position (canvas coords) of the selected hex, for the pin popup. */
+  pinPopup: { x: number; y: number } | null;
   /** Player-chosen map for this session (null = follow the DM default). */
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
@@ -80,6 +82,7 @@ export const useUi = create<UiStore>((set) => ({
   senseHighlight: null,
   trailDraft: [],
   contentSelection: null,
+  pinPopup: null,
   viewedMapId: null,
   dimUnexplored: false,
   altTeleport: false,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -11,6 +11,7 @@ import { ContentDialog } from '../components/ContentDialog.js';
 import { EmptyMapHint, HexReadout } from '../components/StatusOverlays.js';
 import { PendingMoves } from '../components/PendingMoves.js';
 import { SelectionBar } from '../components/SelectionBar.js';
+import { PinActions } from '../components/PinActions.js';
 
 export function TableView({ campaignId }: { campaignId: string }) {
   const hostRef = useRef<HTMLDivElement>(null);
@@ -104,6 +105,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         <PendingMoves />
         {role === 'dm' && <Toolbar />}
         {role === 'dm' && <SelectionBar />}
+        {role === 'dm' && <PinActions />}
         {panelOpen && <SidePanel campaignId={campaignId} />}
         {!hasState && (
           <div className="absolute inset-0 flex items-center justify-center bg-ink-950/70 pointer-events-none">


### PR DESCRIPTION
Clicking a hex with content as the DM now floats a quick-action bar above the pin — glued to the hex through pan and zoom:

- 🟢/⚪ enable/disable the item
- 👁 / 🥾 / 🌫 set the hex's fog (visible / explored / hidden)
- 🎯 move — arms click-to-relocate
- 📖 open the wiki page (dimmed when none is set)

One row per content entry on the hex; Esc or clicking elsewhere dismisses. Verified live: renders on pin click, toggle persists, popup tracks a 100px pan exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)