### PR TITLE
Player-placed map pins and notes

### DIFF
--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -44,6 +44,8 @@ export function InspectTab() {
   const contents = ms.contents.filter((c) => c.q === hex.q && c.r === hex.r);
   const isDm = role === 'dm';
   const myCharacterId = state.seats.find((s) => s.id === seatId)?.characterId ?? null;
+  // Players have no toolbar; a claimed character is the bar for annotating.
+  const canAddNote = !isDm && !!myCharacterId;
 
   return (
     <div>
@@ -99,15 +101,26 @@ export function InspectTab() {
         </Section>
       )}
 
-      {markers.length > 0 && (
-        <Section title="Markers">
+      {(markers.length > 0 || canAddNote) && (
+        <Section title={isDm ? 'Markers' : 'Notes & markers'}>
           <ul className="space-y-1.5">
-            {markers.map((m) => (
-              <li key={m.id} className="flex items-center gap-2 text-sm">
-                <span className="text-base">{m.glyph}</span>
-                <MarkerLabel markerId={m.id} label={m.label} editable={isDm} />
-                {isDm && (
-                  <>
+            {markers.map((m) => {
+              // Players may edit/delete the party notes their own seat placed;
+              // the DM moderates everything.
+              const mine = m.playerPlaced && m.ownerSeatId === seatId;
+              const owner = m.playerPlaced
+                ? state.seats.find((s) => s.id === m.ownerSeatId)?.name
+                : null;
+              return (
+                <li key={m.id} className="flex items-center gap-2 text-sm">
+                  <span className="text-base">{m.glyph}</span>
+                  <MarkerLabel markerId={m.id} label={m.label} editable={isDm || mine} />
+                  {owner && !mine && (
+                    <span className="text-[11px] text-ink-400 shrink-0" title="Party note">
+                      — {owner}
+                    </span>
+                  )}
+                  {isDm && (
                     <button
                       className="text-xs text-ink-400 hover:text-ink-100 cursor-pointer"
                       title={m.dmOnly ? 'DM-only — click to share' : 'Visible to players — click to hide'}
@@ -117,17 +130,21 @@ export function InspectTab() {
                     >
                       {m.dmOnly ? '🚫' : '👁️'}
                     </button>
+                  )}
+                  {(isDm || mine) && (
                     <button
                       className="text-xs text-ink-400 hover:text-ember-500 cursor-pointer ml-auto"
+                      title={mine && !isDm ? 'Delete your note' : 'Delete marker'}
                       onClick={() => send({ kind: 'marker.delete', markerId: m.id })}
                     >
                       ✕
                     </button>
-                  </>
-                )}
-              </li>
-            ))}
+                  )}
+                </li>
+              );
+            })}
           </ul>
+          {canAddNote && <AddPartyNote mapId={map.id} hex={hex} />}
         </Section>
       )}
 
@@ -320,6 +337,71 @@ function SearchHex({ mapId, hex, isDm }: { mapId: string; hex: { q: number; r: n
         </Button>
       </div>
     </Section>
+  );
+}
+
+/** Glyphs a player can pick for a party note (issue #74). */
+const NOTE_GLYPHS: { glyph: string; title: string }[] = [
+  { glyph: '📌', title: 'Note' },
+  { glyph: '⚠️', title: 'Danger' },
+  { glyph: '⛺', title: 'Camp' },
+];
+
+/**
+ * Player-side "add a note here": drops a party-wide marker on the inspected
+ * hex. The server forces ownership and player visibility, so this only needs
+ * the glyph and the text.
+ */
+function AddPartyNote({ mapId, hex }: { mapId: string; hex: { q: number; r: number } }) {
+  const [glyph, setGlyph] = React.useState(NOTE_GLYPHS[0]!.glyph);
+  const [text, setText] = React.useState('');
+  const place = () => {
+    const label = text.trim();
+    if (!label) return;
+    send({
+      kind: 'marker.place',
+      marker: { mapId, q: hex.q, r: hex.r, glyph, label, dmOnly: false },
+    });
+    setText('');
+  };
+  return (
+    <div className="mt-2 pt-2 border-t border-ink-700">
+      <div className="flex gap-1.5">
+        <div className="flex gap-0.5">
+          {NOTE_GLYPHS.map((g) => (
+            <button
+              key={g.glyph}
+              title={g.title}
+              onClick={() => setGlyph(g.glyph)}
+              className={cx(
+                'w-7 h-7 rounded border text-sm cursor-pointer',
+                glyph === g.glyph
+                  ? 'border-brass-500 bg-brass-500/15'
+                  : 'border-ink-700 hover:bg-ink-700',
+              )}
+            >
+              {g.glyph}
+            </button>
+          ))}
+        </div>
+        <input
+          className="flex-1 min-w-0 bg-ink-900 border border-ink-600 rounded px-2 py-1 text-sm text-ink-100"
+          placeholder="Add a note for the party…"
+          maxLength={120}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') place();
+          }}
+        />
+        <Button size="sm" variant="primary" onClick={place}>
+          Pin
+        </Button>
+      </div>
+      <p className="text-[11px] text-ink-400 mt-1">
+        Party notes are visible to everyone at the table.
+      </p>
+    </div>
   );
 }
 

--- a/packages/client/src/components/panels/JournalTab.tsx
+++ b/packages/client/src/components/panels/JournalTab.tsx
@@ -14,6 +14,9 @@ export function JournalTab() {
     (c): c is ContentPlayerView => !isFullContent(c),
   );
   const narrations = state.log.filter((l) => l.kind === 'narration');
+  // Party notes the players pinned themselves (issue #74) — findable without
+  // scanning the map.
+  const partyNotes = (state.mapState?.markers ?? []).filter((m) => m.playerPlaced);
   const trailSigns = state.mapState?.trailSigns ?? [];
   const trails: { trailId: string; glyph: string; cells: { q: number; r: number }[] }[] = [];
   for (const s of trailSigns) {
@@ -58,6 +61,38 @@ export function JournalTab() {
               </ul>
             </button>
           ))}
+        </div>
+      </Section>
+
+      <Section title="Party notes">
+        {partyNotes.length === 0 && (
+          <EmptyNote>
+            No party notes on this map yet — pin one from a hex in the Inspect tab.
+          </EmptyNote>
+        )}
+        <div className="space-y-1.5">
+          {partyNotes.map((n) => {
+            const owner = state.seats.find((s) => s.id === n.ownerSeatId)?.name;
+            return (
+              <button
+                key={n.id}
+                className="w-full text-left bg-ink-850 border border-ink-700 rounded-lg px-2.5 py-2 cursor-pointer hover:border-ink-600"
+                onClick={() => selectHex({ q: n.q, r: n.r })}
+                title="Show on map"
+              >
+                <div className="flex items-center gap-2">
+                  <span>{n.glyph}</span>
+                  <span className="text-sm text-ink-100 truncate flex-1">
+                    {n.label || '(no text)'}
+                  </span>
+                  <span className="text-xs text-ink-400 shrink-0">
+                    {n.q},{n.r}
+                  </span>
+                </div>
+                {owner && <span className="text-[11px] text-ink-400">— {owner}</span>}
+              </button>
+            );
+          })}
         </div>
       </Section>
 

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -44,6 +44,8 @@ const STROKE_FLUSH_MS = 180;
 const PIN_BASE_FONT = 32;
 /** Minimum on-screen token diameter in px. */
 const TOKEN_MIN_SCREEN = 26;
+/** Tag colour for a party note whose owner has no character colour. */
+const NOTE_DEFAULT_TINT = 0x8fb4ff;
 
 type PinContainer = Container & {
   __pin?: { worldSize: number; minScreen: number };
@@ -822,6 +824,9 @@ export class CanvasEngine {
     glyph: string;
     label?: string;
     chip: boolean;
+    /** Player-placed party note: rounded-rect tag tinted with the owner's colour. */
+    note?: boolean;
+    tint?: number;
     dmOnly?: boolean;
     worldSize: number;
     minScreen: number;
@@ -833,6 +838,21 @@ export class CanvasEngine {
       chip.fill({ color: 0x12151d, alpha: 0.88 });
       chip.stroke({ width: PIN_BASE_FONT * 0.07, color: 0xdcb968, alpha: 0.95 });
       pin.addChild(chip);
+    }
+    if (opts.note) {
+      const tint = opts.tint ?? NOTE_DEFAULT_TINT;
+      const w = PIN_BASE_FONT * 1.6;
+      const h = PIN_BASE_FONT * 1.3;
+      const tag = new Graphics();
+      tag.roundRect(-w / 2, -h / 2, w, h, PIN_BASE_FONT * 0.32);
+      tag.fill({ color: 0x12151d, alpha: 0.82 });
+      tag.stroke({ width: PIN_BASE_FONT * 0.1, color: tint, alpha: 0.95 });
+      pin.addChild(tag);
+      // Owner-coloured dog-ear so a note reads as a note even at a glance.
+      const corner = new Graphics();
+      corner.circle(w / 2 - PIN_BASE_FONT * 0.12, -h / 2 + PIN_BASE_FONT * 0.12, PIN_BASE_FONT * 0.2);
+      corner.fill({ color: tint, alpha: 0.95 });
+      pin.addChild(corner);
     }
     const text = new Text({
       text: opts.glyph,
@@ -870,6 +890,18 @@ export class CanvasEngine {
     }
     (pin as PinContainer).__pin = { worldSize: opts.worldSize, minScreen: opts.minScreen };
     return pin;
+  }
+
+  /** seatId → the colour of the character that seat plays (for party notes). */
+  private seatTints(): Map<string, number> {
+    const st = useSession.getState().state;
+    const colors = new Map((st?.characters ?? []).map((c) => [c.id, c.color]));
+    const tints = new Map<string, number>();
+    for (const seat of st?.seats ?? []) {
+      const hex = seat.characterId ? colors.get(seat.characterId) : undefined;
+      if (hex) tints.set(seat.id, Number.parseInt(hex.replace('#', ''), 16));
+    }
+    return tints;
   }
 
   /** Disabled content: dimmed with a red X — staged, not live for players. */
@@ -971,6 +1003,8 @@ export class CanvasEngine {
       list.push(m);
       byHex.set(key, list);
     }
+    // Party notes (issue #74) get a tag in the placing player's colour.
+    const noteTint = this.lastMarkers.some((m) => m.playerPlaced) ? this.seatTints() : null;
     for (const markers of byHex.values()) {
       markers.forEach((m, i) => {
         const center = hexToPixel(this.layout!, { q: m.q, r: m.r });
@@ -978,9 +1012,12 @@ export class CanvasEngine {
         const pin = this.buildPin({
           glyph: m.glyph,
           chip: false,
+          note: m.playerPlaced,
+          tint: m.playerPlaced ? noteTint?.get(m.ownerSeatId ?? '') : undefined,
+          label: m.playerPlaced && m.label ? truncateLabel(m.label) : undefined,
           dmOnly: m.dmOnly,
-          worldSize: size * 1.0,
-          minScreen: 19,
+          worldSize: size * (m.playerPlaced ? 1.15 : 1.0),
+          minScreen: m.playerPlaced ? 21 : 19,
         });
         pin.position.set(center.x + spread, center.y + size * 0.55);
         if (fogByKey) {
@@ -1685,8 +1722,18 @@ function fogCellsEqual(a: FogCell[], b: FogCell[]): boolean {
   return true;
 }
 
+/**
+ * `shallowEqual` walks every key of the marker, so fields added to
+ * `MarkerSchema` (playerPlaced / ownerSeatId) are diffed without touching
+ * this comparator — unlike the explicit-field ones below.
+ */
 function markersEqual(a: Marker[], b: Marker[]): boolean {
   return a.length === b.length && a.every((m, i) => shallowEqual(m, b[i]!));
+}
+
+/** Party-note captions render on the map; keep them to a glance. */
+function truncateLabel(label: string): string {
+  return label.length > 24 ? label.slice(0, 23) + '…' : label;
 }
 
 function contentsEqual(

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -239,6 +239,9 @@ function migrate(d: DB): void {
   ensureColumn(d, 'content', 'known_location', 'INTEGER NOT NULL DEFAULT 0');
   // Campaign clock (issue #57): JSON blob, zod defaults make it migration-free.
   ensureColumn(d, 'campaign', 'time', "TEXT NOT NULL DEFAULT '{}'");
+  // Player-placed party notes (issue #74): existing markers are all DM-placed.
+  ensureColumn(d, 'marker', 'player_placed', 'INTEGER NOT NULL DEFAULT 0');
+  ensureColumn(d, 'marker', 'owner_seat_id', 'TEXT');
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -966,6 +966,153 @@ describe('prep mode (pause player map sync)', () => {
   });
 });
 
+describe('player-placed party notes (issue #74)', () => {
+  function markers() {
+    return [...runtime.requireMap(activeMapId()).markers.values()];
+  }
+
+  it('lets a player pin a note, forcing party visibility and seat ownership', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      // A player claiming dmOnly / someone else's ownership is overridden.
+      marker: { mapId, q: 2, r: 1, glyph: '📌', label: 'We camped here', dmOnly: true, ownerSeatId: dmSeat.id },
+    } as never);
+    const note = markers()[0]!;
+    expect(note.playerPlaced).toBe(true);
+    expect(note.ownerSeatId).toBe(playerSeat.id);
+    expect(note.dmOnly).toBe(false);
+  });
+
+  it('shows a note to the whole party, not just its author', () => {
+    const { mapId, charId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'fog.set', mapId, cells: [{ q: 2, r: 1 }], state: 'explored' } as never);
+    const other = runtime.createSeat('player', 'Bob');
+    asSeat(other, {
+      kind: 'marker.place',
+      marker: { mapId, q: 2, r: 1, glyph: '⚠️', label: 'Wyverns', dmOnly: false },
+    } as never);
+    const view = filterStateForViewer(runtime.buildFullState(), {
+      seatId: playerSeat.id, role: 'player', characterId: charId,
+    });
+    expect(view.mapState!.markers.map((m) => m.label)).toEqual(['Wyverns']);
+  });
+
+  it('DM markers keep their DM-only default when the DM places them', () => {
+    const { mapId } = setupPartyWithScout();
+    dm({
+      kind: 'marker.place',
+      marker: { mapId, q: 0, r: 0, glyph: '💀', label: 'Ambush', dmOnly: true },
+    } as never);
+    const marker = markers()[0]!;
+    expect(marker.dmOnly).toBe(true);
+    expect(marker.playerPlaced).toBe(false);
+    expect(marker.ownerSeatId).toBeNull();
+  });
+
+  it('lets a player edit and delete their own note only', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    const other = runtime.createSeat('player', 'Bob');
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      marker: { mapId, q: 1, r: 1, glyph: '📌', label: 'Mine', dmOnly: false },
+    } as never);
+    const noteId = markers()[0]!.id;
+
+    asSeat(playerSeat, { kind: 'marker.update', markerId: noteId, patch: { label: 'Edited' } } as never);
+    expect(runtime.findMarker(noteId)!.label).toBe('Edited');
+
+    expect(() =>
+      asSeat(other, { kind: 'marker.update', markerId: noteId, patch: { label: 'Hijacked' } } as never),
+    ).toThrow(/own notes/);
+    expect(() => asSeat(other, { kind: 'marker.delete', markerId: noteId } as never)).toThrow(
+      /own notes/,
+    );
+    expect(runtime.findMarker(noteId)!.label).toBe('Edited');
+
+    asSeat(playerSeat, { kind: 'marker.delete', markerId: noteId } as never);
+    expect(runtime.findMarker(noteId)).toBeNull();
+  });
+
+  it('refuses to let a player touch a DM marker, or hide their own note', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    dm({
+      kind: 'marker.place',
+      marker: { mapId, q: 0, r: 0, glyph: '⭐', label: 'DM', dmOnly: false },
+    } as never);
+    const dmMarkerId = markers()[0]!.id;
+    expect(() =>
+      asSeat(playerSeat, { kind: 'marker.update', markerId: dmMarkerId, patch: { label: 'nope' } } as never),
+    ).toThrow(/own notes/);
+    expect(() =>
+      asSeat(playerSeat, { kind: 'marker.delete', markerId: dmMarkerId } as never),
+    ).toThrow(/own notes/);
+
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      marker: { mapId, q: 1, r: 1, glyph: '📌', label: 'Mine', dmOnly: false },
+    } as never);
+    const noteId = markers().find((m) => m.playerPlaced)!.id;
+    asSeat(playerSeat, { kind: 'marker.update', markerId: noteId, patch: { dmOnly: true } } as never);
+    expect(runtime.findMarker(noteId)!.dmOnly).toBe(false);
+  });
+
+  it('lets the DM moderate a player note', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      marker: { mapId, q: 1, r: 1, glyph: '📌', label: 'Rude', dmOnly: false },
+    } as never);
+    const noteId = markers()[0]!.id;
+    dm({ kind: 'marker.update', markerId: noteId, patch: { label: 'Tidied' } } as never);
+    expect(runtime.findMarker(noteId)!.label).toBe('Tidied');
+    dm({ kind: 'marker.delete', markerId: noteId } as never);
+    expect(runtime.findMarker(noteId)).toBeNull();
+  });
+
+  it('persists ownership across a reload', () => {
+    const { mapId, playerSeat } = setupPartyWithScout();
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      marker: { mapId, q: 3, r: 0, glyph: '⛺', label: 'Camp', dmOnly: false },
+    } as never);
+    const db = (store as unknown as { db: unknown }).db;
+    const reloaded = new Store(db as never).getCampaign(runtime.id)!;
+    const note = [...reloaded.requireMap(mapId).markers.values()][0]!;
+    expect(note.playerPlaced).toBe(true);
+    expect(note.ownerSeatId).toBe(playerSeat.id);
+  });
+
+  it('stays live for players through a prep-mode pause', () => {
+    const { mapId, charId, playerSeat } = setupPartyWithScout();
+    dm({ kind: 'fog.set', mapId, cells: [{ q: 2, r: 1 }, { q: 3, r: 1 }], state: 'explored' } as never);
+    dm({ kind: 'campaign.update', settings: { pausePlayerMapSync: true } } as never);
+
+    // DM prep during the pause stays hidden; the player's own note does not.
+    dm({
+      kind: 'marker.place',
+      marker: { mapId, q: 3, r: 1, glyph: '⭐', label: 'Prep', dmOnly: false },
+    } as never);
+    asSeat(playerSeat, {
+      kind: 'marker.place',
+      marker: { mapId, q: 2, r: 1, glyph: '📌', label: 'Note', dmOnly: false },
+    } as never);
+
+    const viewNow = () =>
+      filterStateForViewer(runtime.applyPlayerFreeze(runtime.buildFullState()), {
+        seatId: playerSeat.id, role: 'player', characterId: charId,
+      });
+    expect(viewNow().mapState!.markers.map((m) => m.label)).toEqual(['Note']);
+
+    // Edits and deletes of a live note also land during the pause.
+    const noteId = markers().find((m) => m.playerPlaced)!.id;
+    asSeat(playerSeat, { kind: 'marker.update', markerId: noteId, patch: { label: 'Edited' } } as never);
+    expect(viewNow().mapState!.markers.map((m) => m.label)).toEqual(['Edited']);
+    asSeat(playerSeat, { kind: 'marker.delete', markerId: noteId } as never);
+    expect(viewNow().mapState!.markers).toHaveLength(0);
+  });
+});
+
 describe('campaign clock (issue #57)', () => {
   // The default map is 6 mi/hex and the default mode is foot (3 mph), so a
   // hex costs 120 minutes at normal pace.

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -323,6 +323,8 @@ export class CampaignRuntime {
         glyph: m.glyph as string,
         label: m.label as string,
         dmOnly: Boolean(m.dm_only),
+        playerPlaced: Boolean(m.player_placed),
+        ownerSeatId: (m.owner_seat_id as string | null) ?? null,
       });
     }
     for (const c of d.prepare('SELECT * FROM content WHERE map_id = ?').all(mapId) as Array<
@@ -460,6 +462,10 @@ export class CampaignRuntime {
    * player's full state. Tokens, fog, pending moves, discoveries and the log
    * stay live; terrain, markers, content, images and trails hold at the
    * pause-time snapshot.
+   *
+   * Exception: player-placed party notes (issue #74) stay live through the
+   * pause. They are player output, not DM prep — freezing them would make a
+   * note a player drops mid-pause vanish for the whole party until resume.
    */
   applyPlayerFreeze(full: CampaignState): CampaignState {
     if (!this.campaign.settings.pausePlayerMapSync) return full;
@@ -467,13 +473,17 @@ export class CampaignRuntime {
     if (!mapId || !full.mapState) return full;
     const frozen = this.frozenPlayerMaps.get(mapId);
     if (!frozen) return full;
+    // Frozen DM markers, then every live player note (live wins by id, so an
+    // edit lands and a delete removes the frozen copy).
+    const markers = new Map(frozen.markers.filter((m) => !m.playerPlaced).map((m) => [m.id, m]));
+    for (const m of full.mapState.markers) if (m.playerPlaced) markers.set(m.id, m);
     return {
       ...full,
       mapState: {
         ...full.mapState,
         imageLayers: frozen.imageLayers,
         hexes: frozen.hexes,
-        markers: frozen.markers,
+        markers: [...markers.values()],
         contents: frozen.contents,
         trails: frozen.trails,
       },
@@ -932,8 +942,20 @@ export class CampaignRuntime {
     const rt = this.requireMap(marker.mapId);
     rt.markers.set(marker.id, marker);
     this.db
-      .prepare('INSERT INTO marker (id, map_id, q, r, glyph, label, dm_only) VALUES (?,?,?,?,?,?,?)')
-      .run(marker.id, marker.mapId, marker.q, marker.r, marker.glyph, marker.label, marker.dmOnly ? 1 : 0);
+      .prepare(
+        'INSERT INTO marker (id, map_id, q, r, glyph, label, dm_only, player_placed, owner_seat_id) VALUES (?,?,?,?,?,?,?,?,?)',
+      )
+      .run(
+        marker.id,
+        marker.mapId,
+        marker.q,
+        marker.r,
+        marker.glyph,
+        marker.label,
+        marker.dmOnly ? 1 : 0,
+        marker.playerPlaced ? 1 : 0,
+        marker.ownerSeatId,
+      );
   }
 
   updateMarker(markerId: string, patch: Partial<Marker>): Marker {
@@ -943,8 +965,19 @@ export class CampaignRuntime {
     const updated: Marker = { ...found, ...patch, id: found.id, mapId: found.mapId };
     rt.markers.set(markerId, updated);
     this.db
-      .prepare('UPDATE marker SET q=?, r=?, glyph=?, label=?, dm_only=? WHERE id=?')
-      .run(updated.q, updated.r, updated.glyph, updated.label, updated.dmOnly ? 1 : 0, markerId);
+      .prepare(
+        'UPDATE marker SET q=?, r=?, glyph=?, label=?, dm_only=?, player_placed=?, owner_seat_id=? WHERE id=?',
+      )
+      .run(
+        updated.q,
+        updated.r,
+        updated.glyph,
+        updated.label,
+        updated.dmOnly ? 1 : 0,
+        updated.playerPlaced ? 1 : 0,
+        updated.ownerSeatId,
+        markerId,
+      );
     return updated;
   }
 

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -5,6 +5,7 @@ import type {
   Content,
   LogEntry,
   MapInfo,
+  Marker,
   Rng,
   Token,
 } from '@hexcrawl/shared';
@@ -97,6 +98,21 @@ function recordCellUndo(
 
 function requireDm(ctx: Ctx): void {
   if (ctx.seat.role !== 'dm') throw new Error('Only the DM can do that');
+}
+
+/**
+ * Marker edit/delete authority (issue #74): the DM moderates anything; a
+ * player may only touch a party note their own seat placed. Returns the
+ * marker, or null when it is already gone (the DM's edits stay idempotent).
+ */
+function requireMarkerAccess(ctx: Ctx, markerId: string): Marker | null {
+  const marker = ctx.runtime.findMarker(markerId);
+  if (ctx.seat.role === 'dm') return marker;
+  if (!marker) throw new Error('Marker not found');
+  if (!marker.playerPlaced || marker.ownerSeatId !== ctx.seat.id) {
+    throw new Error('You can only edit your own notes');
+  }
+  return marker;
 }
 
 /** Deliver freshly-created discoveries: toast to the owning player, entry in the DM feed. */
@@ -388,18 +404,29 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
   }) as Handler,
 
   // -- markers ---------------------------------------------------------------
+  // Players may drop party notes (issue #74): always party-visible, owned by
+  // the placing seat. Only the DM can place DM-only / unowned markers.
   'marker.place': ((cmd: Extract<ClientCommand, { kind: 'marker.place' }>, ctx: Ctx) => {
-    requireDm(ctx);
-    ctx.runtime.placeMarker({ ...cmd.marker, id: nanoid(10) });
+    const isDm = ctx.seat.role === 'dm';
+    const marker = {
+      ...cmd.marker,
+      id: nanoid(10),
+      playerPlaced: isDm ? (cmd.marker.playerPlaced ?? false) : true,
+      ownerSeatId: isDm ? (cmd.marker.ownerSeatId ?? null) : ctx.seat.id,
+      dmOnly: isDm ? cmd.marker.dmOnly : false,
+    };
+    ctx.runtime.placeMarker(marker);
   }) as Handler,
 
   'marker.update': ((cmd: Extract<ClientCommand, { kind: 'marker.update' }>, ctx: Ctx) => {
-    requireDm(ctx);
-    ctx.runtime.updateMarker(cmd.markerId, cmd.patch);
+    if (!requireMarkerAccess(ctx, cmd.markerId)) return;
+    // A player editing their own note cannot hide it from the party.
+    const patch = ctx.seat.role === 'dm' ? cmd.patch : { ...cmd.patch, dmOnly: false };
+    ctx.runtime.updateMarker(cmd.markerId, patch);
   }) as Handler,
 
   'marker.delete': ((cmd: Extract<ClientCommand, { kind: 'marker.delete' }>, ctx: Ctx) => {
-    requireDm(ctx);
+    if (!requireMarkerAccess(ctx, cmd.markerId)) return;
     const removed = ctx.runtime.deleteMarker(cmd.markerId);
     if (removed) {
       ctx.runtime.pushUndo({

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -304,6 +304,10 @@ export const MarkerSchema = z.object({
   glyph: z.string().min(1).max(8),
   label: z.string().max(120).default(''),
   dmOnly: z.boolean().default(false),
+  /** Party note dropped by a player rather than the DM (issue #74). */
+  playerPlaced: z.boolean().default(false),
+  /** Seat that placed a player note; that seat (and the DM) may edit/delete it. */
+  ownerSeatId: z.string().nullable().default(null),
 });
 export type Marker = z.infer<typeof MarkerSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -242,7 +242,14 @@ export const TokenDeleteCommand = z.object({
 export const MarkerPlaceCommand = z.object({
   ...base,
   kind: z.literal('marker.place'),
-  marker: MarkerSchema.omit({ id: true }),
+  // The ownership fields are `.optional()` rather than defaulted: a zod default
+  // would make them required in `CommandInput` and break every existing
+  // `marker.place` call site. The server fills them in (and forces them for
+  // player seats).
+  marker: MarkerSchema.omit({ id: true, playerPlaced: true, ownerSeatId: true }).extend({
+    playerPlaced: z.boolean().optional(),
+    ownerSeatId: z.string().nullable().optional(),
+  }),
 });
 
 export const MarkerUpdateCommand = z.object({

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -122,9 +122,11 @@ function fullState(): CampaignState {
         { id: 't4', mapId: 'm1', q: 0, r: 0, kind: 'npc', characterId: null, label: 'Hidden', color: '#000000', glyph: '', playerVisible: false, partyId: null },
       ],
       markers: [
-        { id: 'mk1', mapId: 'm1', q: 0, r: 0, glyph: '🔥', label: 'Fire', dmOnly: false },
-        { id: 'mk2', mapId: 'm1', q: 0, r: 0, glyph: '💀', label: 'Secret', dmOnly: true },
-        { id: 'mk3', mapId: 'm1', q: 2, r: 0, glyph: '⛺', label: 'FoggedCamp', dmOnly: false },
+        { id: 'mk1', mapId: 'm1', q: 0, r: 0, glyph: '🔥', label: 'Fire', dmOnly: false, playerPlaced: false, ownerSeatId: null },
+        { id: 'mk2', mapId: 'm1', q: 0, r: 0, glyph: '💀', label: 'Secret', dmOnly: true, playerPlaced: false, ownerSeatId: null },
+        { id: 'mk3', mapId: 'm1', q: 2, r: 0, glyph: '⛺', label: 'FoggedCamp', dmOnly: false, playerPlaced: false, ownerSeatId: null },
+        // Party note dropped by another player's seat: party-wide (issue #74).
+        { id: 'mk4', mapId: 'm1', q: 1, r: 0, glyph: '📌', label: 'We camped here', dmOnly: false, playerPlaced: true, ownerSeatId: 's2' },
       ],
       contents: [
         {
@@ -184,7 +186,15 @@ describe('filterStateForViewer', () => {
 
   it('filters markers by dmOnly and fog', () => {
     const s = filterStateForViewer(fullState(), viewer);
-    expect(s.mapState!.markers.map((m) => m.id)).toEqual(['mk1']);
+    // mk4 is another seat's party note — player notes are party-wide.
+    expect(s.mapState!.markers.map((m) => m.id)).toEqual(['mk1', 'mk4']);
+  });
+
+  it('keeps ownership fields on party notes so a player can spot their own', () => {
+    const s = filterStateForViewer(fullState(), viewer);
+    const note = s.mapState!.markers.find((m) => m.id === 'mk4')!;
+    expect(note.playerPlaced).toBe(true);
+    expect(note.ownerSeatId).toBe('s2');
   });
 
   it('projects content to discovered clues only', () => {


### PR DESCRIPTION
Closes #74

Players can now annotate the map themselves, built on the existing marker
infrastructure.

## Summary

**Schema** — `MarkerSchema` gains `playerPlaced` (default `false`) and
`ownerSeatId` (default `null`). Persistence is additive: `ensureColumn`
adds `marker.player_placed INTEGER NOT NULL DEFAULT 0` and
`marker.owner_seat_id TEXT`, wired through the load mapping and both the
INSERT and UPDATE statements in `runtime.ts`.

**Command shape** — `marker.place` declares the two new fields as
`.optional()` (not `.default()`), so every existing `send({kind:
'marker.place', ...})` call site keeps compiling; the server decides the
values.

**Permissions** (`ws/handlers.ts`)
- `marker.place`: open to players. A player's marker is forced to
  `dmOnly: false`, `playerPlaced: true`, `ownerSeatId: ctx.seat.id` —
  a client claiming otherwise is overridden. DM placement is unchanged.
- `marker.update` / `marker.delete`: the DM may touch anything (and stays
  idempotent on an already-deleted marker); a player only a note their own
  seat placed, and a player's patch cannot set `dmOnly` (they can't hide a
  note from the party they wrote it for).

**Visibility** — party notes are party-wide, so the existing filter
(`!dmOnly && fog !== 'hidden'`) already delivers them; `filter.ts` is
unchanged. The ownership fields pass through to players so the client can
tell "mine" from "someone else's".

**Prep mode** — markers are part of `FrozenMapLayers`, so a note pinned
during a DM pause would have vanished for the party until resume.
`applyPlayerFreeze` now merges live `playerPlaced` markers over the frozen
list by id (live wins), which also makes a mid-pause edit or delete land.
DM markers still freeze.

**Rendering** — a party note draws as a rounded-rect tag outlined in the
placing player's character colour, with a colour dot and the note text as a
caption, visually distinct from a bare DM marker glyph.

**UI**
- `InspectTab`: players with a claimed character get a 3-glyph picker
  (📌 / ⚠️ / ⛺) plus a text field and a Pin button in the markers section
  for the selected hex, and can edit the label / delete their own notes
  inline. Notes show their author's name.
- `JournalTab`: a "Party notes" section lists every player pin on the
  current map (glyph, text, hex, author); clicking a row selects the hex
  like the Discoveries rows.

**Tests** — `pnpm typecheck && pnpm test` green: 86 tests (7 new server
tests covering forced ownership, party-wide visibility, own-note-only
edit/delete, DM moderation, persistence across reload, and the prep-mode
merge; 2 new shared filter tests).

## Docs notes

For `docs/AI-DEVELOPMENT.md` (not edited here, to keep parallel branches
merging cleanly):

- **Prep-mode gotcha, amended.** The existing bullet says new
  player-visible map-layer data must be added to `FrozenMapLayers` or it
  leaks during a pause. The converse now also applies: data players
  *produce* (party notes) must be merged back over the frozen layer in
  `applyPlayerFreeze`, or a player's own action disappears for the whole
  party until the DM resumes. The rule of thumb: freeze DM prep, never
  freeze player output.
- **Engine diff caches.** `markersEqual` is the exception to that bullet —
  it delegates to the generic `shallowEqual`, which walks every key, so
  marker fields are diffed without extending a field list. `contentsEqual`
  and friends still need editing by hand. (Comment added in the code.)
- **Command-schema gotcha, reinforced.** Adding a field to a schema reused
  by a command (`MarkerSchema.omit({id: true})`) breaks call sites via
  `CommandInput` exactly like a `.default()` does. Fix: omit the field from
  the command and re-`.extend()` it as `.optional()`, with the server
  supplying the value — that also keeps the field server-authoritative,
  which is what the permission model wanted anyway.

## Concerns / follow-ups

- Nothing rate-limits notes: a player can pin as many as they like, and
  many notes on one hex spread along the hex's bottom edge like DM markers
  (the tag is slightly larger, so a crowded hex will look busy).
- A player can pin a note on a hex that is fogged for them; the note is
  stored fine but will not render until the fog opens. Server-side that is
  harmless, but it can read as "nothing happened".
- The note tag colour comes from the owner seat's character colour; if a
  character's colour changes, the canvas only repaints notes when some
  marker/content/trail diff also fires.
- Notes are per-map (they live on `marker`), so switching maps switches the
  Journal's "Party notes" list — consistent with Discoveries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
