### PR TITLE
Game log, clue sharing, auto encounters, prep mode, and UI issues #52/#53

### DIFF
--- a/packages/client/src/components/SidePanel.tsx
+++ b/packages/client/src/components/SidePanel.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { useSession } from '../stores/session.js';
-import { useUi, type PanelTab } from '../stores/ui.js';
+import {
+  PANEL_WIDTH_MAX,
+  PANEL_WIDTH_MIN,
+  persistPanelWidth,
+  useUi,
+  type PanelTab,
+} from '../stores/ui.js';
 import { cx } from '../ui/kit.js';
 import { InspectTab } from './panels/InspectTab.js';
 import { MapsTab } from './panels/MapsTab.js';
@@ -33,13 +39,55 @@ const PLAYER_TABS: { tab: PanelTab; icon: string; name: string }[] = [
 export function SidePanel({ campaignId }: { campaignId: string }) {
   const role = useSession((s) => s.role);
   const tab = useUi((s) => s.panelTab);
+  const width = useUi((s) => s.panelWidth);
   const setUi = useUi((s) => s.set);
   const tabs = role === 'dm' ? DM_TABS : PLAYER_TABS;
   const active = tabs.some((t) => t.tab === tab) ? tab : 'inspect';
+  // When the panel is too narrow for one row of tabs, wrap into two rows
+  // instead of scrolling horizontally.
+  const twoRows = width < tabs.length * 64;
+
+  const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = useUi.getState().panelWidth;
+    const onMove = (ev: PointerEvent) => {
+      const next = Math.min(
+        PANEL_WIDTH_MAX,
+        Math.max(PANEL_WIDTH_MIN, startWidth + (startX - ev.clientX)),
+      );
+      useUi.getState().set('panelWidth', next);
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      persistPanelWidth(useUi.getState().panelWidth);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
 
   return (
-    <aside className="w-80 shrink-0 bg-ink-900 border-l border-ink-700 flex flex-col z-20">
-      <nav className="flex border-b border-ink-700 shrink-0 overflow-x-auto">
+    <aside
+      style={{ width }}
+      className="relative shrink-0 bg-ink-900 border-l border-ink-700 flex flex-col z-20"
+    >
+      <div
+        onPointerDown={startResize}
+        className="absolute left-0 top-0 bottom-0 w-1.5 -translate-x-0.5 cursor-col-resize z-30 hover:bg-brass-500/40 active:bg-brass-500/60"
+        title="Drag to resize the panel"
+      />
+      <nav
+        className={cx(
+          'border-b border-ink-700 shrink-0',
+          twoRows ? 'grid' : 'flex overflow-x-auto',
+        )}
+        style={
+          twoRows
+            ? { gridTemplateColumns: `repeat(${Math.ceil(tabs.length / 2)}, minmax(0, 1fr))` }
+            : undefined
+        }
+      >
         {tabs.map((t) => (
           <button
             key={t.tab}

--- a/packages/client/src/components/TopBar.tsx
+++ b/packages/client/src/components/TopBar.tsx
@@ -59,12 +59,34 @@ function DimToggle() {
   );
 }
 
+/** DM prep mode: pause/resume live map updates for players. */
+function PauseSyncToggle() {
+  const paused = useSession((s) => s.state?.campaign.settings.pausePlayerMapSync ?? false);
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => send({ kind: 'campaign.update', settings: { pausePlayerMapSync: !paused } })}
+      className={paused ? '!text-ember-500' : ''}
+      title={
+        paused
+          ? 'Prep mode: players see the map as it was when you paused — click to push your edits live'
+          : 'Players see map edits live — click to pause updates while you prep'
+      }
+    >
+      {paused ? '▶' : '⏸'}
+    </Button>
+  );
+}
+
 export function TopBar({
   campaignId: _campaignId,
   onRecenter,
+  onGoToMe,
 }: {
   campaignId: string;
   onRecenter: () => void;
+  onGoToMe: () => void;
 }) {
   const state = useSession((s) => s.state);
   const role = useSession((s) => s.role);
@@ -147,6 +169,17 @@ export function TopBar({
         </Button>
       )}
       {role === 'dm' && <DimToggle />}
+      {role === 'dm' && <PauseSyncToggle />}
+      {role === 'player' && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onGoToMe}
+          title="Go to me — center the view on your token"
+        >
+          🎯 Me
+        </Button>
+      )}
       <Button variant="ghost" size="sm" onClick={onRecenter} title="Re-center map">
         ⌖
       </Button>

--- a/packages/client/src/components/panels/EncountersTab.tsx
+++ b/packages/client/src/components/panels/EncountersTab.tsx
@@ -103,6 +103,32 @@ function RollPanel({ mapId }: { mapId: string }) {
           />
         </Field>
       </div>
+      <div className="mt-2">
+        <Field label="Auto-check every N hexes of travel (0 = off)">
+          <Input
+            type="number"
+            min={0}
+            max={99}
+            defaultValue={map.encounterCheck.autoEvery}
+            key={map.encounterCheck.autoEvery}
+            onBlur={(e) => {
+              const v = Math.round(Number(e.target.value));
+              if (Number.isFinite(v) && v >= 0 && v <= 99 && v !== map.encounterCheck.autoEvery) {
+                send({ kind: 'map.update', mapId, patch: { encounterCheck: { autoEvery: v } } });
+              }
+            }}
+          />
+        </Field>
+        {map.encounterCheck.autoEvery > 0 && (
+          <p className="text-[11px] text-ink-400 mt-1">
+            Rolling automatically as the party travels — every{' '}
+            {map.encounterCheck.autoEvery === 1
+              ? 'hex'
+              : `${map.encounterCheck.autoEvery} hexes`}
+            . Results land in the DM log.
+          </p>
+        )}
+      </div>
     </Section>
   );
 }

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -428,8 +428,15 @@ function PlayerContentCard({ content }: { content: ContentPlayerView }) {
       </div>
       <ul className="mt-1.5 space-y-1">
         {content.discoveredClues.map((c) => (
-          <li key={c.clueId} className="text-xs text-ink-200">
-            {c.text}
+          <li key={c.clueId} className="text-xs text-ink-200 flex items-start gap-2">
+            <span className="flex-1">{c.text}</span>
+            <button
+              className="shrink-0 text-[10px] text-brass-400 hover:text-brass-300 cursor-pointer"
+              title="Tell the party — everyone learns this clue"
+              onClick={() => send({ kind: 'clue.share', clueId: c.clueId })}
+            >
+              🤝 Share
+            </button>
           </li>
         ))}
       </ul>

--- a/packages/client/src/components/panels/LogTab.tsx
+++ b/packages/client/src/components/panels/LogTab.tsx
@@ -8,9 +8,10 @@ const KIND_META: Record<string, { icon: string; label: string }> = {
   check: { icon: '🎯', label: 'Check' },
   encounter: { icon: '🎲', label: 'Encounter' },
   narration: { icon: '📜', label: 'Narration' },
+  share: { icon: '🤝', label: 'Shared' },
 };
 
-const FILTERS = ['all', 'discovery', 'check', 'encounter', 'narration'] as const;
+const FILTERS = ['all', 'discovery', 'check', 'encounter', 'narration', 'share'] as const;
 
 export function LogTab() {
   const state = useSession((s) => s.state);

--- a/packages/client/src/components/panels/SensesTab.tsx
+++ b/packages/client/src/components/panels/SensesTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Sense } from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { useUi } from '../../stores/ui.js';
+import { send } from '../../ws.js';
 import { EmptyNote, Section, cx } from '../../ui/kit.js';
 
 /**
@@ -81,6 +82,17 @@ function SenseRow({ sense }: { sense: Sense }) {
           'Observed earlier'
         )}
         {highlighted && ' · highlighted on map'}
+        <span
+          role="button"
+          className="float-right text-brass-400 hover:text-brass-300"
+          title="Tell the party — everyone learns this clue"
+          onClick={(e) => {
+            e.stopPropagation();
+            send({ kind: 'clue.share', clueId: sense.clueId });
+          }}
+        >
+          🤝 Share
+        </span>
       </span>
     </button>
   );

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -1565,7 +1565,34 @@ export class CanvasEngine {
     if (teleport) {
       useSession.getState().pushToast({ kind: 'info', title: 'Teleported', text: `${token.label || 'Token'} moved without leaving a trail.` });
     }
+    // Landing selects the destination, so the inspect tab shows the new hex.
+    if (token.kind === 'pc') useUi.getState().selectHex(dropHex);
     return 'moved';
+  }
+
+  /** Center and zoom the view on the viewer's own PC token ("Go to me"). */
+  centerOnMyToken(): void {
+    if (!this.layout) return;
+    const view = [...this.tokens.values()].find(
+      (v) =>
+        v.token.kind === 'pc' &&
+        v.token.characterId !== null &&
+        v.token.characterId === this.myCharacterId,
+    );
+    if (!view) {
+      useSession.getState().pushToast({
+        kind: 'info',
+        title: 'No token',
+        text: 'Your character has no token on this map.',
+      });
+      return;
+    }
+    const p = hexToPixel(this.layout, view.token);
+    // Zoom so one hex reads comfortably regardless of the map's hex size.
+    const scale = Math.min(Math.max(120 / (this.layout.size * 2), 0.3), 3);
+    this.viewport.setZoom(scale, true);
+    this.viewport.moveCenter(p.x, p.y);
+    this.viewDirty = true;
   }
 
   // -- ticker ----------------------------------------------------------------

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -28,6 +28,8 @@ interface UiStore {
   editingContentId: string | null;
   panelTab: PanelTab;
   panelOpen: boolean;
+  /** Right sidebar width in px (drag the left edge to resize). */
+  panelWidth: number;
   measureStart: HexCoord | null;
   /** Held spacebar: pan with left-drag regardless of the active tool. */
   spacePan: boolean;
@@ -61,6 +63,30 @@ interface UiStore {
   selectHex(hex: HexCoord | null): void;
 }
 
+export const PANEL_WIDTH_MIN = 240;
+export const PANEL_WIDTH_MAX = 640;
+const PANEL_WIDTH_KEY = 'hexcrawl.panelWidth';
+
+function initialPanelWidth(): number {
+  try {
+    const stored = Number(localStorage.getItem(PANEL_WIDTH_KEY));
+    if (Number.isFinite(stored) && stored >= PANEL_WIDTH_MIN && stored <= PANEL_WIDTH_MAX) {
+      return stored;
+    }
+  } catch {
+    // Storage unavailable (private mode etc.) — fall through to the default.
+  }
+  return 320;
+}
+
+export function persistPanelWidth(width: number): void {
+  try {
+    localStorage.setItem(PANEL_WIDTH_KEY, String(Math.round(width)));
+  } catch {
+    // Best-effort convenience only.
+  }
+}
+
 export const useUi = create<UiStore>((set) => ({
   tool: 'select',
   paintTerrain: 'plains',
@@ -75,6 +101,7 @@ export const useUi = create<UiStore>((set) => ({
   editingContentId: null,
   panelTab: 'inspect',
   panelOpen: true,
+  panelWidth: initialPanelWidth(),
   measureStart: null,
   spacePan: false,
   scaleLock: 'auto',

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -98,7 +98,11 @@ export function TableView({ campaignId }: { campaignId: string }) {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <TopBar campaignId={campaignId} onRecenter={() => engineRef.current?.recenter()} />
+      <TopBar
+        campaignId={campaignId}
+        onRecenter={() => engineRef.current?.recenter()}
+        onGoToMe={() => engineRef.current?.centerOnMyToken()}
+      />
       <div className="flex-1 flex min-h-0 relative">
         <div ref={hostRef} className="canvas-host flex-1 min-w-0 relative" />
         <EmptyMapHint />

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -89,6 +89,8 @@ function handleMessage(msg: ServerMessage): void {
         });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'narration') {
         session.pushToast({ kind: 'narration', title: 'The DM narrates', text: msg.entry.text });
+      } else if (msg.kind === 'log.appended' && msg.entry.kind === 'share') {
+        session.pushToast({ kind: 'discovery', title: 'Clue shared', text: msg.entry.text });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'check') {
         session.pushToast({ kind: 'info', title: 'Skill check', text: msg.entry.text });
       } else if (msg.kind === 'log.appended' && msg.entry.kind === 'encounter') {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -799,3 +799,169 @@ describe('known-location content', () => {
     expect((bridgeAfter as { discoveredClues: { text: string }[] }).discoveredClues[0]!.text).toContain('smugglers');
   });
 });
+
+describe('clue sharing', () => {
+  function setupSharedClue() {
+    const { mapId, charId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'character.create',
+      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {} },
+    } as never);
+    const bardId = [...runtime.characters.keys()].find((id) => id !== charId)!;
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 3, r: 0, type: 'ruin', title: 'Old Ruin', dmNotes: '', glyph: '',
+        clues: [{ id: null, text: 'Crumbled stones whisper', gate: { kind: 'auto' }, sortOrder: 0 }],
+      },
+    } as never);
+    // Walking onto the hex opens the auto gate for the scout only.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 3, r: 0 } as never);
+    const clueId = [...runtime.requireMap(mapId).contents.values()][0]!.clues[0]!.id;
+    return { charId, bardId, clueId, playerSeat };
+  }
+
+  it('a player shares a discovered clue with every other character', () => {
+    const { charId, bardId, clueId, playerSeat } = setupSharedClue();
+    expect(runtime.hasDiscovery(clueId, charId)).toBe(true);
+    expect(runtime.hasDiscovery(clueId, bardId)).toBe(false);
+
+    asSeat(playerSeat, { kind: 'clue.share', clueId } as never);
+    expect(runtime.hasDiscovery(clueId, bardId)).toBe(true);
+    const bardDisc = [...runtime.discoveries.values()].find((d) => d.characterId === bardId)!;
+    expect(bardDisc.how).toEqual({ kind: 'shared', fromCharacterId: charId });
+    expect(bardDisc.locates).toBe(true); // sharer had located it
+
+    const entry = runtime.log[runtime.log.length - 1]!;
+    expect(entry.kind).toBe('share');
+    expect(entry.visibility).toBe('all');
+    expect(entry.text).toContain('Scout shared with the party');
+  });
+
+  it('cannot share a clue the character has not discovered', () => {
+    const { mapId } = setupPartyWithScout();
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 9, r: 9, type: 'ruin', title: 'Far Ruin', dmNotes: '', glyph: '',
+        clues: [{ id: null, text: 'Unknown secret', gate: { kind: 'manual' }, sortOrder: 0 }],
+      },
+    } as never);
+    const clueId = [...runtime.requireMap(mapId).contents.values()][0]!.clues[0]!.id;
+    const playerSeat = [...runtime.seats.values()].find((s) => s.role === 'player')!;
+    expect(() => asSeat(playerSeat, { kind: 'clue.share', clueId } as never)).toThrow(/discovered/);
+  });
+});
+
+describe('per-character log filtering', () => {
+  it("a player's roll entries reach only seats owning a rolling character", () => {
+    const { mapId, charId, playerSeat } = setupPartyWithScout();
+    // Second player with their own character.
+    dm({
+      kind: 'character.create',
+      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {} },
+    } as never);
+    const bardId = [...runtime.characters.keys()].find((id) => id !== charId)!;
+    const bardSeat = runtime.createSeat('player', 'Bob');
+    asSeat(bardSeat, { kind: 'seat.claimCharacter', characterId: bardId } as never);
+    bardSeat.characterId = bardId;
+
+    asSeat(playerSeat, {
+      kind: 'check.roll', skill: 'perception', dc: null, characterIds: [], mapId, hex: { q: 0, r: 0 },
+    } as never);
+    const entry = runtime.log[runtime.log.length - 1]!;
+    expect(entry.kind).toBe('check');
+    expect(entry.visibility).toBe('all');
+
+    const scoutView = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(scoutView.log.some((e) => e.id === entry.id)).toBe(true);
+
+    const bardView = filterStateForViewer(runtime.buildFullState(), {
+      seatId: bardSeat.id, role: 'player', characterId: bardId,
+    });
+    expect(bardView.log.some((e) => e.id === entry.id)).toBe(false);
+
+    // Narration to all still reaches everyone.
+    dm({ kind: 'narrate', text: 'The wind howls.', seatIds: [] } as never);
+    const narration = runtime.log[runtime.log.length - 1]!;
+    const bardView2 = filterStateForViewer(runtime.buildFullState(), {
+      seatId: bardSeat.id, role: 'player', characterId: bardId,
+    });
+    expect(bardView2.log.some((e) => e.id === narration.id)).toBe(true);
+  });
+});
+
+describe('auto encounter checks (every N hexes)', () => {
+  it('rolls once per N hexes travelled, carries the counter, skips teleports', () => {
+    const { mapId, tokenId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'map.update', mapId, patch: { encounterCheck: { autoEvery: 2 } } } as never);
+
+    const countEncounters = () => runtime.log.filter((e) => e.kind === 'encounter').length;
+    expect(countEncounters()).toBe(0);
+
+    // 5 hexes of travel with autoEvery=2 → checks at steps 2 and 4, counter 1.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 5, r: 0 } as never);
+    expect(countEncounters()).toBe(2);
+    expect(runtime.maps.get(mapId)!.encounterCheck.hexesSinceCheck).toBe(1);
+
+    // One more hex completes the next window.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 6, r: 0 } as never);
+    expect(countEncounters()).toBe(3);
+    expect(runtime.maps.get(mapId)!.encounterCheck.hexesSinceCheck).toBe(0);
+
+    // DM teleport does not count as travel.
+    dm({ kind: 'token.move', tokenId, q: 20, r: 0, teleport: true } as never);
+    expect(countEncounters()).toBe(3);
+
+    // All auto entries are DM-only.
+    expect(runtime.log.filter((e) => e.kind === 'encounter').every((e) => e.visibility === 'dm')).toBe(true);
+  });
+
+  it('does nothing when autoEvery is 0', () => {
+    const { tokenId, playerSeat } = setupPartyWithScout();
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 8, r: 0 } as never);
+    expect(runtime.log.filter((e) => e.kind === 'encounter')).toHaveLength(0);
+  });
+});
+
+describe('prep mode (pause player map sync)', () => {
+  it('freezes editable layers for players until the pause is lifted', () => {
+    const { mapId, charId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'terrain.paint', mapId, cells: [{ q: 0, r: 0 }], terrain: 'forest' } as never);
+
+    dm({ kind: 'campaign.update', settings: { pausePlayerMapSync: true } } as never);
+    dm({ kind: 'terrain.paint', mapId, cells: [{ q: 1, r: 0 }], terrain: 'swamp' } as never);
+    dm({
+      kind: 'marker.place',
+      marker: { mapId, q: 0, r: 0, glyph: '⭐', label: 'New', dmOnly: false },
+    } as never);
+
+    const playerFull = runtime.applyPlayerFreeze(runtime.buildFullState());
+    const playerView = filterStateForViewer(playerFull, {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    // Pre-pause terrain visible; paused-in edits are not.
+    expect(playerView.mapState!.hexes.some((h) => h.q === 0 && h.terrain === 'forest')).toBe(true);
+    expect(playerView.mapState!.hexes.some((h) => h.q === 1 && h.terrain === 'swamp')).toBe(false);
+    expect(playerView.mapState!.markers).toHaveLength(0);
+
+    // The DM keeps seeing live state.
+    const dmView = filterStateForViewer(runtime.buildFullState(), {
+      seatId: dmSeat.id, role: 'dm', characterId: null,
+    });
+    expect(dmView.mapState!.hexes.some((h) => h.q === 1 && h.terrain === 'swamp')).toBe(true);
+
+    // Tokens stay live during the pause.
+    const rtTokens = [...runtime.requireMap(mapId).tokens.values()];
+    expect(playerFull.mapState!.tokens).toHaveLength(rtTokens.length);
+
+    dm({ kind: 'campaign.update', settings: { pausePlayerMapSync: false } } as never);
+    const resumed = filterStateForViewer(runtime.applyPlayerFreeze(runtime.buildFullState()), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(resumed.mapState!.hexes.some((h) => h.q === 1 && h.terrain === 'swamp')).toBe(true);
+    expect(resumed.mapState!.markers).toHaveLength(1);
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -56,6 +56,15 @@ export interface MapRuntime {
 const LOG_MEMORY_LIMIT = 500;
 const UNDO_STACK_LIMIT = 100;
 
+/** The DM-editable map layers held stable for players during prep mode. */
+interface FrozenMapLayers {
+  imageLayers: ImageLayer[];
+  hexes: HexCell[];
+  markers: Marker[];
+  contents: Content[];
+  trails: Trail[];
+}
+
 /** One undoable change. Held in memory only (drops on server restart). */
 export interface UndoEntry {
   at: number;
@@ -91,6 +100,12 @@ export class CampaignRuntime {
   online = new Set<string>();
   /** DM undo history (in-memory; newest last). */
   undoStack: UndoEntry[] = [];
+  /**
+   * Prep mode (settings.pausePlayerMapSync): per-map snapshot of the editable
+   * layers as players last saw them. In-memory; recaptured at boot when the
+   * pause survived a restart.
+   */
+  private frozenPlayerMaps = new Map<string, FrozenMapLayers>();
 
   constructor(
     private db: DB,
@@ -106,6 +121,7 @@ export class CampaignRuntime {
       settings: CampaignSettingsSchema.parse(safeJson(row.settings)),
     };
     this.load();
+    if (this.campaign.settings.pausePlayerMapSync) this.capturePlayerFreeze();
   }
 
   // -- loading ---------------------------------------------------------------
@@ -386,6 +402,53 @@ export class CampaignRuntime {
       senses: [],
       encounterTables: [...this.encounterTables.values()],
       log: this.log,
+    };
+  }
+
+  // -- prep-mode freeze ------------------------------------------------------
+
+  /** Snapshot every map's editable layers as the player-visible baseline. */
+  capturePlayerFreeze(): void {
+    this.frozenPlayerMaps.clear();
+    for (const mapId of this.maps.keys()) {
+      const ms = this.mapState(mapId);
+      if (!ms) continue;
+      this.frozenPlayerMaps.set(mapId, {
+        imageLayers: ms.imageLayers,
+        hexes: ms.hexes,
+        markers: ms.markers,
+        contents: ms.contents as Content[],
+        trails: ms.trails,
+      });
+    }
+  }
+
+  clearPlayerFreeze(): void {
+    this.frozenPlayerMaps.clear();
+  }
+
+  /**
+   * While prep mode is on, substitute the frozen editable layers into a
+   * player's full state. Tokens, fog, pending moves, discoveries and the log
+   * stay live; terrain, markers, content, images and trails hold at the
+   * pause-time snapshot.
+   */
+  applyPlayerFreeze(full: CampaignState): CampaignState {
+    if (!this.campaign.settings.pausePlayerMapSync) return full;
+    const mapId = full.campaign.activeMapId;
+    if (!mapId || !full.mapState) return full;
+    const frozen = this.frozenPlayerMaps.get(mapId);
+    if (!frozen) return full;
+    return {
+      ...full,
+      mapState: {
+        ...full.mapState,
+        imageLayers: frozen.imageLayers,
+        hexes: frozen.hexes,
+        markers: frozen.markers,
+        contents: frozen.contents,
+        trails: frozen.trails,
+      },
     };
   }
 

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -153,7 +153,13 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
   // -- campaign --------------------------------------------------------------
   'campaign.update': ((cmd: Extract<ClientCommand, { kind: 'campaign.update' }>, ctx: Ctx) => {
     requireDm(ctx);
+    const wasPaused = ctx.runtime.campaign.settings.pausePlayerMapSync;
     ctx.runtime.updateCampaign({ name: cmd.name, settings: cmd.settings });
+    const nowPaused = ctx.runtime.campaign.settings.pausePlayerMapSync;
+    // Entering prep mode freezes what players currently see; leaving it
+    // releases the snapshot so the next sync shows everything at once.
+    if (nowPaused && !wasPaused) ctx.runtime.capturePlayerFreeze();
+    if (!nowPaused && wasPaused) ctx.runtime.clearPlayerFreeze();
   }) as Handler,
 
   // -- maps ------------------------------------------------------------------
@@ -275,7 +281,9 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     const label = token.label || 'token';
     const fromQ = token.q;
     const fromR = token.r;
-    const fogDelta = executePartyMove(ctx, token, cmd.q, cmd.r, cmd.teleport && ctx.seat.role === 'dm');
+    const teleport = cmd.teleport && ctx.seat.role === 'dm';
+    const fogDelta = executePartyMove(ctx, token, cmd.q, cmd.r, teleport);
+    autoEncounterChecks(ctx, map, token, { q: fromQ, r: fromR }, { q: cmd.q, r: cmd.r }, teleport);
     if (ctx.seat.role === 'dm') {
       ctx.runtime.pushUndo({
         at: Date.now(),
@@ -329,7 +337,12 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     rt.pendingMoves.delete(cmd.tokenId);
     if (cmd.approve) {
       const prior = partyMembers(ctx, token).map((m) => ({ id: m.id, q: m.q, r: m.r }));
+      const from = { q: token.q, r: token.r };
       const fogDelta = executePartyMove(ctx, token, pending.toQ, pending.toR, cmd.teleport);
+      const map = ctx.runtime.maps.get(token.mapId);
+      if (map) {
+        autoEncounterChecks(ctx, map, token, from, { q: pending.toQ, r: pending.toR }, cmd.teleport);
+      }
       ctx.runtime.pushUndo({
         at: Date.now(),
         kind: 'token.move',
@@ -625,6 +638,41 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     ctx.runtime.revokeDiscovery(cmd.discoveryId);
   }) as Handler,
 
+  'clue.share': ((cmd: Extract<ClientCommand, { kind: 'clue.share' }>, ctx: Ctx) => {
+    const characterId = ctx.seat.characterId;
+    if (!characterId) throw new Error('Claim a character first');
+    const content = ctx.runtime.findContentByClue(cmd.clueId);
+    if (!content) throw new Error('Clue not found');
+    const clue = content.clues.find((c) => c.id === cmd.clueId)!;
+    const mine = [...ctx.runtime.discoveries.values()].find(
+      (d) => d.clueId === cmd.clueId && d.characterId === characterId,
+    );
+    if (!mine) throw new Error('You can only share clues your character has discovered');
+    const sharer = ctx.runtime.characters.get(characterId);
+    let shared = 0;
+    for (const other of ctx.runtime.characters.values()) {
+      if (other.id === characterId) continue;
+      const added = ctx.runtime.addDiscovery({
+        id: nanoid(12),
+        clueId: cmd.clueId,
+        characterId: other.id,
+        at: Date.now(),
+        how: { kind: 'shared', fromCharacterId: characterId },
+        // Passing on the knowledge passes on what the sharer knew of it.
+        direction: mine.direction,
+        locates: mine.locates,
+      });
+      if (added) shared++;
+    }
+    const entry = ctx.runtime.appendLog(
+      'share',
+      `${sharer?.name ?? 'Someone'} shared with the party: ${clue.text}`,
+      'all',
+      { clueId: cmd.clueId, contentId: content.id, fromCharacterId: characterId, newlyShared: shared },
+    );
+    notifyLog(ctx, entry);
+  }) as Handler,
+
   // -- checks ----------------------------------------------------------------
   'check.roll': ((cmd: Extract<ClientCommand, { kind: 'check.roll' }>, ctx: Ctx) => {
     let targets = cmd.characterIds;
@@ -775,7 +823,21 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       ctx.seat.role === 'dm' ? 'dm' : 'all',
       { skill: cmd.skill, dc: cmd.dc, results },
     );
-    notifyLog(ctx, entry);
+    if (entry.visibility === 'all') {
+      // A character's rolls are theirs alone: notify only the seats owning a
+      // character that rolled (the snapshot filter applies the same rule).
+      const rolled = new Set(results.map((r) => r.characterId));
+      const ownerSeats = [...ctx.runtime.seats.values()]
+        .filter((s) => s.characterId && rolled.has(s.characterId))
+        .map((s) => s.id);
+      ctx.hub.sendTo(
+        ctx.runtime,
+        { type: 'event', kind: 'log.appended', entry },
+        { dm: true, seatIds: ownerSeats },
+      );
+    } else {
+      notifyLog(ctx, entry);
+    }
   }) as Handler,
 
   // -- encounters ------------------------------------------------------------
@@ -942,6 +1004,60 @@ function executeTokenMove(ctx: Ctx, token: Token, q: number, r: number, teleport
   }
   delta.push(...afterPartyMoved(ctx, token.mapId, moved));
   return delta;
+}
+
+/**
+ * Auto wandering-encounter checks: when the map's encounterCheck.autoEvery is
+ * set, every N hexes of PC travel rolls the trigger die. The counter carries
+ * across moves (persisted in the map's encounterCheck config) and a long drag
+ * can roll more than once, at the hexes actually crossed. Teleports don't
+ * count as travel.
+ */
+function autoEncounterChecks(
+  ctx: Ctx,
+  map: MapInfo,
+  token: Token,
+  from: { q: number; r: number },
+  to: { q: number; r: number },
+  teleport: boolean,
+): void {
+  if (teleport || token.kind !== 'pc') return;
+  const every = map.encounterCheck.autoEvery;
+  if (!every) return;
+  const steps = hexLine(from, to).slice(1);
+  if (!steps.length) return;
+  let count = map.encounterCheck.hexesSinceCheck;
+  for (const hex of steps) {
+    count += 1;
+    if (count < every) continue;
+    count = 0;
+    const result = rollEncounter(
+      ctx.runtime,
+      { mapId: map.id, q: hex.q, r: hex.r, tableId: null, skipCheck: false },
+      ctx.rng,
+    );
+    const entry = ctx.runtime.appendLog(
+      'encounter',
+      `Auto check at hex ${hex.q},${hex.r} — ${result.summary}`,
+      'dm',
+      {
+        triggered: result.triggered,
+        terrain: result.terrain,
+        tableId: result.table?.id ?? null,
+        entryText: result.entryText,
+        checkRoll: result.checkRoll as unknown as Record<string, unknown> | null,
+        tableRoll: result.tableRoll as unknown as Record<string, unknown> | null,
+        quantityRoll: result.quantityRoll as unknown as Record<string, unknown> | null,
+        auto: true,
+        q: hex.q,
+        r: hex.r,
+      },
+    );
+    notifyLog(ctx, entry);
+  }
+  ctx.runtime.updateMap(map.id, {
+    encounterCheck: { hexesSinceCheck: count },
+  } as unknown as Partial<MapInfo>);
 }
 
 function capitalize(s: string): string {

--- a/packages/server/src/ws/hub.ts
+++ b/packages/server/src/ws/hub.ts
@@ -51,7 +51,8 @@ export class Hub {
   }
 
   sendSnapshot(conn: Conn): void {
-    const full = conn.runtime.buildFullState(conn.viewedMapId);
+    let full = conn.runtime.buildFullState(conn.viewedMapId);
+    if (conn.seat.role !== 'dm') full = conn.runtime.applyPlayerFreeze(full);
     const state = filterStateForViewer(full, this.viewerFor(conn.seat));
     this.send(conn, { type: 'snapshot', seatId: conn.seat.id, role: conn.seat.role, state });
   }
@@ -113,7 +114,8 @@ export class Hub {
             full = runtime.buildFullState(conn.viewedMapId);
             fullByMap.set(key, full);
           }
-          const state = filterStateForViewer(full, this.viewerFor(conn.seat));
+          const base = conn.seat.role === 'dm' ? full : runtime.applyPlayerFreeze(full);
+          const state = filterStateForViewer(base, this.viewerFor(conn.seat));
           this.send(conn, { type: 'snapshot', seatId: conn.seat.id, role: conn.seat.role, state });
         }
       }, SYNC_COALESCE_MS),

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -87,6 +87,13 @@ export const CampaignSettingsSchema = z.object({
   description: z.string().max(2000).default(''),
   /** Base URL for wiki links on content (page titles are appended). */
   wikiBaseUrl: z.string().max(300).default('https://wiki.deeznuts.wiki/index.php/'),
+  /**
+   * Prep mode: while true, players keep seeing the map layers (terrain,
+   * markers, content, images, trails) as they were when the pause began;
+   * DM edits stay invisible until the pause is lifted. Tokens, fog and the
+   * log stay live throughout.
+   */
+  pausePlayerMapSync: z.boolean().default(false),
 });
 export type CampaignSettings = z.infer<typeof CampaignSettingsSchema>;
 
@@ -143,6 +150,10 @@ export const EncounterCheckConfigSchema = z.object({
   die: z.string().default('1d20'),
   /** An encounter occurs when the roll is >= this threshold. */
   threshold: z.number().int().default(18),
+  /** Auto-roll a check every N hexes of party travel (0 = off). */
+  autoEvery: z.number().int().min(0).max(99).default(0),
+  /** Server-managed: hexes travelled since the last auto check. */
+  hexesSinceCheck: z.number().int().min(0).default(0),
 });
 export type EncounterCheckConfig = z.infer<typeof EncounterCheckConfigSchema>;
 
@@ -415,6 +426,8 @@ export const DiscoveryHowSchema = z.discriminatedUnion('kind', [
     dc: z.number(),
   }),
   z.object({ kind: z.literal('manual') }),
+  /** Another character shared what they knew. */
+  z.object({ kind: z.literal('shared'), fromCharacterId: z.string() }),
 ]);
 export type DiscoveryHow = z.infer<typeof DiscoveryHowSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -32,11 +32,19 @@ const GridStylePatchSchema = z
   .partial();
 
 const EncounterCheckPatchSchema = z
-  .object({ die: z.string(), threshold: z.number().int() })
+  .object({
+    die: z.string(),
+    threshold: z.number().int(),
+    autoEvery: z.number().int().min(0).max(99),
+  })
   .partial();
 
 const CampaignSettingsPatchSchema = z
-  .object({ description: z.string().max(2000), wikiBaseUrl: z.string().max(300) })
+  .object({
+    description: z.string().max(2000),
+    wikiBaseUrl: z.string().max(300),
+    pausePlayerMapSync: z.boolean(),
+  })
   .partial();
 
 const CharacterPatchSchema = z
@@ -406,6 +414,13 @@ export const DiscoveryRevokeCommand = z.object({
   discoveryId: z.string(),
 });
 
+/** Player: share a clue their character discovered with the whole party. */
+export const ClueShareCommand = z.object({
+  ...base,
+  kind: z.literal('clue.share'),
+  clueId: z.string(),
+});
+
 // --- checks, encounters, narration ------------------------------------------
 
 export const CheckRollCommand = z.object({
@@ -503,6 +518,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   ContentDeleteCommand,
   ClueRevealCommand,
   DiscoveryRevokeCommand,
+  ClueShareCommand,
   CheckRollCommand,
   EncounterRollCommand,
   EncounterTableUpsertCommand,

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -4,6 +4,7 @@ import type {
   ContentPlayerView,
   Discovery,
   FogState,
+  LogEntry,
   SeatRole,
   Sense,
   Token,
@@ -68,8 +69,30 @@ export function filterStateForViewer(full: CampaignState, viewer: Viewer): Campa
       : [],
     senses: computeSenses(full, viewer.characterId),
     encounterTables: [],
-    log: full.log.filter((e) => e.visibility === 'all' || e.visibility === viewer.seatId),
+    log: full.log.filter((e) => logEntryVisibleToPlayer(e, viewer)),
   };
+}
+
+/**
+ * A player's log shows their own character's actions, not the whole party's:
+ * 'all'-visibility roll entries reach only viewers whose character rolled.
+ * Other 'all' entries (narration, shares) reach everyone.
+ */
+export function logEntryVisibleToPlayer(e: LogEntry, viewer: Viewer): boolean {
+  if (e.visibility === viewer.seatId) return true;
+  if (e.visibility !== 'all') return false;
+  if (e.kind === 'check') {
+    const results = (e.data as { results?: unknown }).results;
+    if (Array.isArray(results)) {
+      return (
+        viewer.characterId !== null &&
+        results.some(
+          (r) => (r as { characterId?: string } | null)?.characterId === viewer.characterId,
+        )
+      );
+    }
+  }
+  return true;
 }
 
 /**

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -70,7 +70,7 @@ describe('gates', () => {
 
 function fullState(): CampaignState {
   return {
-    campaign: { id: 'c1', name: 'Test', activeMapId: 'm1', settings: { description: '', wikiBaseUrl: 'https://wiki.example/wiki/' } },
+    campaign: { id: 'c1', name: 'Test', activeMapId: 'm1', settings: { description: '', wikiBaseUrl: 'https://wiki.example/wiki/', pausePlayerMapSync: false } },
     seats: [
       { id: 'dm', role: 'dm', name: 'DM', characterId: null, online: true },
       { id: 's1', role: 'player', name: 'Alice', characterId: 'char1', online: true },


### PR DESCRIPTION
## Features

- **Per-character log**: a player's log now shows only their own character's actions. Roll entries with `visibility: all` reach only seats owning a character that rolled (enforced in `filterStateForViewer`, the security boundary, plus matching live-toast targeting). Narration and shares still reach everyone; the DM sees all.
- **Clue sharing**: new `clue.share` command + 🤝 Share buttons in the Senses tab and player hex-inspect cards. Creates discoveries for every other party character (`how: shared`, carrying the sharer's direction/locates knowledge) and logs to the party.
- **Auto-select hex on move**: after a PC token move, the destination hex is selected and the Inspect tab opens on it.
- **Auto encounter checks**: per-map `encounterCheck.autoEvery` — rolls the wandering check every N hexes of party travel, at the hexes actually crossed (a 4-hex drag with N=2 rolls twice). Counter persists across moves; teleports don't count. Configurable in the Encounters tab.
- **Prep mode**: campaign setting `pausePlayerMapSync` with a ⏸/▶ top-bar toggle. While paused, players keep seeing terrain/markers/content/images/trails as they were at pause time; tokens, fog, discoveries and the log stay live. Resume pushes everything at once.
- **Go to Me** button for players — centers and zooms on their token, scaled to hex size.

Closes #52
Closes #53

## Testing

- 6 new server tests (sharing, log filtering, auto encounters, prep-mode freeze); 65 tests passing, typecheck clean.
- Verified live in the browser as DM + player (two origins): auto-select, auto encounter cadence, share flow, per-character log, prep-mode snapshot filtering end-to-end, resizable/wrapping sidebar.

No DB migration needed — new state lives in existing JSON columns with zod defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)