### PR TITLE
Character manager dialog with player-editable info

### DIFF
--- a/packages/client/src/components/CharacterDialog.tsx
+++ b/packages/client/src/components/CharacterDialog.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import type { Character, CharacterExtra } from '@hexcrawl/shared';
+import { useSession } from '../stores/session.js';
+import { send } from '../ws.js';
+import { Button, Dialog, Field, Input, TextArea } from '../ui/kit.js';
+import { CharacterEditor } from './panels/CharactersTab.js';
+
+const EXTRA_FIELDS: Array<{
+  key: keyof CharacterExtra;
+  label: string;
+  placeholder: string;
+  rows: number;
+  hint?: string;
+}> = [
+  { key: 'bio', label: 'Bio', placeholder: 'Who are they, where are they from…', rows: 4 },
+  { key: 'appearance', label: 'Appearance', placeholder: 'What they look like, how they carry themselves…', rows: 3 },
+  { key: 'goals', label: 'Goals', placeholder: 'What they want, who they answer to…', rows: 3 },
+  { key: 'inventory', label: 'Inventory', placeholder: 'Notable gear, loot, coin…', rows: 4 },
+  {
+    key: 'notes',
+    label: 'Notes',
+    placeholder: 'Anything else worth remembering…',
+    rows: 4,
+    hint: 'Notes will sync to the campaign wiki in a future update.',
+  },
+];
+
+/**
+ * The full character sheet: skills (with roll buttons), speed, D&D Beyond
+ * sync, and the player-editable extras (bio/appearance/goals/inventory/
+ * notes). Opened from CharactersTab via the "Open sheet" affordance; the
+ * inline party-list editor keeps working alongside this for quick edits.
+ */
+export function CharacterDialog({ character, onClose }: { character: Character; onClose: () => void }) {
+  const role = useSession((s) => s.role);
+  const seatId = useSession((s) => s.seatId);
+  const state = useSession((s) => s.state);
+  const mySeat = state?.seats.find((s) => s.id === seatId);
+  const isDm = role === 'dm';
+  const isMine = mySeat?.characterId === character.id;
+  const canEdit = isDm || isMine;
+  const claimedBy = state?.seats.find((s) => s.characterId === character.id);
+
+  const patchExtra = (key: keyof CharacterExtra, value: string) => {
+    if (value === character.extra[key]) return;
+    send({
+      kind: 'character.update',
+      characterId: character.id,
+      patch: { extra: { [key]: value } as Partial<CharacterExtra> },
+    });
+  };
+
+  return (
+    <Dialog title={`${character.name}${isMine ? ' (you)' : ''} — character sheet`} onClose={onClose} wide>
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <span
+            className="w-12 h-12 rounded-full flex items-center justify-center text-xl shrink-0 border border-white/20"
+            style={{ background: character.color }}
+          >
+            {character.glyph || character.name.slice(0, 1).toUpperCase()}
+          </span>
+          <div className="min-w-0">
+            <p className="text-base font-semibold text-ink-100 truncate">{character.name}</p>
+            <p className="text-xs text-ink-400 truncate">
+              {claimedBy ? `Played by ${claimedBy.name}` : 'Unclaimed'}
+            </p>
+          </div>
+        </div>
+
+        <Field label="Speed (ft / round)">
+          {canEdit ? (
+            <Input
+              type="number"
+              min={0}
+              max={120}
+              className="!w-24"
+              defaultValue={character.speed}
+              onBlur={(e) => {
+                const v = Math.round(Number(e.target.value));
+                if (Number.isFinite(v) && v !== character.speed) {
+                  send({
+                    kind: 'character.update',
+                    characterId: character.id,
+                    patch: { speed: Math.min(120, Math.max(0, v)) },
+                  });
+                }
+              }}
+            />
+          ) : (
+            <p className="text-sm text-ink-100">{character.speed} ft</p>
+          )}
+        </Field>
+
+        <CharacterEditor character={character} readOnly={!canEdit} canRoll={canEdit} />
+
+        <div className="space-y-3 pt-3 border-t border-ink-700">
+          <p className="text-[11px] uppercase tracking-wider text-ink-400 font-semibold">
+            Character details
+          </p>
+          {EXTRA_FIELDS.map(({ key, label, placeholder, rows, hint }) => (
+            <Field key={key} label={label}>
+              {canEdit ? (
+                <TextArea
+                  rows={rows}
+                  defaultValue={character.extra[key]}
+                  maxLength={5000}
+                  placeholder={placeholder}
+                  onBlur={(e) => patchExtra(key, e.target.value)}
+                />
+              ) : character.extra[key] ? (
+                <p className="text-sm text-ink-100 whitespace-pre-wrap">{character.extra[key]}</p>
+              ) : (
+                <p className="text-sm text-ink-500 italic">—</p>
+              )}
+              {hint && <p className="text-[11px] text-ink-500 mt-1">{hint}</p>}
+            </Field>
+          ))}
+        </div>
+
+        <div className="flex justify-end pt-1">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/panels/CharactersTab.tsx
+++ b/packages/client/src/components/panels/CharactersTab.tsx
@@ -4,6 +4,7 @@ import { useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { Button, EmptyNote, Field, Input, Section, cx } from '../../ui/kit.js';
 import { SendTokenButton } from '../SendTokenButton.js';
+import { CharacterDialog } from '../CharacterDialog.js';
 
 const CHARACTER_COLORS = [
   '#e05555', '#e08f3c', '#c9a24b', '#6fa06b', '#4a9d9c', '#5b8dd9', '#8b7fd4', '#c56bb8',
@@ -15,6 +16,7 @@ export function CharactersTab() {
   const seatId = useSession((s) => s.seatId);
   const [creating, setCreating] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [sheetCharacterId, setSheetCharacterId] = useState<string | null>(null);
 
   if (!state) return null;
   const mySeat = state.seats.find((s) => s.id === seatId);
@@ -70,9 +72,31 @@ export function CharactersTab() {
                   </button>
                   {canEdit && <RollSkillButton characterId={ch.id} skill="perception" />}
                   {canCommand && <SendTokenButton tokenId={token.id} name={ch.name} />}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="!px-1.5 !py-0.5 shrink-0 mr-1"
+                    title="Open character sheet"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSheetCharacterId(ch.id);
+                    }}
+                  >
+                    📜
+                  </Button>
                 </div>
                 {open && (
                   <div className="border-t border-ink-700 p-2.5">
+                    {isMine && (
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        className="w-full mb-2.5"
+                        onClick={() => setSheetCharacterId(ch.id)}
+                      >
+                        Open sheet — bio, goals, inventory &amp; more
+                      </Button>
+                    )}
                     {!claimedBy && !isDm && !mySeat?.characterId && (
                       <Button
                         variant="primary"
@@ -116,6 +140,14 @@ export function CharactersTab() {
         </div>
       </Section>
       {creating && <NewCharacterForm onDone={() => setCreating(false)} />}
+      {sheetCharacterId &&
+        (() => {
+          const sheetCharacter = state.characters.find((c) => c.id === sheetCharacterId);
+          if (!sheetCharacter) return null;
+          return (
+            <CharacterDialog character={sheetCharacter} onClose={() => setSheetCharacterId(null)} />
+          );
+        })()}
     </div>
   );
 }
@@ -127,7 +159,7 @@ export function CharactersTab() {
  * the DM (any character) or a player's own claimed character. Results arrive
  * as a 'check' log toast (see ws.ts) — no result UI needed here.
  */
-function RollSkillButton({
+export function RollSkillButton({
   characterId,
   skill,
   className,
@@ -164,7 +196,15 @@ function NewCharacterForm({ onDone }: { onDone: () => void }) {
     if (!name.trim()) return;
     send({
       kind: 'character.create',
-      character: { name: name.trim(), color, glyph: '', speed: 30, skills: {}, ddbId: null },
+      character: {
+        name: name.trim(),
+        color,
+        glyph: '',
+        speed: 30,
+        skills: {},
+        ddbId: null,
+        extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' },
+      },
     });
     onDone();
   };
@@ -208,7 +248,7 @@ function NewCharacterForm({ onDone }: { onDone: () => void }) {
  * One-click skill sync from a PUBLIC D&D Beyond sheet. The URL/id persists on
  * the character so future syncs are a single click.
  */
-function DdbSync({ character }: { character: Character }) {
+export function DdbSync({ character }: { character: Character }) {
   const [value, setValue] = useState(character.ddbId ?? '');
   const [busy, setBusy] = useState(false);
   const campaignId = useSession((s) => s.state?.campaign.id);
@@ -260,7 +300,7 @@ function DdbSync({ character }: { character: Character }) {
   );
 }
 
-function CharacterEditor({
+export function CharacterEditor({
   character,
   readOnly,
   canRoll,

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -239,6 +239,8 @@ function migrate(d: DB): void {
   ensureColumn(d, 'content', 'known_location', 'INTEGER NOT NULL DEFAULT 0');
   // Campaign clock (issue #57): JSON blob, zod defaults make it migration-free.
   ensureColumn(d, 'campaign', 'time', "TEXT NOT NULL DEFAULT '{}'");
+  // Character sheet extras (issue #63): JSON blob (bio/appearance/goals/inventory/notes).
+  ensureColumn(d, 'character', 'extra', "TEXT NOT NULL DEFAULT '{}'");
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -57,7 +57,7 @@ describe('campaign + seats', () => {
   it('players claim characters exclusively', () => {
     dm({
       kind: 'character.create',
-      character: { name: 'Ash', color: '#ff0000', glyph: '🔥', speed: 30, skills: {} },
+      character: { name: 'Ash', color: '#ff0000', glyph: '🔥', speed: 30, skills: {}, extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' } },
     } as never);
     const charId = [...runtime.characters.keys()][0]!;
     const p1 = runtime.createSeat('player', 'Alice');
@@ -109,7 +109,7 @@ function setupPartyWithScout(): { mapId: string; charId: string; tokenId: string
   const mapId = activeMapId();
   dm({
     kind: 'character.create',
-    character: { name: 'Scout', color: '#00aa00', glyph: '🏹', speed: 30, skills: { perception: 4, survival: 2 } },
+    character: { name: 'Scout', color: '#00aa00', glyph: '🏹', speed: 30, skills: { perception: 4, survival: 2 }, extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' } },
   } as never);
   const charId = [...runtime.characters.keys()][0]!;
   const playerSeat = runtime.createSeat('player', 'Alice');
@@ -805,7 +805,7 @@ describe('clue sharing', () => {
     const { mapId, charId, tokenId, playerSeat } = setupPartyWithScout();
     dm({
       kind: 'character.create',
-      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {} },
+      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {}, extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' } },
     } as never);
     const bardId = [...runtime.characters.keys()].find((id) => id !== charId)!;
     dm({
@@ -859,7 +859,7 @@ describe('per-character log filtering', () => {
     // Second player with their own character.
     dm({
       kind: 'character.create',
-      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {} },
+      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {}, extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' } },
     } as never);
     const bardId = [...runtime.characters.keys()].find((id) => id !== charId)!;
     const bardSeat = runtime.createSeat('player', 'Bob');
@@ -890,6 +890,91 @@ describe('per-character log filtering', () => {
       seatId: bardSeat.id, role: 'player', characterId: bardId,
     });
     expect(bardView2.log.some((e) => e.id === narration.id)).toBe(true);
+  });
+});
+
+describe('character sheet extras (issue #63)', () => {
+  it('defaults to empty strings and round-trips through a DB reload', () => {
+    const { charId } = setupPartyWithScout();
+    expect(runtime.characters.get(charId)!.extra).toEqual({
+      bio: '', appearance: '', goals: '', inventory: '', notes: '',
+    });
+
+    dm({
+      kind: 'character.update',
+      characterId: charId,
+      patch: { extra: { bio: 'A wandering ranger.', notes: 'Owes the guild a favor.' } },
+    } as never);
+
+    // Simulate a server restart: a fresh Store over the same underlying db.
+    const db = (store as unknown as { db: unknown }).db;
+    const reloaded = new Store(db as never).getCampaign(runtime.id)!;
+    expect(reloaded.characters.get(charId)!.extra).toEqual({
+      bio: 'A wandering ranger.',
+      appearance: '',
+      goals: '',
+      inventory: '',
+      notes: 'Owes the guild a favor.',
+    });
+  });
+
+  it('merges an extra sub-patch over the existing value instead of replacing it', () => {
+    const { charId } = setupPartyWithScout();
+    dm({
+      kind: 'character.update',
+      characterId: charId,
+      patch: {
+        extra: {
+          bio: 'A wandering ranger.',
+          appearance: 'Weathered, green cloak.',
+          goals: 'Find the missing caravan.',
+          inventory: 'Longbow, 20 arrows.',
+          notes: 'Trusts no one in Elturel.',
+        },
+      },
+    } as never);
+
+    // A one-field patch must not blank out its siblings (zod v4 `.partial()`
+    // gotcha for the outer schema; here it's our own shallow-merge in the
+    // handler that has to get this right for the nested `extra` object).
+    dm({
+      kind: 'character.update',
+      characterId: charId,
+      patch: { extra: { notes: 'Now trusts the barkeep.' } },
+    } as never);
+
+    expect(runtime.characters.get(charId)!.extra).toEqual({
+      bio: 'A wandering ranger.',
+      appearance: 'Weathered, green cloak.',
+      goals: 'Find the missing caravan.',
+      inventory: 'Longbow, 20 arrows.',
+      notes: 'Now trusts the barkeep.',
+    });
+  });
+
+  it('a player can edit their own extra info but not another character\'s', () => {
+    const { charId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'character.create',
+      character: { name: 'Bard', color: '#0000aa', glyph: '🎻', speed: 30, skills: {}, extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' } },
+    } as never);
+    const bardId = [...runtime.characters.keys()].find((id) => id !== charId)!;
+
+    asSeat(playerSeat, {
+      kind: 'character.update',
+      characterId: charId,
+      patch: { extra: { bio: 'Written by their own player.' } },
+    } as never);
+    expect(runtime.characters.get(charId)!.extra.bio).toBe('Written by their own player.');
+
+    expect(() =>
+      asSeat(playerSeat, {
+        kind: 'character.update',
+        characterId: bardId,
+        patch: { extra: { bio: 'Trying to edit someone else.' } },
+      } as never),
+    ).toThrow(/own character/);
+    expect(runtime.characters.get(bardId)!.extra.bio).toBe('');
   });
 });
 

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -27,6 +27,7 @@ import type {
 import {
   CampaignSettingsSchema,
   CampaignTimeSchema,
+  CharacterExtraSchema,
   EncounterCheckConfigSchema,
   GateSchema,
   GridStyleSchema,
@@ -166,6 +167,7 @@ export class CampaignRuntime {
         speed: c.speed as number,
         skills: SkillsSchema.parse(safeJson(c.skills as string)),
         ddbId: (c.ddb_id as string | null) ?? null,
+        extra: CharacterExtraSchema.parse(safeJson(c.extra as string)),
       });
     }
     for (const m of d
@@ -610,8 +612,8 @@ export class CampaignRuntime {
     this.characters.set(character.id, character);
     this.db
       .prepare(
-        `INSERT INTO character (id, campaign_id, name, color, glyph, speed, skills, ddb_id) VALUES (?,?,?,?,?,?,?,?)
-         ON CONFLICT(id) DO UPDATE SET name=excluded.name, color=excluded.color, glyph=excluded.glyph, speed=excluded.speed, skills=excluded.skills, ddb_id=excluded.ddb_id`,
+        `INSERT INTO character (id, campaign_id, name, color, glyph, speed, skills, ddb_id, extra) VALUES (?,?,?,?,?,?,?,?,?)
+         ON CONFLICT(id) DO UPDATE SET name=excluded.name, color=excluded.color, glyph=excluded.glyph, speed=excluded.speed, skills=excluded.skills, ddb_id=excluded.ddb_id, extra=excluded.extra`,
       )
       .run(
         character.id,
@@ -622,6 +624,7 @@ export class CampaignRuntime {
         character.speed,
         JSON.stringify(character.skills),
         character.ddbId,
+        JSON.stringify(character.extra),
       );
   }
 

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -422,7 +422,10 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     if (ctx.seat.role !== 'dm' && ctx.seat.characterId !== cmd.characterId) {
       throw new Error('You can only edit your own character');
     }
-    ctx.runtime.upsertCharacter({ ...existing, ...cmd.patch, id: existing.id });
+    // `extra` is a sub-object: merge over the existing value so a one-field
+    // patch (e.g. just `notes`) doesn't blank out its siblings.
+    const extra = cmd.patch.extra ? { ...existing.extra, ...cmd.patch.extra } : existing.extra;
+    ctx.runtime.upsertCharacter({ ...existing, ...cmd.patch, id: existing.id, extra });
     // Skill changes can open passive gates anywhere the character stands.
     const discoveries = ctx.runtime.campaign.activeMapId
       ? evaluateKnowledge(ctx.runtime, ctx.runtime.campaign.activeMapId, [cmd.characterId])

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -164,6 +164,20 @@ export const SeatPublicSchema = z.object({
 });
 export type SeatPublic = z.infer<typeof SeatPublicSchema>;
 
+/**
+ * Player-editable free-form character info. Kept as plain strings — the
+ * `notes` field is the storage shape the future wiki-notes sync (issue #64)
+ * will read from, so it stays a simple string rather than rich content.
+ */
+export const CharacterExtraSchema = z.object({
+  bio: z.string().max(5000).default(''),
+  appearance: z.string().max(5000).default(''),
+  goals: z.string().max(5000).default(''),
+  inventory: z.string().max(5000).default(''),
+  notes: z.string().max(5000).default(''),
+});
+export type CharacterExtra = z.infer<typeof CharacterExtraSchema>;
+
 export const CharacterSchema = z.object({
   id: z.string(),
   name: z.string().min(1).max(60),
@@ -173,6 +187,8 @@ export const CharacterSchema = z.object({
   skills: SkillsSchema,
   /** D&D Beyond character id, for one-click skill sync (public sheets only). */
   ddbId: z.string().nullable().default(null),
+  /** Player-editable sheet extras: bio, appearance, goals, inventory, notes. */
+  extra: CharacterExtraSchema.default({ bio: '', appearance: '', goals: '', inventory: '', notes: '' }),
 });
 export type Character = z.infer<typeof CharacterSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -52,6 +52,16 @@ const CampaignSettingsPatchSchema = z
   })
   .partial();
 
+const CharacterExtraPatchSchema = z
+  .object({
+    bio: z.string().max(5000),
+    appearance: z.string().max(5000),
+    goals: z.string().max(5000),
+    inventory: z.string().max(5000),
+    notes: z.string().max(5000),
+  })
+  .partial();
+
 const CharacterPatchSchema = z
   .object({
     name: z.string().min(1).max(60),
@@ -60,6 +70,7 @@ const CharacterPatchSchema = z
     speed: z.number().int().min(0).max(120),
     skills: z.record(z.string(), z.number().int().min(-10).max(20)),
     ddbId: z.string().nullable(),
+    extra: CharacterExtraPatchSchema,
   })
   .partial();
 

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -51,6 +51,7 @@ const scout: Character = {
   speed: 30,
   skills: { perception: 4, survival: 2 },
   ddbId: null,
+  extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' },
 };
 
 describe('gates', () => {


### PR DESCRIPTION
Closes #63

## Summary
- `CharacterSchema` gains `extra: {bio, appearance, goals, inventory, notes}` — five strings, max 5000 chars each, zod-defaulted to `''`. Backed by an additive `character.extra TEXT NOT NULL DEFAULT '{}'` column (JSON blob, parsed/persisted the same way `skills` already is).
- `CharacterPatchSchema` gets a default-free `extra` sub-patch. The `character.update` handler now merges `patch.extra` over the character's existing `extra` (rather than the outer shallow spread replacing it wholesale), so a one-field patch like `{extra: {notes: '...'}}` doesn't blank out bio/appearance/goals/inventory.
- New `CharacterDialog.tsx`: a big-popup character sheet (same `Dialog` pattern as `ContentDialog`) opened from an "Open sheet" button on each party row in `CharactersTab` (and a more prominent one for a player's own claimed character). It shows the header (glyph/color/name/played-by), an editable speed field, the existing skills grid with roll buttons and D&D Beyond sync (reused via the now-exported `CharacterEditor`/`RollSkillButton`/`DdbSync` from `CharactersTab.tsx`), then the five extra-info fields as labeled textareas — editable (save-on-blur) for the DM or the owning player, read-only text for everyone else. The inline party-list editor keeps working unchanged.
- The Notes field carries a one-line hint that it's the future wiki-sync storage shape (issue #64) — kept as a plain string for that reason.

## Decisions
- Extra info is visible to all players (like skills already are) but only editable by the DM or the owning player — matches the existing `canEdit` pattern in `CharactersTab`.
- Reused `CharacterEditor` wholesale inside the dialog (skills grid + DDB sync) rather than duplicating it, adding only a Speed field and the extra-info section around it in the new dialog.
- Left the inline sidebar editor in place per the issue — the dialog is the richer view, not a replacement.

## Test plan
- `pnpm typecheck` — green across shared/server/client.
- `pnpm test` — 35 shared + 45 server tests pass (3 new: extra defaults + DB-reload roundtrip, sub-patch merge semantics keeping siblings, player-cannot-edit-another-character's-extra).
- Did not exercise the dialog in a live browser this run — dev ports 3000/5173 were held by other agents' sessions in sibling worktrees; the UI is built from already-tested `Dialog`/`Field`/`TextArea`/`CharacterEditor` primitives.

## Docs notes
No AI-DEVELOPMENT.md changes needed — this follows the documented "reuse a JSON blob column" pattern for map/campaign settings, applied to `character`, and the zod v4 `.partial()` default-free patch gotcha already called out there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)