### PR TITLE
Words instead of icons (#49)

### DIFF
--- a/packages/client/src/components/PinActions.tsx
+++ b/packages/client/src/components/PinActions.tsx
@@ -42,7 +42,7 @@ export function PinActions() {
           </span>
           <button
             className={cx(
-              'px-1.5 py-0.5 rounded text-xs cursor-pointer',
+              'px-1.5 py-0.5 rounded text-[11px] cursor-pointer',
               c.enabled ? 'text-brass-300 hover:bg-ink-700' : 'text-ink-400 hover:bg-ink-700',
             )}
             title={c.enabled ? 'Live for players — click to disable' : 'Disabled — click to enable'}
@@ -50,7 +50,7 @@ export function PinActions() {
               send({ kind: 'content.setEnabled', contentIds: [c.id], enabled: !c.enabled })
             }
           >
-            {c.enabled ? '🟢' : '⚪'}
+            {c.enabled ? 'Disable' : 'Enable'}
           </button>
           <span className="w-px h-4 bg-ink-700" />
           {(['visible', 'explored', 'hidden'] as FogState[]).map((s) => (
@@ -63,12 +63,12 @@ export function PinActions() {
               title={`Set this hex's fog to ${s}`}
               onClick={() => send({ kind: 'fog.set', mapId: map.id, cells: [hex], state: s })}
             >
-              {s === 'visible' ? '👁' : s === 'explored' ? '🥾' : '🌫'}
+              {s}
             </button>
           ))}
           <span className="w-px h-4 bg-ink-700" />
           <button
-            className="px-1.5 py-0.5 rounded text-xs cursor-pointer text-ink-300 hover:bg-ink-700"
+            className="px-1.5 py-0.5 rounded text-[11px] cursor-pointer text-ink-300 hover:bg-ink-700"
             title="Move: click the destination hex"
             onClick={() => {
               useUi.getState().set('movingContentId', c.id);
@@ -79,7 +79,7 @@ export function PinActions() {
               });
             }}
           >
-            🎯
+            Move
           </button>
           {c.wikiPage ? (
             <a
@@ -89,11 +89,11 @@ export function PinActions() {
               rel="noreferrer"
               title={`Open wiki: ${c.wikiPage}`}
             >
-              📖
+              Wiki
             </a>
           ) : (
-            <span className="px-1.5 py-0.5 text-xs text-ink-600" title="No wiki page set">
-              📖
+            <span className="px-1.5 py-0.5 text-[11px] text-ink-600" title="No wiki page set">
+              Wiki
             </span>
           )}
         </div>

--- a/packages/client/src/components/SidePanel.tsx
+++ b/packages/client/src/components/SidePanel.tsx
@@ -46,13 +46,13 @@ export function SidePanel({ campaignId }: { campaignId: string }) {
             onClick={() => setUi('panelTab', t.tab)}
             title={t.name}
             className={cx(
-              'flex-1 min-w-10 py-2.5 text-center text-base transition-colors cursor-pointer border-b-2',
+              'flex-1 px-2 py-2 text-center text-[11px] font-medium transition-colors cursor-pointer border-b-2 whitespace-nowrap',
               active === t.tab
-                ? 'border-brass-500 bg-ink-850'
-                : 'border-transparent hover:bg-ink-850/60 opacity-60 hover:opacity-100',
+                ? 'border-brass-500 bg-ink-850 text-brass-300'
+                : 'border-transparent hover:bg-ink-850/60 text-ink-300 hover:text-ink-100',
             )}
           >
-            {t.icon}
+            {t.name}
           </button>
         ))}
       </nav>

--- a/packages/client/src/components/Toolbar.tsx
+++ b/packages/client/src/components/Toolbar.tsx
@@ -35,13 +35,13 @@ export function Toolbar() {
             onClick={() => ui.setTool(t.tool)}
             title={`${t.name} — ${t.hint}`}
             className={cx(
-              'w-9 h-9 rounded-md flex items-center justify-center text-base transition-colors cursor-pointer',
+              'px-2.5 py-1.5 rounded-md text-left text-xs font-medium transition-colors cursor-pointer whitespace-nowrap',
               ui.tool === t.tool
                 ? 'bg-brass-500/25 ring-1 ring-brass-500 text-brass-300'
                 : 'hover:bg-ink-700 text-ink-300',
             )}
           >
-            {t.icon}
+            {t.name}
           </button>
         ))}
       </div>


### PR DESCRIPTION
Closes #49. The left toolbar tools (with their hotkeys), the right sidebar tabs, and the DM pin popup buttons (Enable/Disable · visible/explored/hidden · Move · Wiki) now use words instead of icon glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)