### PR TITLE
Trail info in Inspect + editable trail gates and nodes (#44)

### DIFF
--- a/packages/client/src/components/Toolbar.tsx
+++ b/packages/client/src/components/Toolbar.tsx
@@ -186,16 +186,42 @@ export function Toolbar() {
  * A saved trail "pushes": each walked cell tells its finder the way onward
  * and back, never the whole route.
  */
+const TRAIL_SKILLS = ['survival', 'nature', 'perception', 'investigation'] as const;
+
 function TrailOptions() {
   const draft = useUi((s) => s.trailDraft);
+  const editingTrailId = useUi((s) => s.editingTrailId);
   const state = useSession((s) => s.state);
   const map = activeMap(state);
   const trails = state?.mapState?.trails ?? [];
   const [name, setName] = useState('');
-  const [mode, setMode] = useState<'auto' | 'survival'>('auto');
+  const [skill, setSkill] = useState<'auto' | (typeof TRAIL_SKILLS)[number]>('auto');
   const [dc, setDc] = useState('12');
 
   if (!map) return null;
+  const editing = editingTrailId ? trails.find((t) => t.id === editingTrailId) : undefined;
+
+  const reset = () => {
+    useUi.getState().set('trailDraft', []);
+    useUi.getState().set('editingTrailId', null);
+    setName('');
+    setSkill('auto');
+    setDc('12');
+  };
+
+  const startEdit = (trailId: string) => {
+    const t = trails.find((x) => x.id === trailId);
+    if (!t) return;
+    useUi.getState().set('editingTrailId', t.id);
+    useUi.getState().set('trailDraft', [...t.cells]);
+    setName(t.name);
+    if (t.gate.kind === 'skill') {
+      setSkill((TRAIL_SKILLS as readonly string[]).includes(t.gate.skill) ? (t.gate.skill as (typeof TRAIL_SKILLS)[number]) : 'survival');
+      setDc(String(t.gate.dc));
+    } else {
+      setSkill('auto');
+    }
+  };
 
   const save = () => {
     if (draft.length < 2 || !name.trim()) return;
@@ -203,30 +229,30 @@ function TrailOptions() {
     send({
       kind: 'trail.upsert',
       trail: {
-        id: null,
+        id: editingTrailId,
         mapId: map.id,
         name: name.trim(),
-        glyph: '👣',
-        dmNotes: '',
+        glyph: editing?.glyph ?? '👣',
+        dmNotes: editing?.dmNotes ?? '',
         gate:
-          mode === 'auto'
+          skill === 'auto'
             ? { kind: 'auto' }
-            : { kind: 'skill', skill: 'survival', dc: dcNum, maxDistance: 0, mode: 'passive' },
+            : { kind: 'skill', skill, dc: dcNum, maxDistance: 0, mode: 'passive' },
         cells: draft,
       },
     });
-    useUi.getState().set('trailDraft', []);
-    setName('');
+    reset();
   };
 
   return (
     <div className="bg-ink-900/95 border border-ink-700 rounded-lg p-2 shadow-xl backdrop-blur w-52 overflow-y-auto space-y-2">
       <p className="text-[10px] uppercase tracking-wider text-ink-400 font-semibold">
-        Trail — {draft.length} cell{draft.length === 1 ? '' : 's'}
+        {editing ? `Editing: ${editing.name}` : 'New trail'} — {draft.length} cell
+        {draft.length === 1 ? '' : 's'}
       </p>
       <p className="text-[11px] text-ink-400">
-        Click hexes in order. Click the last cell again to step back. Walkers learn the direction
-        onward and back — never the whole route.
+        Click hexes in order; click the last cell again to step back. Walkers learn only the
+        direction onward and back.
       </p>
       <input
         className="w-full bg-ink-950 border border-ink-600 rounded px-2 py-1 text-xs text-ink-100"
@@ -237,14 +263,19 @@ function TrailOptions() {
       />
       <div className="flex items-center gap-1.5 text-[11px] text-ink-300">
         <select
-          className="flex-1 bg-ink-950 border border-ink-600 rounded px-1 py-0.5 cursor-pointer"
-          value={mode}
-          onChange={(e) => setMode(e.target.value as 'auto' | 'survival')}
+          className="flex-1 bg-ink-950 border border-ink-600 rounded px-1 py-0.5 cursor-pointer capitalize"
+          value={skill}
+          onChange={(e) => setSkill(e.target.value as typeof skill)}
+          title="How each cell is noticed: obvious (walking on it), or a passive skill DC"
         >
           <option value="auto">Obvious (auto)</option>
-          <option value="survival">Survival check</option>
+          {TRAIL_SKILLS.map((s) => (
+            <option key={s} value={s}>
+              {s} check
+            </option>
+          ))}
         </select>
-        {mode === 'survival' && (
+        {skill !== 'auto' && (
           <input
             type="number"
             min={1}
@@ -252,7 +283,7 @@ function TrailOptions() {
             className="w-12 bg-ink-950 border border-ink-600 rounded px-1 py-0.5"
             value={dc}
             onChange={(e) => setDc(e.target.value)}
-            title="Passive Survival DC to notice each cell"
+            title={`Passive ${skill} DC to notice each cell (searchable via Search this hex too)`}
           />
         )}
       </div>
@@ -262,13 +293,13 @@ function TrailOptions() {
           disabled={draft.length < 2 || !name.trim()}
           onClick={save}
         >
-          Save trail
+          {editing ? 'Save changes' : 'Save trail'}
         </button>
         <button
           className="px-2 py-1 rounded text-xs cursor-pointer text-ink-300 border border-ink-600 hover:bg-ink-700"
-          onClick={() => useUi.getState().set('trailDraft', [])}
+          onClick={reset}
         >
-          Clear
+          {editing ? 'Cancel' : 'Clear'}
         </button>
       </div>
       {trails.length > 0 && (
@@ -277,8 +308,19 @@ function TrailOptions() {
             <div key={t.id} className="flex items-center gap-1.5 text-xs text-ink-200">
               <span className="truncate flex-1">
                 {t.glyph} {t.name}
-                <span className="text-ink-400"> · {t.cells.length}</span>
+                <span className="text-ink-400">
+                  {' '}
+                  · {t.cells.length} ·{' '}
+                  {t.gate.kind === 'skill' ? `${t.gate.skill} ${t.gate.dc}` : 'auto'}
+                </span>
               </span>
+              <button
+                className="text-ink-400 hover:text-brass-300 cursor-pointer"
+                title="Edit this trail: nodes load into the draft; adjust, then Save changes"
+                onClick={() => startEdit(t.id)}
+              >
+                ✎
+              </button>
               <button
                 className="text-ink-400 hover:text-ember-500 cursor-pointer"
                 title="Delete trail"

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -3,6 +3,7 @@ import {
   CONTENT_TYPE_GLYPHS,
   CORE_SKILLS,
   TERRAINS,
+  compassDirection,
   isFullContent,
   describeGate,
   hexKey,
@@ -161,6 +162,8 @@ export function InspectTab() {
         </div>
       </Section>
 
+      <TrailInfo hex={hex} isDm={isDm} />
+
       {(isDm || myCharacterId) && <SearchHex mapId={map.id} hex={hex} isDm={isDm} />}
 
       {!isDm && !myCharacterId && (
@@ -169,6 +172,68 @@ export function InspectTab() {
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * Trail knowledge for the inspected hex. Players see the signs their
+ * character has found (where the tracks lead and came from); the DM sees
+ * every trail crossing the hex with its position along the route.
+ */
+function TrailInfo({ hex, isDm }: { hex: { q: number; r: number }; isDm: boolean }) {
+  const state = useSession((s) => s.state);
+  const map = activeMap(state);
+  if (!state?.mapState || !map) return null;
+
+  if (!isDm) {
+    const signs = state.mapState.trailSigns.filter((s) => s.q === hex.q && s.r === hex.r);
+    if (signs.length === 0) return null;
+    return (
+      <Section title="Tracks">
+        <ul className="space-y-1.5">
+          {signs.map((s, i) => (
+            <li key={i} className="text-sm text-ink-100">
+              {s.glyph}{' '}
+              {s.forward
+                ? <>The trail continues <span className="text-brass-300">to the {s.forward}</span></>
+                : 'The trail ends here'}
+              {s.backward && (
+                <span className="text-ink-400"> · back-trail {s.backward}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </Section>
+    );
+  }
+
+  const crossing = state.mapState.trails
+    .map((t) => ({ trail: t, idx: t.cells.findIndex((c) => c.q === hex.q && c.r === hex.r) }))
+    .filter((x) => x.idx >= 0);
+  if (crossing.length === 0) return null;
+  return (
+    <Section title="Trails here">
+      <ul className="space-y-1.5">
+        {crossing.map(({ trail, idx }) => {
+          const next = trail.cells[idx + 1];
+          const prev = trail.cells[idx - 1];
+          return (
+            <li key={trail.id} className="text-sm text-ink-100">
+              {trail.glyph} <span className="font-medium">{trail.name}</span>
+              <span className="block text-xs text-ink-400">
+                cell {idx + 1}/{trail.cells.length}
+                {next && ` · onward ${compassDirection(hex, next, map.orientation)}`}
+                {prev && ` · back ${compassDirection(hex, prev, map.orientation)}`}
+                {' · '}
+                {trail.gate.kind === 'skill'
+                  ? `${trail.gate.skill} DC ${trail.gate.dc}`
+                  : 'obvious'}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </Section>
   );
 }
 

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -1331,12 +1331,35 @@ export class CanvasEngine {
         case 'trail': {
           if (!isDm) return;
           const draft = useUi.getState().trailDraft;
-          const last = draft[draft.length - 1];
-          // Clicking the last cell again removes it (undo one step).
-          if (last && last.q === hex.q && last.r === hex.r) {
-            useUi.getState().set('trailDraft', draft.slice(0, -1));
-          } else {
+          const idx = draft.findIndex((c) => c.q === hex.q && c.r === hex.r);
+          if (idx >= 0) {
+            // Clicking an existing node removes it (neighbors reconnect).
+            useUi.getState().set('trailDraft', draft.filter((_, i) => i !== idx));
+          } else if (draft.length < 2) {
             useUi.getState().set('trailDraft', [...draft, hex]);
+          } else {
+            // Insert into whichever segment grows the least — so clicking
+            // between two nodes bends that segment, and clicking past the
+            // end extends the trail.
+            let best = draft.length; // append
+            let bestCost = hexDistance(draft[draft.length - 1]!, hex);
+            const prependCost = hexDistance(hex, draft[0]!);
+            if (prependCost < bestCost) {
+              best = 0;
+              bestCost = prependCost;
+            }
+            for (let i = 0; i < draft.length - 1; i++) {
+              const a = draft[i]!;
+              const b = draft[i + 1]!;
+              const cost = hexDistance(a, hex) + hexDistance(hex, b) - hexDistance(a, b);
+              if (cost < bestCost) {
+                best = i + 1;
+                bestCost = cost;
+              }
+            }
+            const next = [...draft];
+            next.splice(best, 0, hex);
+            useUi.getState().set('trailDraft', next);
           }
           this.drawHighlight();
           break;

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -43,6 +43,8 @@ interface UiStore {
   senseHighlight: { clueId: string; cells: HexCoord[] } | null;
   /** DM trail tool: cells of the trail being drawn, in click order. */
   trailDraft: HexCoord[];
+  /** DM trail tool: id of the trail whose nodes are being edited (null = new). */
+  editingTrailId: string | null;
   /** DM box-select: content ids selected for bulk enable/disable/quest. */
   contentSelection: string[] | null;
   /** Screen position (canvas coords) of the selected hex, for the pin popup. */
@@ -81,6 +83,7 @@ export const useUi = create<UiStore>((set) => ({
   movingTokenId: null,
   senseHighlight: null,
   trailDraft: [],
+  editingTrailId: null,
   contentSelection: null,
   pinPopup: null,
   viewedMapId: null,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -51,6 +51,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.set('movingTokenId', null);
         ui.set('senseHighlight', null);
         ui.set('trailDraft', []);
+        ui.set('editingTrailId', null);
         ui.set('contentSelection', null);
         return;
       }


### PR DESCRIPTION
Closes #44.

- **Inspect tab trail section** — players inspecting a hex where their character has found trail signs see where the tracks lead and where they came from; the DM sees every trail crossing the hex with its cell position, both bearings, and the notice gate.
- **Editable gates** — trails can require survival, nature, perception, or investigation (passive DC, also findable via the hex-search roll), or be obvious. Gate and name editable after creation.
- **Editable nodes** — ✎ on a trail loads its path into the trail tool. Click a node to delete it (neighbors reconnect); click a hex to insert it into whichever segment grows the least (bend the middle, extend the ends). Save updates in place.

Verified live: DM inspect section ('cell 2/4 · onward north-east · back north-west · nature DC 13'), edit mode with prefilled gate, mid-path insertion 4→5 cells, cancel/reset. Typecheck clean; 58 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)