### PR TITLE
DM dims hidden items by default; red X on disabled pins (#47)

### DIFF
--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -830,6 +830,19 @@ export class CanvasEngine {
     return pin;
   }
 
+  /** Disabled content: dimmed with a red X — staged, not live for players. */
+  private markDisabled(pin: Container): void {
+    pin.alpha *= 0.45;
+    const x = new Text({
+      text: '❌',
+      style: { fontSize: PIN_BASE_FONT * 0.55 },
+      resolution: 2,
+    });
+    x.anchor.set(0.5);
+    x.position.set(0, 0);
+    pin.addChild(x);
+  }
+
   private drawPins(): void {
     this.pinsC.removeChildren().forEach((c) => c.destroy({ children: true }));
     if (!this.layout) return;
@@ -880,7 +893,7 @@ export class CanvasEngine {
             'clues' in content && content.clues.some((cl) => discoveredClues.has(cl.id));
           pin.alpha *= known ? 1 : 0.25;
         }
-        if ('enabled' in content && content.enabled === false) pin.alpha *= 0.3;
+        if ('enabled' in content && content.enabled === false) this.markDisabled(pin);
         this.pinsC.addChild(pin);
         continue;
       }
@@ -904,7 +917,7 @@ export class CanvasEngine {
           'clues' in content && content.clues.some((cl) => discoveredClues.has(cl.id));
         pin.alpha *= known ? 1 : 0.25;
       }
-      if ('enabled' in content && content.enabled === false) pin.alpha *= 0.3;
+      if ('enabled' in content && content.enabled === false) this.markDisabled(pin);
       this.pinsC.addChild(pin);
     }
 

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -87,7 +87,7 @@ export const useUi = create<UiStore>((set) => ({
   contentSelection: null,
   pinPopup: null,
   viewedMapId: null,
-  dimUnexplored: false,
+  dimUnexplored: true,
   altTeleport: false,
 
   set: (key, value) => set({ [key]: value } as Partial<UiStore>),


### PR DESCRIPTION
Closes #47.

- The DM's 'dim what players can't see' view aid now defaults ON.
- Disabled (staged) content is slightly less dim than before (0.45 vs 0.3 alpha) and carries a red ❌ over the pin so it reads as 'not live' at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)