### PR TITLE
Known-location content: show the pin, keep clues gated

### DIFF
--- a/packages/client/src/components/ContentDialog.tsx
+++ b/packages/client/src/components/ContentDialog.tsx
@@ -44,6 +44,7 @@ export function ContentDialog() {
   const [scaleVisibility, setScaleVisibility] = useState(existing?.scaleVisibility ?? 1);
   const [wikiPage, setWikiPage] = useState(existing?.wikiPage ?? '');
   const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [knownLocation, setKnownLocation] = useState(existing?.knownLocation ?? false);
   const [quest, setQuest] = useState(existing?.quest ?? '');
   const [clues, setClues] = useState<ClueDraft[]>(
     existing?.clues.map((c) => ({
@@ -79,6 +80,7 @@ export function ContentDialog() {
         scaleVisibility,
         wikiPage: wikiPage.trim(),
         enabled,
+        knownLocation,
         quest: quest.trim(),
         clues: clues
           .filter((c) => c.text.trim())
@@ -125,6 +127,15 @@ export function ContentDialog() {
         <label className="flex items-center gap-2 text-sm text-ink-200 cursor-pointer">
           <input type="checkbox" checked={showLabel} onChange={(e) => setShowLabel(e.target.checked)} />
           Always show the name on the map (major towns and the like)
+        </label>
+        <label className="flex items-center gap-2 text-sm text-ink-200 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={knownLocation}
+            onChange={(e) => setKnownLocation(e.target.checked)}
+          />
+          Location known to players
+          <span className="text-xs text-ink-400">(pin always shown; clues stay gated)</span>
         </label>
         <div className="grid grid-cols-2 gap-2 items-end">
           <label className="flex items-center gap-2 text-sm text-ink-200 cursor-pointer pb-1.5">

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -226,6 +226,7 @@ function migrate(d: DB): void {
   ensureColumn(d, 'clue', 'reveals_location', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'content', 'enabled', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'content', 'quest', "TEXT NOT NULL DEFAULT ''");
+  ensureColumn(d, 'content', 'known_location', 'INTEGER NOT NULL DEFAULT 0');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -269,6 +269,7 @@ export function createApp(store: Store, hub: Hub): Hono {
     showLabel: z.boolean().default(false),
     scaleVisibility: z.number().int().min(0).max(2).default(1),
     enabled: z.boolean().default(true),
+    knownLocation: z.boolean().default(false),
     quest: z.string().max(120).default(''),
     clues: z
       .array(
@@ -324,6 +325,7 @@ export function createApp(store: Store, hub: Hub): Hono {
       scaleVisibility: input.scaleVisibility,
       wikiPage: input.wikiPage || existing?.wikiPage || '',
       enabled: input.enabled ?? existing?.enabled ?? true,
+      knownLocation: input.knownLocation ?? existing?.knownLocation ?? false,
       quest: input.quest || existing?.quest || '',
       clues: input.clues.length
         ? input.clues.map((cl, i) => ({

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -766,3 +766,36 @@ describe('content enable/disable + quests (issue #42)', () => {
     expect(runtime.requireMap(mapId).contents.get(ruin.id)!.quest).toBe('act3');
   });
 });
+
+describe('known-location content', () => {
+  it('players see the pin with no clues; clues still gate normally', () => {
+    const { mapId, charId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 6, r: 0, type: 'landmark', title: 'Famous Bridge', dmNotes: '', glyph: '',
+        knownLocation: true,
+        clues: [
+          { id: null, text: 'A secret smugglers cache under the third arch', gate: { kind: 'manual' }, sortOrder: 0 },
+        ],
+      },
+    } as never);
+
+    const view = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    const bridge = view.mapState!.contents.find((c) => c.title === 'Famous Bridge')!;
+    expect(bridge).toBeDefined();
+    expect((bridge as { discoveredClues: unknown[] }).discoveredClues).toHaveLength(0);
+
+    // Revealing the clue adds its text to the already-visible pin.
+    const clueId = [...runtime.requireMap(mapId).contents.values()]
+      .find((c) => c.title === 'Famous Bridge')!.clues[0]!.id;
+    dm({ kind: 'clue.reveal', clueId, characterIds: [charId] } as never);
+    const after = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    const bridgeAfter = after.mapState!.contents.find((c) => c.title === 'Famous Bridge')!;
+    expect((bridgeAfter as { discoveredClues: { text: string }[] }).discoveredClues[0]!.text).toContain('smugglers');
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -311,6 +311,7 @@ export class CampaignRuntime {
         scaleVisibility: (c.scale_visibility as number) ?? 1,
         wikiPage: (c.wiki_page as string) ?? '',
         enabled: Boolean(c.enabled ?? 1),
+        knownLocation: Boolean(c.known_location),
         quest: (c.quest as string) ?? '',
         clues,
       });
@@ -812,10 +813,10 @@ export class CampaignRuntime {
     const tx = this.db.transaction(() => {
       this.db
         .prepare(
-          `INSERT INTO content (id, map_id, q, r, type, title, dm_notes, glyph, show_label, scale_visibility, wiki_page, enabled, quest) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON CONFLICT(id) DO UPDATE SET q=excluded.q, r=excluded.r, type=excluded.type, title=excluded.title, dm_notes=excluded.dm_notes, glyph=excluded.glyph, show_label=excluded.show_label, scale_visibility=excluded.scale_visibility, wiki_page=excluded.wiki_page, enabled=excluded.enabled, quest=excluded.quest`,
+          `INSERT INTO content (id, map_id, q, r, type, title, dm_notes, glyph, show_label, scale_visibility, wiki_page, enabled, quest, known_location) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+           ON CONFLICT(id) DO UPDATE SET q=excluded.q, r=excluded.r, type=excluded.type, title=excluded.title, dm_notes=excluded.dm_notes, glyph=excluded.glyph, show_label=excluded.show_label, scale_visibility=excluded.scale_visibility, wiki_page=excluded.wiki_page, enabled=excluded.enabled, quest=excluded.quest, known_location=excluded.known_location`,
         )
-        .run(content.id, content.mapId, content.q, content.r, content.type, content.title, content.dmNotes, content.glyph, content.showLabel ? 1 : 0, content.scaleVisibility, content.wikiPage, content.enabled ? 1 : 0, content.quest);
+        .run(content.id, content.mapId, content.q, content.r, content.type, content.title, content.dmNotes, content.glyph, content.showLabel ? 1 : 0, content.scaleVisibility, content.wikiPage, content.enabled ? 1 : 0, content.quest, content.knownLocation ? 1 : 0);
       const keep = new Set(content.clues.map((c) => c.id));
       if (existing) {
         for (const old of existing.clues) {

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -444,6 +444,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       scaleVisibility: cmd.content.scaleVisibility ?? 1,
       wikiPage: cmd.content.wikiPage ?? '',
       enabled: cmd.content.enabled ?? true,
+      knownLocation: cmd.content.knownLocation ?? false,
       quest: cmd.content.quest ?? '',
       clues: cmd.content.clues.map((c, i) => ({
         id: c.id ?? nanoid(10),

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -383,6 +383,12 @@ export const ContentSchema = z.object({
   scaleVisibility: z.number().int().min(0).max(2).default(1),
   /** Disabled content doesn't exist yet for players: no clues, no pin. */
   enabled: z.boolean().default(true),
+  /**
+   * Common knowledge: players always see this pin (name and place), even
+   * with no discoveries. Clues stay gated — they know WHERE it is, not
+   * what's true about it.
+   */
+  knownLocation: z.boolean().default(false),
   /** Free-form quest tag for grouping (enable/disable a whole quest). */
   quest: z.string().max(120).default(''),
   /** Wiki page title (or full URL) players can read for more information. */

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -318,6 +318,7 @@ export const ContentUpsertCommand = z.object({
     scaleVisibility: z.number().int().min(0).max(2).default(1),
     wikiPage: z.string().max(300).default(''),
     enabled: z.boolean().default(true),
+    knownLocation: z.boolean().default(false),
     quest: z.string().max(120).default(''),
     clues: z.array(
       ClueSchema.omit({ id: true, contentId: true }).extend({

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -142,7 +142,9 @@ export function contentPlayerView(
   const mine = full.discoveries.filter(
     (d) => d.characterId === characterId && clueIds.has(d.clueId),
   );
-  if (!mine.some(discoveryLocates)) return null;
+  // Common-knowledge places show their pin with whatever clues (possibly
+  // none) the character has actually learned.
+  if (!content.knownLocation && !mine.some(discoveryLocates)) return null;
   const clueText = new Map(content.clues.map((c) => [c.id, c.text]));
   return {
     id: content.id,
@@ -193,10 +195,12 @@ function computeSenses(full: CampaignState, characterId: string | null): Sense[]
   const senses: Sense[] = [];
   for (const content of mapState.contents) {
     if (!isFullContent(content) || !content.enabled) continue;
-    const located = content.clues.some((clue) => {
-      const d = mine.get(clue.id);
-      return d ? discoveryLocates(d) : false;
-    });
+    const located =
+      content.knownLocation ||
+      content.clues.some((clue) => {
+        const d = mine.get(clue.id);
+        return d ? discoveryLocates(d) : false;
+      });
     for (const clue of content.clues) {
       const d = mine.get(clue.id);
       if (!d) continue;

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -104,14 +104,14 @@ function fullState(): CampaignState {
       ],
       contents: [
         {
-          id: 'ct1', mapId: 'm1', q: 1, r: 0, type: 'lair', title: 'Dragon Lair', dmNotes: 'secret', glyph: '🐉', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, quest: '',
+          id: 'ct1', mapId: 'm1', q: 1, r: 0, type: 'lair', title: 'Dragon Lair', dmNotes: 'secret', glyph: '🐉', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, knownLocation: false, quest: '',
           clues: [
             { id: 'cl1', contentId: 'ct1', text: 'Dead vegetation', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false, revealsLocation: true },
             { id: 'cl2', contentId: 'ct1', text: 'Acid scars', gate: { kind: 'manual' }, sortOrder: 1, indicatesDirection: false, revealsLocation: true },
           ],
         },
         {
-          id: 'ct2', mapId: 'm1', q: 2, r: 0, type: 'cache', title: 'Buried gold', dmNotes: '', glyph: '', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, quest: '',
+          id: 'ct2', mapId: 'm1', q: 2, r: 0, type: 'cache', title: 'Buried gold', dmNotes: '', glyph: '', showLabel: false, scaleVisibility: 1, wikiPage: '', enabled: true, knownLocation: false, quest: '',
           clues: [{ id: 'cl3', contentId: 'ct2', text: 'Disturbed earth', gate: { kind: 'auto' }, sortOrder: 0, indicatesDirection: false, revealsLocation: true }],
         },
       ],


### PR DESCRIPTION
Content gains a **Location known to players** checkbox: the pin (name + place) always shows on player maps, while clues keep their normal gates — the party knows *where* it is, not what's true about it. Exposed in the content dialog and the integration API. Test covers: pin visible with zero discovered clues, then a DM clue reveal adds text to the already-visible pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)