### PR TITLE
Trails as clickable objects with full-trail highlight

### DIFF
--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -183,25 +183,52 @@ export function InspectTab() {
 function TrailInfo({ hex, isDm }: { hex: { q: number; r: number }; isDm: boolean }) {
   const state = useSession((s) => s.state);
   const map = activeMap(state);
+  const highlight = useUi((u) => u.trailHighlight);
+  const setUi = useUi((s) => s.set);
   if (!state?.mapState || !map) return null;
 
   if (!isDm) {
     const signs = state.mapState.trailSigns.filter((s) => s.q === hex.q && s.r === hex.r);
     if (signs.length === 0) return null;
+    const toggle = (trailId: string) => {
+      if (highlight?.trailId === trailId) {
+        setUi('trailHighlight', null);
+        return;
+      }
+      const cells = state.mapState!.trailSigns
+        .filter((s) => s.trailId === trailId)
+        .map((s) => ({ q: s.q, r: s.r }));
+      setUi('trailHighlight', { trailId, cells });
+    };
     return (
       <Section title="Tracks">
         <ul className="space-y-1.5">
-          {signs.map((s, i) => (
-            <li key={i} className="text-sm text-ink-100">
-              {s.glyph}{' '}
-              {s.forward
-                ? <>The trail continues <span className="text-brass-300">to the {s.forward}</span></>
-                : 'The trail ends here'}
-              {s.backward && (
-                <span className="text-ink-400"> · back-trail {s.backward}</span>
-              )}
-            </li>
-          ))}
+          {signs.map((s, i) => {
+            const active = highlight?.trailId === s.trailId;
+            return (
+              <li key={i}>
+                <button
+                  onClick={() => toggle(s.trailId)}
+                  className={cx(
+                    'w-full text-left rounded-md border px-2.5 py-1.5 text-sm text-ink-100 cursor-pointer transition-colors',
+                    active
+                      ? 'border-brass-500 bg-brass-500/10'
+                      : 'border-transparent hover:border-ink-600 hover:bg-ink-850',
+                  )}
+                  title={active ? 'Hide this trail on the map' : 'Show every cell you’ve found of this trail'}
+                >
+                  {s.glyph}{' '}
+                  {s.forward
+                    ? <>The trail continues <span className="text-brass-300">to the {s.forward}</span></>
+                    : 'The trail ends here'}
+                  {s.backward && (
+                    <span className="text-ink-400"> · back-trail {s.backward}</span>
+                  )}
+                  {active && <span className="block text-[11px] text-brass-300 mt-0.5">highlighted on map</span>}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       </Section>
     );
@@ -211,24 +238,44 @@ function TrailInfo({ hex, isDm }: { hex: { q: number; r: number }; isDm: boolean
     .map((t) => ({ trail: t, idx: t.cells.findIndex((c) => c.q === hex.q && c.r === hex.r) }))
     .filter((x) => x.idx >= 0);
   if (crossing.length === 0) return null;
+  const toggleDm = (trailId: string, cells: { q: number; r: number }[]) => {
+    if (highlight?.trailId === trailId) {
+      setUi('trailHighlight', null);
+      return;
+    }
+    setUi('trailHighlight', { trailId, cells });
+  };
   return (
     <Section title="Trails here">
       <ul className="space-y-1.5">
         {crossing.map(({ trail, idx }) => {
           const next = trail.cells[idx + 1];
           const prev = trail.cells[idx - 1];
+          const active = highlight?.trailId === trail.id;
           return (
-            <li key={trail.id} className="text-sm text-ink-100">
-              {trail.glyph} <span className="font-medium">{trail.name}</span>
-              <span className="block text-xs text-ink-400">
-                cell {idx + 1}/{trail.cells.length}
-                {next && ` · onward ${compassDirection(hex, next, map.orientation)}`}
-                {prev && ` · back ${compassDirection(hex, prev, map.orientation)}`}
-                {' · '}
-                {trail.gate.kind === 'skill'
-                  ? `${trail.gate.skill} DC ${trail.gate.dc}`
-                  : 'obvious'}
-              </span>
+            <li key={trail.id}>
+              <button
+                onClick={() => toggleDm(trail.id, trail.cells)}
+                className={cx(
+                  'w-full text-left rounded-md border px-2.5 py-1.5 text-sm text-ink-100 cursor-pointer transition-colors',
+                  active
+                    ? 'border-brass-500 bg-brass-500/10'
+                    : 'border-transparent hover:border-ink-600 hover:bg-ink-850',
+                )}
+                title={active ? 'Hide this trail on the map' : 'Show the full trail on the map'}
+              >
+                {trail.glyph} <span className="font-medium">{trail.name}</span>
+                <span className="block text-xs text-ink-400">
+                  cell {idx + 1}/{trail.cells.length}
+                  {next && ` · onward ${compassDirection(hex, next, map.orientation)}`}
+                  {prev && ` · back ${compassDirection(hex, prev, map.orientation)}`}
+                  {' · '}
+                  {trail.gate.kind === 'skill'
+                    ? `${trail.gate.skill} DC ${trail.gate.dc}`
+                    : 'obvious'}
+                </span>
+                {active && <span className="block text-[11px] text-brass-300 mt-0.5">highlighted on map</span>}
+              </button>
             </li>
           );
         })}

--- a/packages/client/src/components/panels/JournalTab.tsx
+++ b/packages/client/src/components/panels/JournalTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CONTENT_TYPE_GLYPHS, isFullContent, type ContentPlayerView } from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { useUi } from '../../stores/ui.js';
-import { EmptyNote, Section } from '../../ui/kit.js';
+import { EmptyNote, Section, cx } from '../../ui/kit.js';
 
 /** Player-side journal: everything their character has learned, grouped by place. */
 export function JournalTab() {
@@ -14,6 +14,16 @@ export function JournalTab() {
     (c): c is ContentPlayerView => !isFullContent(c),
   );
   const narrations = state.log.filter((l) => l.kind === 'narration');
+  const trailSigns = state.mapState?.trailSigns ?? [];
+  const trails: { trailId: string; glyph: string; cells: { q: number; r: number }[] }[] = [];
+  for (const s of trailSigns) {
+    let entry = trails.find((t) => t.trailId === s.trailId);
+    if (!entry) {
+      entry = { trailId: s.trailId, glyph: s.glyph, cells: [] };
+      trails.push(entry);
+    }
+    entry.cells.push({ q: s.q, r: s.r });
+  }
 
   return (
     <div>
@@ -51,6 +61,17 @@ export function JournalTab() {
         </div>
       </Section>
 
+      <Section title="Tracks you've found">
+        {trails.length === 0 && (
+          <EmptyNote>No tracks discovered yet — footprints and trail signs show up here.</EmptyNote>
+        )}
+        <div className="space-y-2">
+          {trails.map((t) => (
+            <TrackRow key={t.trailId} trail={t} />
+          ))}
+        </div>
+      </Section>
+
       <Section title="The story so far">
         {narrations.length === 0 && <EmptyNote>No narration shared yet.</EmptyNote>}
         <div className="space-y-1.5">
@@ -62,5 +83,46 @@ export function JournalTab() {
         </div>
       </Section>
     </div>
+  );
+}
+
+/**
+ * One known trail: clicking toggles the full-trail highlight on the map
+ * (every cell this character has discovered) without navigating the
+ * Inspect selection — this is a map overlay, not a "go to hex" shortcut.
+ */
+function TrackRow({
+  trail,
+}: {
+  trail: { trailId: string; glyph: string; cells: { q: number; r: number }[] };
+}) {
+  const highlighted = useUi((u) => u.trailHighlight?.trailId === trail.trailId);
+  const toggle = () => {
+    const ui = useUi.getState();
+    ui.set('trailHighlight', highlighted ? null : { trailId: trail.trailId, cells: trail.cells });
+  };
+  return (
+    <button
+      onClick={toggle}
+      className={cx(
+        'w-full text-left rounded-lg border px-2.5 py-2 cursor-pointer transition-colors',
+        highlighted
+          ? 'border-brass-500 bg-brass-500/10'
+          : 'border-ink-700 bg-ink-850 hover:border-ink-600',
+      )}
+      title={
+        highlighted
+          ? 'Hide this trail'
+          : `Show the ${trail.cells.length} place(s) you've spotted this trail`
+      }
+    >
+      <div className="flex items-center gap-2">
+        <span>{trail.glyph}</span>
+        <span className="text-sm font-medium text-ink-100 flex-1">
+          {trail.cells.length} place{trail.cells.length === 1 ? '' : 's'} spotted
+        </span>
+      </div>
+      {highlighted && <span className="block text-[11px] text-brass-300 mt-0.5">highlighted on map</span>}
+    </button>
   );
 }

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -90,6 +90,7 @@ export class CanvasEngine {
   private tokensC = new Container();
   private pendingC = new Container();
   private senseG = new Graphics();
+  private trailHighlightG = new Graphics();
   private highlightG = new Graphics();
 
   private tokens = new Map<string, TokenView>();
@@ -171,6 +172,7 @@ export class CanvasEngine {
     this.viewport.addChild(this.exploredC);
     this.viewport.addChild(this.fogC);
     this.viewport.addChild(this.senseG);
+    this.viewport.addChild(this.trailHighlightG);
     this.viewport.addChild(this.highlightG);
 
     // Every layer except tokensC must be event-transparent: Pixi treats any
@@ -186,6 +188,7 @@ export class CanvasEngine {
       this.exploredC,
       this.fogC,
       this.senseG,
+      this.trailHighlightG,
       this.highlightG,
     ]) {
       layer.eventMode = 'none';
@@ -236,6 +239,9 @@ export class CanvasEngine {
       }
       if (u.senseHighlight !== prev.senseHighlight) {
         this.drawSenseHighlight();
+      }
+      if (u.trailHighlight !== prev.trailHighlight) {
+        this.drawTrailHighlight();
       }
       if (u.selectedHex !== prev.selectedHex) {
         this.updatePinPopupPos();
@@ -349,9 +355,11 @@ export class CanvasEngine {
     if (layoutChanged && this.lastMapIdForCenter !== map.id) {
       this.lastMapIdForCenter = map.id;
       this.recenter();
-      // Sense-highlight cells belong to the previous map.
+      // Sense/trail-highlight cells belong to the previous map.
       useUi.getState().set('senseHighlight', null);
       this.drawSenseHighlight();
+      useUi.getState().set('trailHighlight', null);
+      this.drawTrailHighlight();
     }
   }
 
@@ -365,6 +373,7 @@ export class CanvasEngine {
     this.fogEraseG.clear();
     this.exploredG.clear();
     this.senseG.clear();
+    this.trailHighlightG.clear();
     this.highlightG.clear();
     this.pinsC.removeChildren().forEach((c) => c.destroy({ children: true }));
     this.tokensReset();
@@ -673,6 +682,39 @@ export class CanvasEngine {
       g.poly(this.polyPoints(center, corners));
     }
     g.stroke({ width: 1.5 / this.viewport.scale.x, color: 0xd9b44f, alpha: 0.55 });
+  }
+
+  /**
+   * Highlight a clicked trail: soft fill over its cells plus a connecting
+   * line in cell order. The DM gets the whole path; players get only the
+   * cells passed in (their character's discovered signs) — the caller is
+   * responsible for that knowledge boundary, this just draws what it's given.
+   */
+  private drawTrailHighlight(): void {
+    const g = this.trailHighlightG;
+    g.clear();
+    if (!this.layout) return;
+    const highlight = useUi.getState().trailHighlight;
+    if (!highlight || highlight.cells.length === 0) return;
+    const corners = this.corners();
+    for (const cell of highlight.cells) {
+      const center = hexToPixel(this.layout, cell);
+      g.poly(this.polyPoints(center, corners));
+    }
+    g.fill({ color: 0x8b7fd4, alpha: 0.18 });
+    if (highlight.cells.length > 1) {
+      const pts = highlight.cells.map((c) => hexToPixel(this.layout!, c));
+      for (let i = 0; i < pts.length; i++) {
+        if (i === 0) g.moveTo(pts[i]!.x, pts[i]!.y);
+        else g.lineTo(pts[i]!.x, pts[i]!.y);
+      }
+      g.stroke({ width: 2.5 / this.viewport.scale.x, color: 0x8b7fd4, alpha: 0.75 });
+    }
+    for (const cell of highlight.cells) {
+      const center = hexToPixel(this.layout, cell);
+      g.poly(this.polyPoints(center, corners));
+    }
+    g.stroke({ width: 1.5 / this.viewport.scale.x, color: 0x8b7fd4, alpha: 0.55 });
   }
 
   /** Keep the DM pin-action popup glued above the selected hex. */

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -43,6 +43,8 @@ interface UiStore {
   movingTokenId: string | null;
   /** Sense triangulation: visited hexes a clicked clue is observable from. */
   senseHighlight: { clueId: string; cells: HexCoord[] } | null;
+  /** Trail highlight: the full path (DM) or discovered cells (player) of a clicked trail. */
+  trailHighlight: { trailId: string; cells: HexCoord[] } | null;
   /** DM trail tool: cells of the trail being drawn, in click order. */
   trailDraft: HexCoord[];
   /** DM trail tool: id of the trail whose nodes are being edited (null = new). */
@@ -109,6 +111,7 @@ export const useUi = create<UiStore>((set) => ({
   movingContentId: null,
   movingTokenId: null,
   senseHighlight: null,
+  trailHighlight: null,
   trailDraft: [],
   editingTrailId: null,
   contentSelection: null,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -50,6 +50,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.set('measureStart', null);
         ui.set('movingTokenId', null);
         ui.set('senseHighlight', null);
+        ui.set('trailHighlight', null);
         ui.set('trailDraft', []);
         ui.set('editingTrailId', null);
         ui.set('contentSelection', null);


### PR DESCRIPTION
Closes #81

## Summary
- Trails become clickable objects: clicking a trail entry highlights the whole path on the map (soft cell fill + connecting polyline), matching the existing senses-triangulation UX (`ui.senseHighlight`).
- New `ui.trailHighlight: { trailId, cells } | null` in `stores/ui.ts`; cleared on Escape and on map switch, same as `senseHighlight`.
- `CanvasEngine`: new `trailHighlightG` Graphics layer, added to the `eventMode='none'` list, drawn from `drawTrailHighlight()`, subscribed alongside `drawSenseHighlight()`.
- DM: "Trails here" rows in `InspectTab` toggle the highlight using the full `trail.cells` from `mapState.trails`.
- Player: "Tracks" rows in `InspectTab` toggle a highlight built from `mapState.trailSigns` grouped by `trailId` (cells in the order signs appear, i.e. discovery order) — never anything beyond what the client already has.
- Player: new "Tracks you've found" section in `JournalTab`, one entry per known trail (glyph + place count), same toggle behavior, does not navigate the Inspect selection.

## Decisions
- No server/`filterStateForViewer` changes: players only ever see `trailSigns` client-side, so grouping them client-side to build the highlight cannot leak undiscovered cells — the knowledge boundary stays exactly where it already was.
- Highlight color uses the existing arcane purple (`0x8b7fd4`, already used for the measure-tool line) to stay visually distinct from the senses highlight (brass/gold) and the DM's default faint trail connector line (brown).
- Discovery-order polyline for players: cells are connected in the order they appear in `trailSigns` for that `trailId`, per the issue's spec — no server-side reordering.

## Test plan
- [x] `pnpm typecheck && pnpm test` (shared 30 passed, server 35 passed, client has no unit tests — `--passWithNoTests`)
- [ ] Manual: DM clicks a "Trails here" row, sees the full path highlighted; clicking again (or Escape) clears it.
- [ ] Manual: Player clicks a "Tracks" row or a Journal "Tracks you've found" entry, sees their discovered cells highlighted; switching maps clears the highlight.

## Docs notes
No changes to `docs/AI-DEVELOPMENT.md` were needed — this feature follows the documented `eventMode='none'` gotcha and the `senseHighlight` pattern exactly, so no new gotcha was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)