### PR TITLE
Day/night tint, rests, and travel-time estimates

### DIFF
--- a/packages/client/src/components/StatusOverlays.tsx
+++ b/packages/client/src/components/StatusOverlays.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { TERRAINS, hexDistance, hexKey } from '@hexcrawl/shared';
+import {
+  TERRAINS,
+  formatDuration,
+  hexDistance,
+  hexKey,
+  minutesPerHex,
+  resolveTravelMode,
+} from '@hexcrawl/shared';
 import { activeMap, useSession } from '../stores/session.js';
 import { useUi } from '../stores/ui.js';
 
@@ -17,6 +24,18 @@ export function HexReadout() {
   const measuring = tool === 'measure' && measureStart;
   const dist = measuring ? hexDistance(measureStart, hover) : null;
 
+  // Travel-time estimate (#77): distance at the campaign's current travel
+  // mode/pace. Both roles see it — it's the "should we push on?" question.
+  let travelEstimate: string | null = null;
+  const time = state.campaign.time;
+  if (dist !== null && dist > 0 && time) {
+    const mode = resolveTravelMode(time.travelMode, state.campaign.settings.customTravelModes);
+    const totalMinutes = dist * minutesPerHex(map.milesPerHex, mode, time.pace);
+    if (totalMinutes > 0) {
+      travelEstimate = `~${formatDuration(totalMinutes)} · ${mode.label} (${time.pace})`;
+    }
+  }
+
   return (
     <div className="absolute bottom-3 left-3 z-30 bg-ink-900/90 border border-ink-700 rounded-md px-2.5 py-1.5 text-xs text-ink-300 backdrop-blur pointer-events-none">
       <span className="text-ink-100 font-medium">
@@ -29,6 +48,7 @@ export function HexReadout() {
           · {dist} hex{dist === 1 ? '' : 'es'} ≈ {dist * map.milesPerHex} mi
         </span>
       )}
+      {travelEstimate && <span className="text-ink-400"> · {travelEstimate}</span>}
     </div>
   );
 }

--- a/packages/client/src/components/TopBar.tsx
+++ b/packages/client/src/components/TopBar.tsx
@@ -6,6 +6,7 @@ import {
   formatTimeOfDay,
   isNight,
   minutesPerHex,
+  minutesUntilSunrise,
   resolveTravelMode,
   travelModes,
 } from '@hexcrawl/shared';
@@ -78,8 +79,8 @@ function TimeControl() {
   const mode = resolveTravelMode(time.travelMode, settings?.customTravelModes ?? []);
   const perHex = map ? Math.round(minutesPerHex(map.milesPerHex, mode, time.pace)) : null;
 
-  const advance = (minutes: number) => {
-    if (minutes > 0) send({ kind: 'time.advance', minutes });
+  const advance = (minutes: number, note?: string) => {
+    if (minutes > 0) send({ kind: 'time.advance', minutes, note });
   };
 
   return (
@@ -172,6 +173,26 @@ function TimeControl() {
                 </Button>
               ))}
             </div>
+            <div className="flex gap-1 mt-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex-1 !px-1 border border-ink-600"
+                onClick={() => advance(60, 'short rest')}
+                title="Short rest — advance the clock 1 hour"
+              >
+                Short rest (+1h)
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex-1 !px-1 border border-ink-600"
+                onClick={() => advance(minutesUntilSunrise(time.minutes, settings), 'camp')}
+                title="Camp — advance the clock to the next sunrise"
+              >
+                Camp until dawn
+              </Button>
+            </div>
             <form
               className="flex gap-1 mt-1"
               onSubmit={(e) => {
@@ -197,6 +218,27 @@ function TimeControl() {
         </div>
       )}
     </div>
+  );
+}
+
+/** Toggle the map's day/night tint overlay — cosmetic, both roles. */
+function DayNightToggle() {
+  const enabled = useUi((s) => s.dayNightTint);
+  const setUi = useUi((s) => s.set);
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => setUi('dayNightTint', !enabled)}
+      className={enabled ? '!text-brass-300' : ''}
+      title={
+        enabled
+          ? 'Day/night map tint is on — the map dims at night and warms at dusk/dawn. Click to turn off.'
+          : 'Day/night map tint is off — click to tint the map for the current time of day'
+      }
+    >
+      🌗
+    </Button>
   );
 }
 
