### PR TITLE
Pin popup: Show players toggle

### DIFF
--- a/packages/client/src/components/PinActions.tsx
+++ b/packages/client/src/components/PinActions.tsx
@@ -52,6 +52,48 @@ export function PinActions() {
           >
             {c.enabled ? 'Disable' : 'Enable'}
           </button>
+          <button
+            className={cx(
+              'px-1.5 py-0.5 rounded text-[11px] cursor-pointer whitespace-nowrap',
+              c.knownLocation ? 'bg-brass-500/25 text-brass-300' : 'text-ink-300 hover:bg-ink-700',
+            )}
+            title={
+              c.knownLocation
+                ? 'Players see this pin (location is common knowledge) — click to make it discovery-gated again'
+                : 'Show the pin to players: they learn WHERE it is, but clues stay gated'
+            }
+            onClick={() =>
+              send({
+                kind: 'content.upsert',
+                content: {
+                  id: c.id,
+                  mapId: c.mapId,
+                  q: c.q,
+                  r: c.r,
+                  type: c.type,
+                  title: c.title,
+                  dmNotes: c.dmNotes,
+                  glyph: c.glyph,
+                  showLabel: c.showLabel,
+                  scaleVisibility: c.scaleVisibility,
+                  wikiPage: c.wikiPage,
+                  enabled: c.enabled,
+                  knownLocation: !c.knownLocation,
+                  quest: c.quest,
+                  clues: c.clues.map((cl) => ({
+                    id: cl.id,
+                    text: cl.text,
+                    gate: cl.gate,
+                    sortOrder: cl.sortOrder,
+                    indicatesDirection: cl.indicatesDirection,
+                    revealsLocation: cl.revealsLocation,
+                  })),
+                },
+              })
+            }
+          >
+            {c.knownLocation ? 'Known ✓' : 'Show players'}
+          </button>
           <span className="w-px h-4 bg-ink-700" />
           {(['visible', 'explored', 'hidden'] as FogState[]).map((s) => (
             <button

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -1635,7 +1635,9 @@ function contentsEqual(
       c.type === o.type &&
       c.title === o.title &&
       c.showLabel === o.showLabel &&
-      ('enabled' in c ? c.enabled : true) === ('enabled' in o ? o.enabled : true)
+      ('enabled' in c ? c.enabled : true) === ('enabled' in o ? o.enabled : true) &&
+      ('knownLocation' in c ? c.knownLocation : false) ===
+        ('knownLocation' in o ? o.knownLocation : false)
     );
   });
 }


### PR DESCRIPTION
Adds a **Show players / Known ✓** button to the DM pin action popup, toggling the item's known-location flag in place: players see the pin (they learn *where* it is) while clues keep their gates. Verified live: toggle round-trips and the button reflects state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)