### PR TITLE
Roll buttons on skill lists (casual-player UX)

### DIFF
--- a/packages/client/src/components/panels/CharactersTab.tsx
+++ b/packages/client/src/components/panels/CharactersTab.tsx
@@ -68,6 +68,7 @@ export function CharactersTab() {
                     </span>
                     <span className="text-ink-400 text-xs">{open ? '▲' : '▼'}</span>
                   </button>
+                  {canEdit && <RollSkillButton characterId={ch.id} skill="perception" />}
                   {canCommand && <SendTokenButton tokenId={token.id} name={ch.name} />}
                 </div>
                 {open && (
@@ -92,7 +93,7 @@ export function CharactersTab() {
                         Release character
                       </Button>
                     )}
-                    <CharacterEditor character={ch} readOnly={!canEdit} />
+                    <CharacterEditor character={ch} readOnly={!canEdit} canRoll={canEdit} />
                     {isDm && (
                       <Button
                         variant="danger"
@@ -116,6 +117,38 @@ export function CharactersTab() {
       </Section>
       {creating && <NewCharacterForm onDone={() => setCreating(false)} />}
     </div>
+  );
+}
+
+/**
+ * Fires a check.roll for one character/skill directly from wherever skills
+ * are listed. The server rejects rolls for characters a player doesn't own
+ * (it substitutes their own claimed character), so this is only rendered for
+ * the DM (any character) or a player's own claimed character. Results arrive
+ * as a 'check' log toast (see ws.ts) — no result UI needed here.
+ */
+function RollSkillButton({
+  characterId,
+  skill,
+  className,
+}: {
+  characterId: string;
+  skill: string;
+  className?: string;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cx('!px-1.5 !py-0.5 shrink-0', className)}
+      title={`Roll ${skill}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        send({ kind: 'check.roll', skill, dc: null, characterIds: [characterId], mapId: null, hex: null });
+      }}
+    >
+      🎲
+    </Button>
   );
 }
 
@@ -227,7 +260,15 @@ function DdbSync({ character }: { character: Character }) {
   );
 }
 
-function CharacterEditor({ character, readOnly }: { character: Character; readOnly: boolean }) {
+function CharacterEditor({
+  character,
+  readOnly,
+  canRoll,
+}: {
+  character: Character;
+  readOnly: boolean;
+  canRoll: boolean;
+}) {
   const [customName, setCustomName] = useState('');
   const patch = (p: Partial<Character>) =>
     send({ kind: 'character.update', characterId: character.id, patch: p });
@@ -265,30 +306,33 @@ function CharacterEditor({ character, readOnly }: { character: Character; readOn
         </p>
         <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
           {allSkills.map((skill) => (
-            <label key={skill} className="flex items-center justify-between gap-1 text-xs text-ink-200">
+            <div key={skill} className="flex items-center justify-between gap-1 text-xs text-ink-200">
               <span className="capitalize truncate">{skill}</span>
-              {readOnly ? (
-                <span className="font-mono text-ink-100">
-                  {(character.skills[skill] ?? 0) >= 0 ? '+' : ''}
-                  {character.skills[skill] ?? 0}
-                </span>
-              ) : (
-                <input
-                  type="number"
-                  min={-10}
-                  max={20}
-                  className="w-13 rounded bg-ink-900 border border-ink-600 px-1 py-0.5 text-xs text-right focus:outline-none focus:border-brass-500"
-                  key={`${skill}-${character.skills[skill] ?? 0}`}
-                  defaultValue={character.skills[skill] ?? 0}
-                  onBlur={(e) => {
-                    const v = Math.round(Number(e.target.value));
-                    if (Number.isFinite(v) && v !== (character.skills[skill] ?? 0)) {
-                      patch({ skills: { ...character.skills, [skill]: Math.min(20, Math.max(-10, v)) } });
-                    }
-                  }}
-                />
-              )}
-            </label>
+              <span className="flex items-center gap-1 shrink-0">
+                {readOnly ? (
+                  <span className="font-mono text-ink-100">
+                    {(character.skills[skill] ?? 0) >= 0 ? '+' : ''}
+                    {character.skills[skill] ?? 0}
+                  </span>
+                ) : (
+                  <input
+                    type="number"
+                    min={-10}
+                    max={20}
+                    className="w-13 rounded bg-ink-900 border border-ink-600 px-1 py-0.5 text-xs text-right focus:outline-none focus:border-brass-500"
+                    key={`${skill}-${character.skills[skill] ?? 0}`}
+                    defaultValue={character.skills[skill] ?? 0}
+                    onBlur={(e) => {
+                      const v = Math.round(Number(e.target.value));
+                      if (Number.isFinite(v) && v !== (character.skills[skill] ?? 0)) {
+                        patch({ skills: { ...character.skills, [skill]: Math.min(20, Math.max(-10, v)) } });
+                      }
+                    }}
+                  />
+                )}
+                {canRoll && <RollSkillButton characterId={character.id} skill={skill} />}
+              </span>
+            </div>
           ))}
         </div>
         {!readOnly && (


### PR DESCRIPTION
Part of #62

First concrete slice of the casual-player UX pass: a small 🎲 roll button wherever skills are listed in the Party tab, so a player doesn't have to know `check.roll` exists or where the DM's roll tools live.

## Summary
- `packages/client/src/components/panels/CharactersTab.tsx`: added a `RollSkillButton` that sends `send({kind:'check.roll', skill, dc: null, characterIds: [characterId], mapId: null, hex: null})`.
- Placed on:
  - The passive-perception summary line in each character's collapsed row (rolls `perception`).
  - Every skill modifier row inside the expanded character editor (both read-only and editable views).
- Visible for: the DM on every character, and a player on their own claimed character only — mirrors the server-side check in `ws/handlers.ts` (`check.roll` substitutes the caller's own `seat.characterId` for non-DM callers, so a player can't actually roll someone else's character even if the button were shown).
- No new result UI: `check` log entries already surface as an info toast in `ws.ts` (`log.appended` + `kind === 'check'`), which was verified but not changed.
- Minor structural tweak: skill rows switched from `<label>` to `<div>` wrappers so the new button doesn't interact with the wrapping label's implicit-control-forwarding behavior.

## Test plan
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — green (existing suites untouched)
- [ ] Manual: as DM, expand a character and click a skill's roll button — toast appears with the roll. As a player who has claimed a character, confirm the roll button appears on their own character and rolls correctly; confirm it does not appear on other characters' rows/skills.