@@ -293,6 +335,7 @@ export function TopBar({
 
       {map && <ScaleControl baseMiles={map.milesPerHex} />}
       <TimeControl />
+      <DayNightToggle />
 
       <div className="flex-1" />
 

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -1,6 +1,7 @@
 import { AlphaFilter, Application, Assets, Circle, Container, Graphics, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import type {
+  CampaignSettings,
   CampaignState,
   Content,
   ContentPlayerView,
@@ -30,6 +31,8 @@ import {
   hexToPixel,
   hexesInPixelRect,
   indexToFineCenter,
+  isNight,
+  MINUTES_PER_DAY,
   pixelToHex,
   superCornerOffsets,
   superIndexRange,
@@ -87,6 +90,9 @@ export class CanvasEngine {
   private exploredG = new Graphics();
   private exploredAlpha = new AlphaFilter({ alpha: 0.3 });
   private pinsC = new Container();
+  // Day/night tint: a single generous rect above pins/terrain, below tokens,
+  // redrawn whenever the view, clock or toggle changes. Cheap — no per-hex work.
+  private tintG = new Graphics();
   private tokensC = new Container();
   private pendingC = new Container();
   private senseG = new Graphics();
@@ -107,6 +113,7 @@ export class CanvasEngine {
   private lastTrailSigns: TrailSign[] = [];
   private lastImages: ImageLayer[] = [];
   private lastDiscoveriesRef: unknown = null;
+  private lastTintKey = '';
   private role: SeatRole = 'player';
   private myCharacterId: string | null = null;
 
@@ -167,6 +174,7 @@ export class CanvasEngine {
     this.viewport.addChild(this.terrainG);
     this.viewport.addChild(this.gridG);
     this.viewport.addChild(this.pinsC);
+    this.viewport.addChild(this.tintG);
     this.viewport.addChild(this.tokensC);
     this.viewport.addChild(this.pendingC);
     this.viewport.addChild(this.exploredC);
@@ -184,6 +192,7 @@ export class CanvasEngine {
       this.terrainG,
       this.gridG,
       this.pinsC,
+      this.tintG,
       this.pendingC,
       this.exploredC,
       this.fogC,
@@ -236,6 +245,9 @@ export class CanvasEngine {
       }
       if (u.dimUnexplored !== prev.dimUnexplored) {
         this.drawPins();
+      }
+      if (u.dayNightTint !== prev.dayNightTint) {
+        this.viewDirty = true;
       }
       if (u.senseHighlight !== prev.senseHighlight) {
         this.drawSenseHighlight();
@@ -312,6 +324,14 @@ export class CanvasEngine {
 
     const ms = state.mapState;
 
+    // Day/night tint tracks the clock and daylight settings, independent of
+    // the map layers above — redraw the (cheap) tint rect when either moves.
+    const tintKey = `${state.campaign.time.minutes}|${state.campaign.settings.sunriseHour}|${state.campaign.settings.sunsetHour}`;
+    if (tintKey !== this.lastTintKey) {
+      this.lastTintKey = tintKey;
+      this.viewDirty = true;
+    }
+
     if (layoutChanged || !hexCellsEqual(ms.hexes, this.lastHexes) || styleChanged) {
       this.lastHexes = ms.hexes;
       this.drawTerrain();
@@ -375,6 +395,7 @@ export class CanvasEngine {
     this.senseG.clear();
     this.trailHighlightG.clear();
     this.highlightG.clear();
+    this.tintG.clear();
     this.pinsC.removeChildren().forEach((c) => c.destroy({ children: true }));
     this.tokensReset();
     for (const sprite of this.images.values()) sprite.destroy();
@@ -638,7 +659,32 @@ export class CanvasEngine {
     this.fogEraseG.fill({ color: 0xffffff });
     this.exploredG.fill({ color: 0x0b0d12 });
 
+    this.drawTint(bounds);
     this.updatePinScales();
+  }
+
+  /**
+   * Day/night map tint (#58): a single rect covering the visible area
+   * generously, tinted to match the campaign clock. Purely cosmetic — no
+   * per-hex work, cheap to redraw on every view/clock/toggle change.
+   */
+  private drawTint(bounds: { x: number; y: number; width: number; height: number }): void {
+    this.tintG.clear();
+    if (!useUi.getState().dayNightTint) return;
+    const state = useSession.getState().state;
+    const time = state?.campaign.time;
+    if (!time) return;
+    const settings = state.campaign.settings;
+    const tint = tintForClock(time.minutes, settings);
+    if (!tint) return;
+    const margin = Math.max(bounds.width, bounds.height);
+    this.tintG.rect(
+      bounds.x - margin,
+      bounds.y - margin,
+      bounds.width + margin * 2,
+      bounds.height + margin * 2,
+    );
+    this.tintG.fill({ color: tint.color, alpha: tint.alpha });
   }
 
   /**
@@ -1661,6 +1707,26 @@ export class CanvasEngine {
       }
     }
   }
+}
+
+// -- day/night tint ------------------------------------------------------------
+
+/**
+ * Tint color/alpha for the campaign clock: deep blue at night, a warm dusk/
+ * dawn wash in the hour to either side of sunset/sunrise, nothing by day.
+ */
+function tintForClock(
+  minutes: number,
+  settings: Pick<CampaignSettings, 'sunriseHour' | 'sunsetHour'>,
+): { color: number; alpha: number } | null {
+  if (isNight(minutes, settings)) return { color: 0x1a2244, alpha: 0.28 };
+  const sunrise = settings.sunriseHour ?? 6;
+  const sunset = settings.sunsetHour ?? 20;
+  const hour = (Math.max(0, Math.floor(minutes)) % MINUTES_PER_DAY) / 60;
+  const inDusk = hour >= sunset - 1 && hour < sunset;
+  const inDawn = hour >= sunrise && hour < sunrise + 1;
+  if (inDusk || inDawn) return { color: 0xd9822b, alpha: 0.12 };
+  return null;
 }
 
 // -- diff helpers ------------------------------------------------------------

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -57,6 +57,8 @@ interface UiStore {
   viewedMapId: string | null;
   /** DM view aid: dim location pins on hexes the party hasn't explored. */
   dimUnexplored: boolean;
+  /** Tint the map to match the campaign clock's time of day. */
+  dayNightTint: boolean;
   /** Held Alt/Option: a DM token drop teleports (no explored trail). */
   altTeleport: boolean;
 
@@ -118,6 +120,7 @@ export const useUi = create<UiStore>((set) => ({
   pinPopup: null,
   viewedMapId: null,
   dimUnexplored: true,
+  dayNightTint: true,
   altTeleport: false,
 
   set: (key, value) => set({ [key]: value } as Partial<UiStore>),

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -1033,6 +1033,41 @@ describe('campaign clock (issue #57)', () => {
     expect(setEntry.visibility).toBe('dm');
   });
 
+  it('time.advance appends a note and the party hex/location (issue #59)', () => {
+    const { mapId } = setupPartyWithScout();
+    // The PC token appears at (0,0), which stamps partyHex there.
+    expect(runtime.campaign.time.partyHex).toMatchObject({ mapId, q: 0, r: 0 });
+
+    dm({ kind: 'time.advance', minutes: 60, note: 'short rest' } as never);
+    let entry = runtime.log.filter((e) => e.kind === 'time').at(-1)!;
+    expect(entry.text).toBe('Time advances 1 hour (short rest) — Day 1, 9:00 AM at hex 0,0');
+    expect(entry.data.note).toBe('short rest');
+
+    // Enabled content on the party's hex is named instead of the bare coords.
+    dm({
+      kind: 'content.upsert',
+      content: {
+        id: null, mapId, q: 0, r: 0, type: 'settlement', title: "Durlag's Tower", dmNotes: '',
+        glyph: '', clues: [],
+      },
+    } as never);
+    dm({ kind: 'time.advance', minutes: 8 * 60, note: 'camp' } as never);
+    entry = runtime.log.filter((e) => e.kind === 'time').at(-1)!;
+    expect(entry.text).toBe("Time advances 8 hours (camp) — Day 1, 5:00 PM at Durlag's Tower");
+
+    // No note: unchanged from the plain "advances ... — clock" shape, plus location.
+    dm({ kind: 'time.advance', minutes: 30 } as never);
+    entry = runtime.log.filter((e) => e.kind === 'time').at(-1)!;
+    expect(entry.text).toBe("Time advances 30 minutes — Day 1, 5:30 PM at Durlag's Tower");
+
+    // Disabled content doesn't exist yet — falls back to the bare hex.
+    const content = [...runtime.requireMap(mapId).contents.values()][0]!;
+    dm({ kind: 'content.upsert', content: { ...content, enabled: false } } as never);
+    dm({ kind: 'time.advance', minutes: 60 } as never);
+    entry = runtime.log.filter((e) => e.kind === 'time').at(-1)!;
+    expect(entry.text).toBe('Time advances 1 hour — Day 1, 6:30 PM at hex 0,0');
+  });
+
   it('accumulates per-hex time while the party lingers, and persists it', () => {
     const { mapId, tokenId, playerSeat } = setupPartyWithScout();
     // The starting hex is stamped when the PC token appears.

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -893,12 +893,17 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
   'time.advance': ((cmd: Extract<ClientCommand, { kind: 'time.advance' }>, ctx: Ctx) => {
     requireDm(ctx);
     const time = ctx.runtime.advanceTime(cmd.minutes);
-    const entry = ctx.runtime.appendLog(
-      'time',
-      `Time advances ${formatDuration(cmd.minutes)} — ${formatClock(time.minutes)}`,
-      'all',
-      { minutes: time.minutes, advancedBy: cmd.minutes },
-    );
+    let text = `Time advances ${formatDuration(cmd.minutes)}`;
+    if (cmd.note) text += ` (${cmd.note})`;
+    text += ` — ${formatClock(time.minutes)}`;
+    if (time.partyHex) {
+      text += ` at ${hexLocationLabel(ctx.runtime, time.partyHex)}`;
+    }
+    const entry = ctx.runtime.appendLog('time', text, 'all', {
+      minutes: time.minutes,
+      advancedBy: cmd.minutes,
+      note: cmd.note ?? null,
+    });
     notifyLog(ctx, entry);
   }) as Handler,
 
@@ -944,6 +949,23 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     }
   }) as Handler,
 };
+
+/**
+ * A human-readable label for a party-hex reference: the title of enabled
+ * content sitting on that hex (a town, a dungeon), or a bare hex coordinate.
+ */
+function hexLocationLabel(
+  runtime: CampaignRuntime,
+  hex: { mapId: string; q: number; r: number },
+): string {
+  const rt = runtime.mapStates.get(hex.mapId);
+  if (rt) {
+    for (const content of rt.contents.values()) {
+      if (content.q === hex.q && content.r === hex.r && content.enabled) return content.title;
+    }
+  }
+  return `hex ${hex.q},${hex.r}`;
+}
 
 /** Fog auto-reveal + knowledge evaluation after a PC token appears or moves. */
 function afterPartyMoved(ctx: Ctx, mapId: string, token: Token): FogDelta {

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -482,6 +482,8 @@ export const TimeAdvanceCommand = z.object({
   ...base,
   kind: z.literal('time.advance'),
   minutes: z.number().int().min(1).max(60 * 24 * 365),
+  /** Why the clock moved ("camp", "short rest") — shown in the log line. */
+  note: z.string().max(200).optional(),
 });
 
 /** DM: set the clock absolutely (session bookkeeping, fixing a mistake). */

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -9,6 +9,7 @@ import {
   formatTimeOfDay,
   isNight,
   minutesPerHex,
+  minutesUntilSunrise,
   resolveTravelMode,
   timeOfDay,
   travelModes,
@@ -263,5 +264,18 @@ describe('campaign clock', () => {
     // A campaign with long nights.
     expect(isNight(8 * 60, { sunriseHour: 9, sunsetHour: 16 })).toBe(true);
     expect(isNight(15 * 60, { sunriseHour: 9, sunsetHour: 16 })).toBe(false);
+  });
+
+  it('counts minutes to the next sunrise for "camp until dawn"', () => {
+    // Default sunrise (6 AM). Currently 8 AM day 1 — sunrise is tomorrow.
+    expect(minutesUntilSunrise(8 * 60)).toBe(22 * 60);
+    // Just before dawn: a short hop to sunrise, same day.
+    expect(minutesUntilSunrise(5 * 60 + 30)).toBe(30);
+    // Exactly at sunrise: the *next* sunrise is a full day away, not zero.
+    expect(minutesUntilSunrise(6 * 60)).toBe(24 * 60);
+    // A custom sunrise hour.
+    expect(minutesUntilSunrise(3 * 60, { sunriseHour: 9 })).toBe(6 * 60);
+    // Works past day 1 the same way.
+    expect(minutesUntilSunrise(1440 + 20 * 60)).toBe(10 * 60);
   });
 });

--- a/packages/shared/src/rules/time.ts
+++ b/packages/shared/src/rules/time.ts
@@ -102,6 +102,20 @@ export function isNight(minutes: number, settings: DaylightSettings = {}): boole
   return hour >= sunset && hour < sunrise;
 }
 
+/**
+ * Minutes from the current clock forward to the next sunrise (strictly in
+ * the future — if the clock reads exactly sunrise right now, this returns a
+ * full day, not zero). Used by "camp until dawn".
+ */
+export function minutesUntilSunrise(minutes: number, settings: DaylightSettings = {}): number {
+  const sunrise = settings.sunriseHour ?? 6;
+  const total = Math.max(0, Math.floor(minutes));
+  const day = Math.floor(total / MINUTES_PER_DAY);
+  const sunriseToday = day * MINUTES_PER_DAY + sunrise * 60;
+  if (total < sunriseToday) return sunriseToday - total;
+  return sunriseToday + MINUTES_PER_DAY - total;
+}
+
 /** "Day 3" — deliberately calendar-free; #79 can rename this layer. */
 export function formatDay(minutes: number): string {
   return `Day ${timeOfDay(minutes).day}`;


### PR DESCRIPTION
Closes #58
Closes #59
Closes #77

## Summary

Built on the campaign clock foundation from #57 (`shared/src/rules/time.ts`, `campaign.time`, `time.advance`/`time.set`/`time.config`, the TimeControl popover, per-hex visit accounting).

- **#58 Day/night map tint.** New `dayNightTint` boolean in the client ui-store (default on), toggled from a small button next to `TimeControl` in the top bar (both roles). `CanvasEngine` draws a single tinted rect — deep blue (`0x1a2244`, alpha 0.28) at night per `isNight`, warm dusk/dawn orange (`0xd9822b`, alpha 0.12) in the hour before sunset or after sunrise, nothing during the rest of the day. The layer sits above `pinsC`/terrain and below `tokensC` in the viewport child order, is added to the `eventMode = 'none'` list, and is redrawn only on view/layout change, a clock/settings change, or the toggle — no per-hex work.
- **#59 Time spent in place.** `TimeControl`'s popover gets "Short rest (+1h)" and "Camp until dawn" buttons. `Camp until dawn` uses a new shared helper, `minutesUntilSunrise`, to compute minutes to the next sunrise. `time.advance` gained an optional `note` field (`.optional()`, not `.default()` — see the `CommandInput` gotcha in the docs). The server log line is now `"Time advances 8 hours (camp) — Day 4, 6:00 AM"` when a note is present, and appends `" at <location>"` when `campaign.time.partyHex` is set — the location is the title of any *enabled* content pinned on that hex, or `"hex q,r"` otherwise. Left `InspectTab` untouched, per the current file-ownership split.
- **#77 Travel-time estimate on the measure tool.** `HexReadout` (in `StatusOverlays.tsx`) now appends an estimated duration for the measured path — hexes × `minutesPerHex` at the campaign's current travel mode/pace, formatted with `formatDuration` — e.g. `"~1 hour 40 minutes · On foot (normal)"`. Rendered in the React overlay (the engine's measure line is geometry-only, no text), visible to both roles.

## Decisions worth flagging

- The dusk/dawn tint windows are exactly the 1-hour spans `[sunset-1, sunset)` and `[sunrise, sunrise+1)` — i.e. entirely on the "day" side of the isNight boundary, per the issue's "within 1h before sunset/after sunrise" wording. It does not add a symmetric window just after sunset / before sunrise (those minutes are already covered by the night tint).
- `formatDuration`'s existing "8 hours" / "45 minutes" phrasing was used for the travel-time estimate rather than a custom "5h 20m" abbreviation, to stay consistent with how duration is already rendered everywhere else (log lines, TimeControl). The separator/labels ("On foot (normal)") also reuse `TravelMode.label` and `TravelPace` as-is rather than free-text grammar ("on foot at normal pace"), since that's how the same values are already displayed in `TopBar`.
- `minutesUntilSunrise(minutes)` when the clock reads exactly the sunrise hour returns a full day (the *next* sunrise), not zero — matters for "camp until dawn" clicked right at dawn.
- Kept `time.advance`'s log text byte-for-byte identical when no note/location is present, so the existing #57 test assertions didn't need touching.

## Docs notes

No changes made to `docs/AI-DEVELOPMENT.md` — the existing "Engine diff caches" and "Pixi v8 hit-testing" gotchas already covered everything needed for the new tint layer (new `eventMode='none'` layer, no new comparator needed since the tint isn't part of a diffed snapshot type).

## Test plan

- [x] `pnpm typecheck` (all 3 workspaces)
- [x] `pnpm test` (shared: 36 passed, server: 43 passed, client: no test files)
- [x] `pnpm build` succeeds
- [x] New shared test: `minutesUntilSunrise` (default/custom sunrise, exact-sunrise edge case, cross-day)
- [x] New server test: `time.advance` note + hex/content location text, including the disabled-content fallback to bare hex coordinates