### PR TITLE
Time tracking: campaign clock with travel mode and pace

### DIFF
--- a/packages/client/src/components/TopBar.tsx
+++ b/packages/client/src/components/TopBar.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
-import { SUPER_SCALE } from '@hexcrawl/shared';
+import {
+  SUPER_SCALE,
+  TRAVEL_PACES,
+  formatDay,
+  formatTimeOfDay,
+  isNight,
+  minutesPerHex,
+  resolveTravelMode,
+  travelModes,
+} from '@hexcrawl/shared';
+import type { TravelPace } from '@hexcrawl/shared';
 import { activeMap, useSession } from '../stores/session.js';
 import { useUi } from '../stores/ui.js';
 import { send } from '../ws.js';
-import { Button, Select, cx } from '../ui/kit.js';
+import { Button, Input, Select, cx } from '../ui/kit.js';
 
 function ScaleControl({ baseMiles }: { baseMiles: number }) {
   const scaleLock = useUi((s) => s.scaleLock);
@@ -35,6 +45,157 @@ function ScaleControl({ baseMiles }: { baseMiles: number }) {
           </button>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * The campaign clock. Everyone sees the readout ("Day 3 · 6:40 PM" plus a
+ * sun/moon); the DM gets travel mode, pace and time-advance controls in a
+ * popover, since the top bar has no room for them inline.
+ */
+function TimeControl() {
+  const time = useSession((s) => s.state?.campaign.time);
+  const settings = useSession((s) => s.state?.campaign.settings);
+  const role = useSession((s) => s.role);
+  const map = activeMap(useSession((s) => s.state));
+  const [open, setOpen] = React.useState(false);
+  const [custom, setCustom] = React.useState('');
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  if (!time) return null;
+  const night = isNight(time.minutes, settings);
+  const modes = travelModes(settings?.customTravelModes ?? []);
+  const mode = resolveTravelMode(time.travelMode, settings?.customTravelModes ?? []);
+  const perHex = map ? Math.round(minutesPerHex(map.milesPerHex, mode, time.pace)) : null;
+
+  const advance = (minutes: number) => {
+    if (minutes > 0) send({ kind: 'time.advance', minutes });
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => role === 'dm' && setOpen((o) => !o)}
+        className={cx(
+          'flex items-center gap-1.5 rounded-md border border-ink-600 px-2 py-1 text-[11px] text-ink-200',
+          role === 'dm' ? 'cursor-pointer hover:bg-ink-700' : 'cursor-default',
+        )}
+        title={
+          role === 'dm'
+            ? 'Campaign clock — travel mode, pace, and time advance'
+            : 'Campaign clock'
+        }
+      >
+        <span>{night ? '🌙' : '☀️'}</span>
+        <span className="whitespace-nowrap">
+          {formatDay(time.minutes)} · {formatTimeOfDay(time.minutes)}
+        </span>
+      </button>
+
+      {open && role === 'dm' && (
+        <div className="absolute left-0 top-full mt-1 w-60 rounded-md border border-ink-700 bg-ink-900 p-2.5 shadow-lg space-y-2 z-40">
+          <div>
+            <span className="block text-[10px] uppercase tracking-wider text-ink-400 mb-1">
+              Travel mode
+            </span>
+            <Select
+              value={time.travelMode}
+              onChange={(e) => send({ kind: 'time.config', travelMode: e.target.value })}
+            >
+              {modes.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label} ({m.mph} mph)
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <div>
+            <span className="block text-[10px] uppercase tracking-wider text-ink-400 mb-1">
+              Pace
+            </span>
+            <div className="flex items-center rounded-md border border-ink-600 overflow-hidden text-[11px]">
+              {TRAVEL_PACES.map((p: TravelPace) => (
+                <button
+                  key={p}
+                  onClick={() => send({ kind: 'time.config', pace: p })}
+                  className={cx(
+                    'flex-1 px-2 py-1 capitalize cursor-pointer transition-colors',
+                    time.pace === p
+                      ? 'bg-brass-500/25 text-brass-300'
+                      : 'text-ink-400 hover:bg-ink-700',
+                  )}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {perHex !== null && (
+            <p className="text-[11px] text-ink-400">
+              {perHex} min per hex at {map!.milesPerHex} mi/hex
+            </p>
+          )}
+
+          <div>
+            <span className="block text-[10px] uppercase tracking-wider text-ink-400 mb-1">
+              Advance time
+            </span>
+            <div className="flex gap-1">
+              {(
+                [
+                  ['+1h', 60],
+                  ['+8h', 8 * 60],
+                  ['+1 day', 24 * 60],
+                ] as const
+              ).map(([label, minutes]) => (
+                <Button
+                  key={label}
+                  variant="ghost"
+                  size="sm"
+                  className="flex-1 !px-1 border border-ink-600"
+                  onClick={() => advance(minutes)}
+                  title={label === '+8h' ? 'Long rest' : `Advance ${label}`}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+            <form
+              className="flex gap-1 mt-1"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const minutes = Math.floor(Number(custom));
+                if (Number.isFinite(minutes) && minutes > 0) advance(minutes);
+                setCustom('');
+              }}
+            >
+              <Input
+                type="number"
+                min={1}
+                value={custom}
+                onChange={(e) => setCustom(e.target.value)}
+                placeholder="minutes"
+                className="!py-1 text-[11px]"
+              />
+              <Button type="submit" variant="ghost" size="sm" className="border border-ink-600">
+                Add
+              </Button>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -131,6 +292,7 @@ export function TopBar({
       )}
 
       {map && <ScaleControl baseMiles={map.milesPerHex} />}
+      <TimeControl />
 
       <div className="flex-1" />
 

--- a/packages/client/src/components/panels/LogTab.tsx
+++ b/packages/client/src/components/panels/LogTab.tsx
@@ -9,9 +9,10 @@ const KIND_META: Record<string, { icon: string; label: string }> = {
   encounter: { icon: '🎲', label: 'Encounter' },
   narration: { icon: '📜', label: 'Narration' },
   share: { icon: '🤝', label: 'Shared' },
+  time: { icon: '🕐', label: 'Time' },
 };
 
-const FILTERS = ['all', 'discovery', 'check', 'encounter', 'narration', 'share'] as const;
+const FILTERS = ['all', 'discovery', 'check', 'encounter', 'narration', 'share', 'time'] as const;
 
 export function LogTab() {
   const state = useSession((s) => s.state);

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -198,6 +198,16 @@ function migrate(d: DB): void {
     );
     CREATE INDEX IF NOT EXISTS trail_map ON trail(map_id);
 
+    CREATE TABLE IF NOT EXISTS hex_visit (
+      map_id TEXT NOT NULL REFERENCES map(id) ON DELETE CASCADE,
+      q INTEGER NOT NULL,
+      r INTEGER NOT NULL,
+      first_arrived INTEGER NOT NULL,
+      last_arrived INTEGER NOT NULL,
+      total_minutes INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (map_id, q, r)
+    );
+
     CREATE TABLE IF NOT EXISTS trail_discovery (
       id TEXT PRIMARY KEY,
       campaign_id TEXT NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
@@ -227,6 +237,8 @@ function migrate(d: DB): void {
   ensureColumn(d, 'content', 'enabled', 'INTEGER NOT NULL DEFAULT 1');
   ensureColumn(d, 'content', 'quest', "TEXT NOT NULL DEFAULT ''");
   ensureColumn(d, 'content', 'known_location', 'INTEGER NOT NULL DEFAULT 0');
+  // Campaign clock (issue #57): JSON blob, zod defaults make it migration-free.
+  ensureColumn(d, 'campaign', 'time', "TEXT NOT NULL DEFAULT '{}'");
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -965,3 +965,116 @@ describe('prep mode (pause player map sync)', () => {
     expect(resumed.mapState!.markers).toHaveLength(1);
   });
 });
+
+describe('campaign clock (issue #57)', () => {
+  // The default map is 6 mi/hex and the default mode is foot (3 mph), so a
+  // hex costs 120 minutes at normal pace.
+  it('starts at 8:00 AM on day 1', () => {
+    expect(runtime.campaign.time.minutes).toBe(8 * 60);
+    expect(runtime.campaign.time.travelMode).toBe('foot');
+    expect(runtime.campaign.time.pace).toBe('normal');
+  });
+
+  it('advances on travel by hexes crossed, and not on a teleport', () => {
+    const { tokenId, playerSeat } = setupPartyWithScout();
+    expect(runtime.campaign.time.minutes).toBe(480);
+
+    // 3 hexes on foot at 6 mi/hex = 6 hours.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 3, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(480 + 3 * 120);
+
+    // Teleports cost no time but still relocate the party.
+    dm({ kind: 'token.move', tokenId, q: 20, r: 0, teleport: true } as never);
+    expect(runtime.campaign.time.minutes).toBe(480 + 3 * 120);
+    expect(runtime.campaign.time.partyHex).toMatchObject({ q: 20, r: 0 });
+  });
+
+  it('applies travel mode and pace to the cost of a hex', () => {
+    const { tokenId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'time.config', pace: 'careful' } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(480 + 180);
+
+    // Horseback at fast pace: 6 mph × 4/3 = 8 mph → 45 minutes per hex.
+    dm({ kind: 'time.config', travelMode: 'horse', pace: 'fast' } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 2, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(480 + 180 + 45);
+  });
+
+  it('npc moves leave the clock alone', () => {
+    const mapId = activeMapId();
+    dm({
+      kind: 'token.create', mapId, q: 0, r: 0, tokenKind: 'npc', characterId: null,
+      label: 'Ogre', color: '#aa0000', glyph: '', playerVisible: true,
+    } as never);
+    const tokenId = [...runtime.requireMap(mapId).tokens.keys()][0]!;
+    dm({ kind: 'token.move', tokenId, q: 4, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(480);
+  });
+
+  it('time.advance and time.set log and require the DM', () => {
+    const player = runtime.createSeat('player', 'Mallory');
+    expect(() => asSeat(player, { kind: 'time.advance', minutes: 60 } as never)).toThrow(/DM/);
+    expect(() => asSeat(player, { kind: 'time.set', minutes: 0 } as never)).toThrow(/DM/);
+    expect(() => asSeat(player, { kind: 'time.config', pace: 'fast' } as never)).toThrow(/DM/);
+    expect(runtime.campaign.time.minutes).toBe(480);
+
+    dm({ kind: 'time.advance', minutes: 8 * 60 } as never);
+    expect(runtime.campaign.time.minutes).toBe(480 + 480);
+    const advanced = runtime.log.filter((e) => e.kind === 'time');
+    expect(advanced).toHaveLength(1);
+    expect(advanced[0]!.text).toBe('Time advances 8 hours — Day 1, 4:00 PM');
+    expect(advanced[0]!.visibility).toBe('all');
+
+    dm({ kind: 'time.set', minutes: 2 * 1440 + 18 * 60 + 40 } as never);
+    expect(runtime.campaign.time.minutes).toBe(2 * 1440 + 18 * 60 + 40);
+    const setEntry = runtime.log.filter((e) => e.kind === 'time')[1]!;
+    expect(setEntry.text).toBe('Clock set to Day 3, 6:40 PM');
+    expect(setEntry.visibility).toBe('dm');
+  });
+
+  it('accumulates per-hex time while the party lingers, and persists it', () => {
+    const { mapId, tokenId, playerSeat } = setupPartyWithScout();
+    // The starting hex is stamped when the PC token appears.
+    expect(runtime.hexVisit(mapId, 0, 0)).toMatchObject({ firstArrived: 480, totalMinutes: 0 });
+
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(600);
+    expect(runtime.hexVisit(mapId, 1, 0)).toMatchObject({ firstArrived: 600, totalMinutes: 0 });
+
+    // Camp for eight hours, then move on: the parked hex banks the downtime,
+    // and travel time is charged to neither hex.
+    dm({ kind: 'time.advance', minutes: 8 * 60 } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 2, r: 0 } as never);
+    expect(runtime.hexVisit(mapId, 1, 0)!.totalMinutes).toBe(480);
+    expect(runtime.hexVisit(mapId, 2, 0)).toMatchObject({ totalMinutes: 0, lastArrived: 1200 });
+
+    // Coming back re-stamps lastArrived while keeping the history.
+    dm({ kind: 'time.advance', minutes: 30 } as never);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    const revisit = runtime.hexVisit(mapId, 1, 0)!;
+    expect(revisit.firstArrived).toBe(600);
+    expect(revisit.lastArrived).toBe(1350);
+    expect(runtime.hexVisit(mapId, 2, 0)!.totalMinutes).toBe(30);
+
+    // Clock and visits survive a restart.
+    const db = (store as unknown as { db: unknown }).db;
+    const reloaded = new Store(db as never).getCampaign(runtime.id)!;
+    expect(reloaded.campaign.time.minutes).toBe(runtime.campaign.time.minutes);
+    expect(reloaded.campaign.time.partyHex).toEqual(runtime.campaign.time.partyHex);
+    expect(reloaded.hexVisit(mapId, 1, 0)).toEqual(revisit);
+  });
+
+  it('exposes visits to the DM snapshot only', () => {
+    const { mapId, charId, playerSeat, tokenId } = setupPartyWithScout();
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    const full = runtime.buildFullState(mapId);
+    expect(full.mapState!.visits.length).toBeGreaterThan(0);
+    const playerView = filterStateForViewer(full, {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(playerView.mapState!.visits).toEqual([]);
+    // The clock itself is public.
+    expect(playerView.campaign.time.minutes).toBe(runtime.campaign.time.minutes);
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -4,6 +4,7 @@ import type {
   PendingMove,
   CampaignSettings,
   CampaignState,
+  CampaignTime,
   Character,
   Content,
   Discovery,
@@ -12,6 +13,7 @@ import type {
   EncounterTable,
   FogState,
   HexCell,
+  HexVisit,
   ImageLayer,
   LogEntry,
   MapInfo,
@@ -24,6 +26,7 @@ import type {
 } from '@hexcrawl/shared';
 import {
   CampaignSettingsSchema,
+  CampaignTimeSchema,
   EncounterCheckConfigSchema,
   GateSchema,
   GridStyleSchema,
@@ -51,6 +54,8 @@ export interface MapRuntime {
   /** In-memory only: player moves awaiting DM approval, by tokenId. */
   pendingMoves: Map<string, PendingMove>;
   trails: Map<string, Trail>;
+  /** Party visit accounting per hex, keyed by hexKey. */
+  visits: Map<string, HexVisit>;
 }
 
 const LOG_MEMORY_LIMIT = 500;
@@ -109,7 +114,16 @@ export class CampaignRuntime {
 
   constructor(
     private db: DB,
-    row: { id: string; name: string; dm_secret: string; player_secret: string; active_map_id: string | null; settings: string },
+    row: {
+      id: string;
+      name: string;
+      dm_secret: string;
+      player_secret: string;
+      active_map_id: string | null;
+      settings: string;
+      /** Added after first release; absent on rows selected before the column. */
+      time?: string | null;
+    },
   ) {
     this.id = row.id;
     this.dmSecret = row.dm_secret;
@@ -119,6 +133,7 @@ export class CampaignRuntime {
       name: row.name,
       activeMapId: row.active_map_id,
       settings: CampaignSettingsSchema.parse(safeJson(row.settings)),
+      time: CampaignTimeSchema.parse(safeJson(row.time)),
     };
     this.load();
     if (this.campaign.settings.pausePlayerMapSync) this.capturePlayerFreeze();
@@ -244,7 +259,19 @@ export class CampaignRuntime {
       contents: new Map(),
       pendingMoves: new Map(),
       trails: new Map(),
+      visits: new Map(),
     };
+    for (const v of d.prepare('SELECT * FROM hex_visit WHERE map_id = ?').all(mapId) as Array<
+      Record<string, unknown>
+    >) {
+      rt.visits.set(hexKey(v.q as number, v.r as number), {
+        q: v.q as number,
+        r: v.r as number,
+        firstArrived: v.first_arrived as number,
+        lastArrived: v.last_arrived as number,
+        totalMinutes: v.total_minutes as number,
+      });
+    }
     for (const t of d.prepare('SELECT * FROM trail WHERE map_id = ?').all(mapId) as Array<
       Record<string, unknown>
     >) {
@@ -361,6 +388,7 @@ export class CampaignRuntime {
       pendingMoves: [...rt.pendingMoves.values()],
       trails: [...rt.trails.values()],
       trailSigns: [],
+      visits: [...rt.visits.values()],
     };
   }
 
@@ -462,6 +490,73 @@ export class CampaignRuntime {
       .run(this.campaign.name, JSON.stringify(this.campaign.settings), this.id);
   }
 
+  // -- campaign clock --------------------------------------------------------
+
+  /** Patch the clock blob and write it through. */
+  updateTime(patch: Partial<CampaignTime>): CampaignTime {
+    this.campaign.time = { ...this.campaign.time, ...patch };
+    this.db
+      .prepare('UPDATE campaign SET time = ? WHERE id = ?')
+      .run(JSON.stringify(this.campaign.time), this.id);
+    return this.campaign.time;
+  }
+
+  /** Push the clock forward by whole minutes (never backwards). */
+  advanceTime(minutes: number): CampaignTime {
+    const delta = Math.max(0, Math.round(minutes));
+    if (delta === 0) return this.campaign.time;
+    return this.updateTime({ minutes: this.campaign.time.minutes + delta });
+  }
+
+  setTime(minutes: number): CampaignTime {
+    return this.updateTime({ minutes: Math.max(0, Math.round(minutes)) });
+  }
+
+  // -- hex visits ------------------------------------------------------------
+
+  hexVisit(mapId: string, q: number, r: number): HexVisit | null {
+    return this.mapStates.get(mapId)?.visits.get(hexKey(q, r)) ?? null;
+  }
+
+  /**
+   * Stamp the party's arrival on a hex at clock minute `at`, creating the
+   * record on first visit.
+   */
+  recordHexArrival(mapId: string, q: number, r: number, at: number): HexVisit {
+    const rt = this.requireMap(mapId);
+    const key = hexKey(q, r);
+    const existing = rt.visits.get(key);
+    const visit: HexVisit = existing
+      ? { ...existing, lastArrived: at }
+      : { q, r, firstArrived: at, lastArrived: at, totalMinutes: 0 };
+    rt.visits.set(key, visit);
+    this.writeHexVisit(mapId, visit);
+    return visit;
+  }
+
+  /** Credit minutes spent standing on a hex (no-op if never arrived there). */
+  addHexTime(mapId: string, q: number, r: number, minutes: number): void {
+    const delta = Math.max(0, Math.round(minutes));
+    if (delta === 0) return;
+    const rt = this.mapStates.get(mapId);
+    if (!rt) return;
+    const key = hexKey(q, r);
+    const existing = rt.visits.get(key);
+    if (!existing) return;
+    const visit: HexVisit = { ...existing, totalMinutes: existing.totalMinutes + delta };
+    rt.visits.set(key, visit);
+    this.writeHexVisit(mapId, visit);
+  }
+
+  private writeHexVisit(mapId: string, visit: HexVisit): void {
+    this.db
+      .prepare(
+        `INSERT INTO hex_visit (map_id, q, r, first_arrived, last_arrived, total_minutes) VALUES (?,?,?,?,?,?)
+         ON CONFLICT(map_id,q,r) DO UPDATE SET first_arrived=excluded.first_arrived, last_arrived=excluded.last_arrived, total_minutes=excluded.total_minutes`,
+      )
+      .run(mapId, visit.q, visit.r, visit.firstArrived, visit.lastArrived, visit.totalMinutes);
+  }
+
   setActiveMap(mapId: string | null): void {
     this.campaign.activeMapId = mapId;
     this.db.prepare('UPDATE campaign SET active_map_id = ? WHERE id = ?').run(mapId, this.id);
@@ -555,6 +650,7 @@ export class CampaignRuntime {
       contents: new Map(),
       pendingMoves: new Map(),
       trails: new Map(),
+      visits: new Map(),
     });
     this.db
       .prepare(

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -11,11 +11,15 @@ import type {
 import {
   compassDirection,
   EncounterCheckConfigSchema,
+  formatClock,
+  formatDuration,
   GridStyleSchema,
   hexDistance,
   hexKey,
   hexLine,
+  minutesPerHex,
   parseHexKey,
+  resolveTravelMode,
   rollD20,
 } from '@hexcrawl/shared';
 import type { FogState, TerrainId } from '@hexcrawl/shared';
@@ -250,6 +254,15 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       token.glyph = token.glyph || character.glyph;
     }
     ctx.runtime.createToken(token);
+    // The first PC on the board establishes where "the party" stands, so
+    // lingering time is credited from the moment they exist.
+    if (token.kind === 'pc' && !ctx.runtime.campaign.time.partyHex) {
+      const now = ctx.runtime.campaign.time.minutes;
+      ctx.runtime.recordHexArrival(token.mapId, token.q, token.r, now);
+      ctx.runtime.updateTime({
+        partyHex: { mapId: token.mapId, q: token.q, r: token.r, arrivedMinutes: now },
+      });
+    }
     afterPartyMoved(ctx, cmd.mapId, token);
   }) as Handler,
 
@@ -284,6 +297,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     const teleport = cmd.teleport && ctx.seat.role === 'dm';
     const fogDelta = executePartyMove(ctx, token, cmd.q, cmd.r, teleport);
     autoEncounterChecks(ctx, map, token, { q: fromQ, r: fromR }, { q: cmd.q, r: cmd.r }, teleport);
+    advanceTravelClock(ctx, map, token, { q: fromQ, r: fromR }, { q: cmd.q, r: cmd.r }, teleport);
     if (ctx.seat.role === 'dm') {
       ctx.runtime.pushUndo({
         at: Date.now(),
@@ -342,6 +356,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       const map = ctx.runtime.maps.get(token.mapId);
       if (map) {
         autoEncounterChecks(ctx, map, token, from, { q: pending.toQ, r: pending.toR }, cmd.teleport);
+        advanceTravelClock(ctx, map, token, from, { q: pending.toQ, r: pending.toR }, cmd.teleport);
       }
       ctx.runtime.pushUndo({
         at: Date.now(),
@@ -874,6 +889,36 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     ctx.runtime.deleteEncounterTable(cmd.tableId);
   }) as Handler,
 
+  // -- campaign clock --------------------------------------------------------
+  'time.advance': ((cmd: Extract<ClientCommand, { kind: 'time.advance' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const time = ctx.runtime.advanceTime(cmd.minutes);
+    const entry = ctx.runtime.appendLog(
+      'time',
+      `Time advances ${formatDuration(cmd.minutes)} — ${formatClock(time.minutes)}`,
+      'all',
+      { minutes: time.minutes, advancedBy: cmd.minutes },
+    );
+    notifyLog(ctx, entry);
+  }) as Handler,
+
+  'time.set': ((cmd: Extract<ClientCommand, { kind: 'time.set' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const time = ctx.runtime.setTime(cmd.minutes);
+    const entry = ctx.runtime.appendLog('time', `Clock set to ${formatClock(time.minutes)}`, 'dm', {
+      minutes: time.minutes,
+    });
+    notifyLog(ctx, entry);
+  }) as Handler,
+
+  'time.config': ((cmd: Extract<ClientCommand, { kind: 'time.config' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const patch: Parameters<CampaignRuntime['updateTime']>[0] = {};
+    if (cmd.travelMode !== undefined) patch.travelMode = cmd.travelMode;
+    if (cmd.pace !== undefined) patch.pace = cmd.pace;
+    ctx.runtime.updateTime(patch);
+  }) as Handler,
+
   // -- undo ------------------------------------------------------------------
   undo: ((_cmd: Extract<ClientCommand, { kind: 'undo' }>, ctx: Ctx) => {
     requireDm(ctx);
@@ -1058,6 +1103,40 @@ function autoEncounterChecks(
   ctx.runtime.updateMap(map.id, {
     encounterCheck: { hexesSinceCheck: count },
   } as unknown as Partial<MapInfo>);
+}
+
+/**
+ * Campaign clock + per-hex visit accounting for a party move.
+ *
+ * Travel costs `hexes crossed × minutesPerHex(map scale, mode, pace)`. The hex
+ * the party leaves is credited with the time they lingered there — the clock
+ * delta since they arrived, which excludes this move's travel time because the
+ * credit is taken before the clock advances. Teleports move the party without
+ * spending time (but still re-stamp where they now stand). "The party" is the
+ * moved PC token; NPC tokens don't move the clock.
+ */
+function advanceTravelClock(
+  ctx: Ctx,
+  map: MapInfo,
+  token: Token,
+  from: { q: number; r: number },
+  to: { q: number; r: number },
+  teleport: boolean,
+): void {
+  if (token.kind !== 'pc') return;
+  const time = ctx.runtime.campaign.time;
+  const mode = resolveTravelMode(time.travelMode, ctx.runtime.campaign.settings.customTravelModes);
+  const hexes = teleport ? 0 : Math.max(0, hexLine(from, to).length - 1);
+  const travelMinutes = hexes * minutesPerHex(map.milesPerHex, mode, time.pace);
+
+  const parked = time.partyHex;
+  if (parked) {
+    ctx.runtime.addHexTime(parked.mapId, parked.q, parked.r, time.minutes - parked.arrivedMinutes);
+  }
+  if (travelMinutes > 0) ctx.runtime.advanceTime(travelMinutes);
+  const arrivedMinutes = ctx.runtime.campaign.time.minutes;
+  ctx.runtime.recordHexArrival(map.id, to.q, to.r, arrivedMinutes);
+  ctx.runtime.updateTime({ partyHex: { mapId: map.id, q: to.q, r: to.r, arrivedMinutes } });
 }
 
 function capitalize(s: string): string {

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -82,11 +82,26 @@ export type FogState = z.infer<typeof FogStateSchema>;
 // Campaign / seats / characters
 // ---------------------------------------------------------------------------
 
+/** A campaign-defined travel mode, on top of the built-in list in rules/time. */
+export const CustomTravelModeSchema = z.object({
+  id: z.string().min(1).max(40),
+  name: z.string().min(1).max(60),
+  /** Miles per hour at normal pace. */
+  mph: z.number().min(0.1).max(500),
+});
+export type CustomTravelMode = z.infer<typeof CustomTravelModeSchema>;
+
 export const CampaignSettingsSchema = z.object({
   /** Free text shown on the join screen. */
   description: z.string().max(2000).default(''),
   /** Base URL for wiki links on content (page titles are appended). */
   wikiBaseUrl: z.string().max(300).default('https://wiki.deeznuts.wiki/index.php/'),
+  /** Extra travel modes for the campaign clock. */
+  customTravelModes: z.array(CustomTravelModeSchema).default([]),
+  /** Hour of day (0-23) the sun rises; drives day/night derivation. */
+  sunriseHour: z.number().min(0).max(23).default(6),
+  /** Hour of day (0-24) the sun sets. */
+  sunsetHour: z.number().min(0).max(24).default(20),
   /**
    * Prep mode: while true, players keep seeing the map layers (terrain,
    * markers, content, images, trails) as they were when the pause began;
@@ -97,11 +112,42 @@ export const CampaignSettingsSchema = z.object({
 });
 export type CampaignSettings = z.infer<typeof CampaignSettingsSchema>;
 
+export const TravelPaceSchema = z.enum(['fast', 'normal', 'careful']);
+export type TravelPace = z.infer<typeof TravelPaceSchema>;
+
+/**
+ * The campaign clock. `minutes` is in-game minutes since campaign start, so
+ * day/hour arithmetic is pure integer math and a calendar can be layered on
+ * later (issue #79). Campaigns begin at 8:00 AM on day 1.
+ */
+export const CampaignTimeSchema = z.object({
+  minutes: z.number().int().min(0).default(8 * 60),
+  /** Travel mode id — a built-in or one of settings.customTravelModes. */
+  travelMode: z.string().min(1).max(40).default('foot'),
+  pace: TravelPaceSchema.default('normal'),
+  /**
+   * Where the party stands and when they got there (clock minutes), so time
+   * spent lingering can be credited to that hex when they leave.
+   */
+  partyHex: z
+    .object({
+      mapId: z.string(),
+      q: z.number().int(),
+      r: z.number().int(),
+      arrivedMinutes: z.number().int().min(0),
+    })
+    .nullable()
+    .default(null),
+});
+export type CampaignTime = z.infer<typeof CampaignTimeSchema>;
+
 export const CampaignSchema = z.object({
   id: z.string(),
   name: z.string().min(1).max(120),
   activeMapId: z.string().nullable(),
   settings: CampaignSettingsSchema,
+  /** Visible to everyone: players see the clock too. */
+  time: CampaignTimeSchema,
 });
 export type Campaign = z.infer<typeof CampaignSchema>;
 
@@ -562,6 +608,22 @@ export const TrailSignSchema = z.object({
 });
 export type TrailSign = z.infer<typeof TrailSignSchema>;
 
+/**
+ * Per-hex visit accounting for the party, in campaign-clock minutes. Feeds
+ * "when were we here?" (#66) and time-spent-in-hex (#59). DM-only for now.
+ */
+export const HexVisitSchema = z.object({
+  q: z.number().int(),
+  r: z.number().int(),
+  /** Clock minutes at the party's first arrival on this hex. */
+  firstArrived: z.number().int().min(0),
+  /** Clock minutes at their most recent arrival. */
+  lastArrived: z.number().int().min(0),
+  /** Total minutes the party has spent standing here (travel time excluded). */
+  totalMinutes: z.number().int().min(0).default(0),
+});
+export type HexVisit = z.infer<typeof HexVisitSchema>;
+
 export const MapStateSchema = z.object({
   imageLayers: z.array(ImageLayerSchema),
   hexes: z.array(HexCellSchema),
@@ -575,6 +637,8 @@ export const MapStateSchema = z.object({
   trails: z.array(TrailSchema).default([]),
   /** Players: signs for the trail cells their character has discovered. */
   trailSigns: z.array(TrailSignSchema).default([]),
+  /** DM only: per-hex party visit records (players get last-visited in #66). */
+  visits: z.array(HexVisitSchema).default([]),
 });
 export type MapState = z.infer<typeof MapStateSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -3,6 +3,8 @@ import {
   CharacterSchema,
   ContentTypeSchema,
   ClueSchema,
+  CustomTravelModeSchema,
+  TravelPaceSchema,
   EncounterTableSchema,
   FogStateSchema,
   MarkerSchema,
@@ -44,6 +46,9 @@ const CampaignSettingsPatchSchema = z
     description: z.string().max(2000),
     wikiBaseUrl: z.string().max(300),
     pausePlayerMapSync: z.boolean(),
+    customTravelModes: z.array(CustomTravelModeSchema),
+    sunriseHour: z.number().min(0).max(23),
+    sunsetHour: z.number().min(0).max(24),
   })
   .partial();
 
@@ -465,6 +470,35 @@ export const EncounterTableDeleteCommand = z.object({
   tableId: z.string(),
 });
 
+// --- campaign clock ---------------------------------------------------------
+
+/**
+ * DM: push the campaign clock forward (rests, downtime, a searched hex).
+ * Capped at a year so a fat-fingered entry can't send the party to the
+ * far future. Fields stay `.optional()` rather than `.default()`ed — a
+ * default would make them required in `CommandInput` at every call site.
+ */
+export const TimeAdvanceCommand = z.object({
+  ...base,
+  kind: z.literal('time.advance'),
+  minutes: z.number().int().min(1).max(60 * 24 * 365),
+});
+
+/** DM: set the clock absolutely (session bookkeeping, fixing a mistake). */
+export const TimeSetCommand = z.object({
+  ...base,
+  kind: z.literal('time.set'),
+  minutes: z.number().int().min(0).max(60 * 24 * 365 * 1000),
+});
+
+/** DM: change how fast the party travels. */
+export const TimeConfigCommand = z.object({
+  ...base,
+  kind: z.literal('time.config'),
+  travelMode: z.string().min(1).max(40).optional(),
+  pace: TravelPaceSchema.optional(),
+});
+
 /** DM: undo the most recent undoable change (fog, terrain, moves, edits). */
 export const UndoCommand = z.object({
   ...base,
@@ -523,6 +557,9 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   EncounterRollCommand,
   EncounterTableUpsertCommand,
   EncounterTableDeleteCommand,
+  TimeAdvanceCommand,
+  TimeSetCommand,
+  TimeConfigCommand,
   UndoCommand,
   NarrateCommand,
 ]);

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -51,6 +51,9 @@ export function filterStateForViewer(full: CampaignState, viewer: Viewer): Campa
           // Trail definitions never reach players; only discovered signs do.
           trails: [],
           trailSigns: computeTrailSigns(full, viewer.characterId),
+          // Visit history is DM bookkeeping for now (players get last-visited
+          // in #66, which will need its own per-hex fog check).
+          visits: [],
         };
       })()
     : null;

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -1,3 +1,4 @@
 export * from './dice.js';
 export * from './gates.js';
 export * from './filter.js';
+export * from './time.js';

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { diceBounds, parseDice, rollDice, seededRng } from './dice.js';
 import { gateOpensPassively } from './gates.js';
 import { filterStateForViewer } from './filter.js';
+import {
+  TRAVEL_MODES,
+  formatClock,
+  formatDuration,
+  formatTimeOfDay,
+  isNight,
+  minutesPerHex,
+  resolveTravelMode,
+  timeOfDay,
+  travelModes,
+} from './time.js';
 import type { CampaignState, Character } from '../domain.js';
 
 describe('dice', () => {
@@ -70,7 +81,20 @@ describe('gates', () => {
 
 function fullState(): CampaignState {
   return {
-    campaign: { id: 'c1', name: 'Test', activeMapId: 'm1', settings: { description: '', wikiBaseUrl: 'https://wiki.example/wiki/', pausePlayerMapSync: false } },
+    campaign: {
+      id: 'c1',
+      name: 'Test',
+      activeMapId: 'm1',
+      settings: {
+        description: '',
+        wikiBaseUrl: 'https://wiki.example/wiki/',
+        pausePlayerMapSync: false,
+        customTravelModes: [],
+        sunriseHour: 6,
+        sunsetHour: 20,
+      },
+      time: { minutes: 8 * 60, travelMode: 'foot', pace: 'normal', partyHex: null },
+    },
     seats: [
       { id: 'dm', role: 'dm', name: 'DM', characterId: null, online: true },
       { id: 's1', role: 'player', name: 'Alice', characterId: 'char1', online: true },
@@ -118,6 +142,7 @@ function fullState(): CampaignState {
       pendingMoves: [],
       trails: [],
       trailSigns: [],
+      visits: [{ q: 0, r: 0, firstArrived: 480, lastArrived: 480, totalMinutes: 30 }],
     },
     discoveries: [
       { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' }, direction: null, locates: true },
@@ -171,6 +196,15 @@ describe('filterStateForViewer', () => {
     expect((view as { discoveredClues: unknown[] }).discoveredClues).toHaveLength(1);
   });
 
+  it('withholds per-hex visit records from players', () => {
+    const full = fullState();
+    expect(full.mapState!.visits).toHaveLength(1);
+    const s = filterStateForViewer(full, viewer);
+    expect(s.mapState!.visits).toEqual([]);
+    // The clock itself is public: players see day, time and daylight.
+    expect(s.campaign.time).toEqual(full.campaign.time);
+  });
+
   it('filters discoveries, tables, and log', () => {
     const s = filterStateForViewer(fullState(), viewer);
     expect(s.discoveries.map((d) => d.id)).toEqual(['d1']);
@@ -182,5 +216,52 @@ describe('filterStateForViewer', () => {
     const s = filterStateForViewer(fullState(), { seatId: 's9', role: 'player', characterId: null });
     expect(s.mapState!.contents).toEqual([]);
     expect(s.discoveries).toEqual([]);
+  });
+});
+
+describe('campaign clock', () => {
+  it('computes minutes per hex from scale, mode speed and pace', () => {
+    const foot = resolveTravelMode('foot');
+    expect(foot.mph).toBe(3);
+    // 6 miles at 3 mph = 2 hours.
+    expect(minutesPerHex(6, foot, 'normal')).toBe(120);
+    // Fast pace is 4/3 speed: 90 minutes. Careful is 2/3: 180.
+    expect(minutesPerHex(6, foot, 'fast')).toBe(90);
+    expect(minutesPerHex(6, foot, 'careful')).toBe(180);
+    // A raw mph works too, and horses are twice as fast as boots.
+    expect(minutesPerHex(6, 6, 'normal')).toBe(60);
+    expect(minutesPerHex(6, resolveTravelMode('horse'), 'normal')).toBe(60);
+    // Degenerate inputs cost nothing rather than diverging.
+    expect(minutesPerHex(0, foot, 'normal')).toBe(0);
+    expect(minutesPerHex(6, 0, 'normal')).toBe(0);
+  });
+
+  it('resolves custom travel modes and falls back to foot', () => {
+    const custom = [{ id: 'griffon', name: 'Griffon', mph: 12 }];
+    expect(resolveTravelMode('griffon', custom).mph).toBe(12);
+    expect(travelModes(custom)).toHaveLength(TRAVEL_MODES.length + 1);
+    expect(resolveTravelMode('nonsense', custom).id).toBe('foot');
+  });
+
+  it('derives day, time of day and formatting', () => {
+    expect(timeOfDay(8 * 60)).toEqual({ day: 1, hour: 8, minute: 0 });
+    expect(timeOfDay(2 * 1440 + 18 * 60 + 40)).toEqual({ day: 3, hour: 18, minute: 40 });
+    expect(formatClock(2 * 1440 + 18 * 60 + 40)).toBe('Day 3, 6:40 PM');
+    expect(formatTimeOfDay(0)).toBe('12:00 AM');
+    expect(formatTimeOfDay(12 * 60)).toBe('12:00 PM');
+    expect(formatDuration(8 * 60)).toBe('8 hours');
+    expect(formatDuration(1500)).toBe('1 day 1 hour');
+    expect(formatDuration(45)).toBe('45 minutes');
+  });
+
+  it('derives night from configurable sunrise/sunset', () => {
+    expect(isNight(8 * 60)).toBe(false);
+    expect(isNight(22 * 60)).toBe(true);
+    expect(isNight(3 * 60)).toBe(true);
+    // Second day, still daylight at noon.
+    expect(isNight(1440 + 12 * 60)).toBe(false);
+    // A campaign with long nights.
+    expect(isNight(8 * 60, { sunriseHour: 9, sunsetHour: 16 })).toBe(true);
+    expect(isNight(15 * 60, { sunriseHour: 9, sunsetHour: 16 })).toBe(false);
   });
 });

--- a/packages/shared/src/rules/time.ts
+++ b/packages/shared/src/rules/time.ts
@@ -1,0 +1,141 @@
+import type { CampaignTime, CustomTravelMode, TravelPace } from '../domain.js';
+
+/**
+ * Campaign clock rules: travel speed, time of day, day/night.
+ *
+ * The clock is a single integer — in-game minutes since campaign start — so
+ * arithmetic never has to care about calendars. A day is 1440 minutes and
+ * dates render as "Day N"; a fantasy calendar (issue #79) can layer month and
+ * year naming on top of the same number without touching any of this.
+ */
+
+export const MINUTES_PER_DAY = 1440;
+
+export interface TravelMode {
+  id: string;
+  label: string;
+  /** Miles covered per hour at normal pace. */
+  mph: number;
+}
+
+/** Built-in travel modes. Campaigns may add their own in settings. */
+export const TRAVEL_MODES: TravelMode[] = [
+  { id: 'foot', label: 'On foot', mph: 3 },
+  { id: 'horse', label: 'Horseback', mph: 6 },
+  { id: 'wagon', label: 'Wagon', mph: 4 },
+  { id: 'ship', label: 'Ship', mph: 5 },
+  { id: 'flying', label: 'Flying', mph: 9 },
+];
+
+export const TRAVEL_PACES = ['fast', 'normal', 'careful'] as const;
+
+/** D&D-style pace multipliers applied to the mode's speed. */
+export const PACE_MULTIPLIER: Record<TravelPace, number> = {
+  fast: 4 / 3,
+  normal: 1,
+  careful: 2 / 3,
+};
+
+export const PACE_LABEL: Record<TravelPace, string> = {
+  fast: 'Fast',
+  normal: 'Normal',
+  careful: 'Careful',
+};
+
+/** Every mode available to a campaign: the built-ins plus its custom ones. */
+export function travelModes(custom: CustomTravelMode[] = []): TravelMode[] {
+  return [...TRAVEL_MODES, ...custom.map((m) => ({ id: m.id, label: m.name, mph: m.mph }))];
+}
+
+/** Look up a mode by id; falls back to the first built-in (on foot). */
+export function resolveTravelMode(id: string, custom: CustomTravelMode[] = []): TravelMode {
+  return travelModes(custom).find((m) => m.id === id) ?? TRAVEL_MODES[0]!;
+}
+
+/**
+ * In-game minutes to cross one hex. `mode` is a travel mode or a raw speed in
+ * miles per hour. Returns 0 for a zero-length hex or a standstill speed.
+ */
+export function minutesPerHex(
+  milesPerHex: number,
+  mode: TravelMode | number,
+  pace: TravelPace = 'normal',
+): number {
+  const mph = typeof mode === 'number' ? mode : mode.mph;
+  const effective = mph * PACE_MULTIPLIER[pace];
+  if (!(effective > 0) || !(milesPerHex > 0)) return 0;
+  return (milesPerHex / effective) * 60;
+}
+
+export interface TimeOfDay {
+  /** 1-based day number since campaign start. */
+  day: number;
+  /** 0-23. */
+  hour: number;
+  /** 0-59. */
+  minute: number;
+}
+
+export function timeOfDay(minutes: number): TimeOfDay {
+  const total = Math.max(0, Math.floor(minutes));
+  const dayMinutes = total % MINUTES_PER_DAY;
+  return {
+    day: Math.floor(total / MINUTES_PER_DAY) + 1,
+    hour: Math.floor(dayMinutes / 60),
+    minute: dayMinutes % 60,
+  };
+}
+
+export interface DaylightSettings {
+  sunriseHour?: number;
+  sunsetHour?: number;
+}
+
+/** Is the campaign clock currently after sunset / before sunrise? */
+export function isNight(minutes: number, settings: DaylightSettings = {}): boolean {
+  const sunrise = settings.sunriseHour ?? 6;
+  const sunset = settings.sunsetHour ?? 20;
+  const total = Math.max(0, Math.floor(minutes));
+  const hour = (total % MINUTES_PER_DAY) / 60;
+  if (sunrise <= sunset) return hour < sunrise || hour >= sunset;
+  // Inverted configuration (polar night and the like): daylight wraps midnight.
+  return hour >= sunset && hour < sunrise;
+}
+
+/** "Day 3" — deliberately calendar-free; #79 can rename this layer. */
+export function formatDay(minutes: number): string {
+  return `Day ${timeOfDay(minutes).day}`;
+}
+
+/** "6:40 PM" */
+export function formatTimeOfDay(minutes: number): string {
+  const { hour, minute } = timeOfDay(minutes);
+  const suffix = hour < 12 ? 'AM' : 'PM';
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:${String(minute).padStart(2, '0')} ${suffix}`;
+}
+
+/** "Day 3, 6:40 PM" */
+export function formatClock(minutes: number): string {
+  return `${formatDay(minutes)}, ${formatTimeOfDay(minutes)}`;
+}
+
+/** "8 hours", "45 minutes", "1 day 3 hours" — for time-advance log lines. */
+export function formatDuration(minutes: number): string {
+  const total = Math.max(0, Math.round(minutes));
+  if (total === 0) return 'no time';
+  const days = Math.floor(total / MINUTES_PER_DAY);
+  const hours = Math.floor((total % MINUTES_PER_DAY) / 60);
+  const mins = total % 60;
+  const parts: string[] = [];
+  if (days) parts.push(`${days} day${days === 1 ? '' : 's'}`);
+  if (hours) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`);
+  if (mins) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`);
+  return parts.join(' ');
+}
+
+/** Minutes the party has spent on their current hex, per the campaign clock. */
+export function minutesOnCurrentHex(time: CampaignTime): number {
+  if (!time.partyHex) return 0;
+  return Math.max(0, time.minutes - time.partyHex.arrivedMinutes);
+}


### PR DESCRIPTION
Closes #57

Adds the campaign clock: an in-game time base that travel spends, the DM can adjust, and later features (day/night tint #58, time-in-hex #59, last-visited #66, wiki timeline #65) can build on.

## Design

**Clock representation.** `campaign.time` is a JSON blob on the `campaign` table (additive `ensureColumn`), parsed by `CampaignTimeSchema`:

```
{ minutes, travelMode, pace, partyHex }
```

`minutes` is in-game minutes since campaign start (default `8*60` — campaigns open at 8:00 AM on day 1), so all date math is integer arithmetic and a fantasy calendar (#79) can be layered on top without touching storage. Dates render as "Day N"; no month names are hardcoded anywhere. The clock rides in `CampaignState.campaign`, so **players see it too** — no filter change needed beyond hiding visit records.

**Travel rules** live in `shared/src/rules/time.ts`: built-in modes (foot 3, horse 6, wagon 4, ship 5, flying 9 mph) plus optional `settings.customTravelModes: [{id,name,mph}]`; pace multipliers fast 4/3, normal 1, careful 2/3. `minutesPerHex(milesPerHex, mode, pace)` accepts a mode object or a raw mph. `timeOfDay`, `isNight` (configurable `settings.sunriseHour` 6 / `sunsetHour` 20), `formatDay`, `formatTimeOfDay`, `formatClock`, `formatDuration`.

**Travel advancement.** `advanceTravelClock(ctx, map, token, from, to, teleport)` runs alongside the existing `autoEncounterChecks` in both `token.move` and `move.resolve`, using the same `hexLine` path length. PC tokens only; teleports cost no time (but still relocate the party).

**Per-hex visit accounting.** New `hex_visit(map_id, q, r, first_arrived, last_arrived, total_minutes)` table, mirrored in `MapRuntime.visits`. `time.partyHex` (`{mapId,q,r,arrivedMinutes}`) tracks where the party stands. On each party move the previous hex is credited with `clock − arrivedMinutes` **before** the clock advances, so lingering time lands on the hex and travel time is charged to neither hex. The first PC token created also stamps `partyHex`, so the starting hex is tracked from the beginning. Visits reach the DM as `mapState.visits` and are stripped in `filterStateForViewer` (players get last-visited in #66).

**Commands** (`time.advance` / `time.set` / `time.config`, all DM-gated): advance logs `time` visibility `all` ("Time advances 8 hours — Day 1, 4:00 PM"), set logs `dm`, config is silent.

**Client.** `TimeControl` sits next to `ScaleControl`. Everyone sees `☀️/🌙 Day 3 · 6:40 PM`; the DM's click opens a compact popover with a travel-mode select, a 3-way pace segmented control, the derived minutes-per-hex for the current map, and +1h / +8h / +1 day / custom-minutes advance buttons. `LogTab` gains a `time` kind and filter.

## Tests

77 total (up 12): 4 shared clock tests (pace math, custom-mode resolution, day/time formatting, sunrise/sunset), 1 filter test (visits stripped, clock public), and 7 server tests (start time, multi-hex travel vs teleport, mode/pace applied, NPC moves ignored, DM gating + log text/visibility for advance and set, lingering accumulation with a restart-persistence check, DM-only visits in the snapshot).

`pnpm typecheck`, `pnpm test`, and `pnpm build` are green. The UI was not exercised in a live browser — ports 3000/5173 were occupied by a parallel session's dev server.

## Docs notes

- **New JSON blob column pattern held up well**: `campaign.time` needed only `ensureColumn` + a `CampaignTimeSchema.parse(safeJson(row.time))` in the runtime constructor. Worth noting that `CampaignRuntime`'s constructor row type is declared inline, so the new field was added there as `time?: string | null` — optional, so `Store.getCampaign`'s explicit row type (which doesn't list it) still assigns. Any future campaign column needs the same two-place edit.
- **Adding a field to `CampaignSettingsSchema` or `MapStateSchema` breaks the shared `rules.test.ts` fixture** (`fullState()` is a fully-typed literal, not a zod parse). Expect to update it whenever state types grow — the typecheck error points straight at it.
- **`filterStateForViewer` returns a hand-written object literal per map layer**, so a new `MapState` field must be added there explicitly or the player branch won't compile. That's the intended forcing function (you must decide player visibility), worth stating in the guide.
- **Log `kind` strings are open** — a new kind only needs `KIND_META` + `FILTERS` entries in `LogTab.tsx` to render nicely; unknown kinds fall back to a `·` bullet.
- **Ordering matters in the move handlers**: the clock advance must run after `executePartyMove` and credit the departed hex *before* advancing, or travel time gets attributed to the hex the party just left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
