### PR TITLE
Standardize MCP server and AI skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ most of this was built): **[docs/AI-DEVELOPMENT.md](docs/AI-DEVELOPMENT.md)**.
 ## Integration API + MCP
 
 Other tools — e.g. a DM-companion agent that maintains a campaign wiki — can
-manage map locations through `/api/integration/campaigns/:id/...` using the
-campaign DM key as a Bearer token: list maps, list locations, upsert by title
-(with pixel→hex conversion in the map-image frame that wiki DataMaps use), and
-delete. `mcp/hexcrawl-mcp.mjs` is a dependency-free stdio MCP server wrapping
-that API:
+manage map locations, trails, and settlement clues through
+`/api/integration/campaigns/:id/...` using the campaign DM key as a Bearer
+token. `mcp/hexcrawl-mcp.mjs` is a dependency-free stdio MCP server wrapping
+that API so any MCP-capable AI assistant can be wired to a deployment in
+minutes:
 
 ```bash
 claude mcp add hexcrawl \
@@ -228,6 +228,16 @@ claude mcp add hexcrawl \
 
 Locations can carry a `wikiPage`; players get a "wiki ↗" link on discovered
 content (base URL configurable in Setup).
+
+## AI integration
+
+Full setup (env contract, registration for Claude Code/opencode/generic
+stdio clients, tool reference, REST API reference, troubleshooting) lives in
+**[docs/MCP.md](docs/MCP.md)**. If you're connecting an assistant to
+maintain campaign content, also hand it
+**[docs/skills/hexcrawl-campaign-assistant.md](docs/skills/hexcrawl-campaign-assistant.md)**
+— it covers the knowledge model, spoiler hygiene, and upsert semantics an
+assistant needs to avoid leaking DM-only information to players.
 
 ## License
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,364 @@
+# MCP server & AI integration
+
+HexCrawl VTT ships a small **MCP (Model Context Protocol) server** —
+[`mcp/hexcrawl-mcp.mjs`](../mcp/hexcrawl-mcp.mjs) — that lets any MCP-capable
+AI assistant (Claude Code, opencode, a custom agent, ...) create and update
+campaign content: locations, clues, trails. It is a thin, dependency-free
+wrapper around the app's own `/api/integration/*` REST API, so anything the
+MCP server can do, a script or another tool can also do directly over HTTP.
+
+This document covers:
+
+- [What it is, and what it is not](#what-it-is-and-what-it-is-not)
+- [Env contract](#env-contract)
+- [Registering the server](#registering-the-server)
+- [Tool reference](#tool-reference)
+- [REST integration API reference](#rest-integration-api-reference)
+- [Troubleshooting](#troubleshooting)
+
+For campaign-content safety rules (spoiler hygiene, what an assistant should
+never write into a player-visible field), see the companion document:
+[`docs/skills/hexcrawl-campaign-assistant.md`](skills/hexcrawl-campaign-assistant.md).
+Hand that file to whatever assistant you connect — it is the "how to behave"
+half of this integration; this document is the "how to connect" half.
+
+## What it is, and what it is not
+
+- It is a **stdio MCP server**: a single Node process, no install step beyond
+  Node itself, no network listener of its own. An MCP client launches it as a
+  subprocess and talks JSON-RPC over its stdin/stdout.
+- It is **scoped to one campaign**, chosen by the DM key you configure it
+  with. It has no way to list campaigns, create a campaign, or touch any
+  campaign it doesn't hold the key for.
+- It is **DM-equivalent access** to that one campaign's content: it can read
+  and write map locations and trails, including DM-only notes. It has no
+  access to characters, party position, encounter tables, session logs, or
+  campaign settings — the integration API surface is content-only today.
+- It is **optional**. The app and every other feature work with no MCP
+  server, no wiki, nothing configured. This bridge exists purely so an AI
+  assistant maintaining, say, a campaign wiki can mirror content into the map
+  without a human re-typing it.
+- It does **not** talk to a wiki. If you use MediaWiki (or any wiki) for
+  campaign notes, that's a separate integration on the assistant's side —
+  this server only knows about HexCrawl's own data.
+
+## Env contract
+
+The MCP server reads three environment variables, all required. Unlike the
+app server (`packages/server`), it does **not** read a `.env` file — set
+these when you register the server with your MCP client (see below), or
+export them in the environment that launches it. They mirror the
+`# MCP server` section of [`.env.example`](../.env.example).
+
+| Variable | Required | What it is |
+|---|---|---|
+| `HEXCRAWL_URL` | yes | Base URL of your HexCrawl instance, e.g. `https://hex-crawl.example.com` or `http://localhost:3000`. No trailing slash needed. |
+| `HEXCRAWL_CAMPAIGN` | yes | The campaign id, from the DM link (`.../c/<id>?key=...`) or the Setup tab. |
+| `HEXCRAWL_TOKEN` | yes | The campaign's **DM key**. **This is a secret** — anyone holding it has full DM read/write access to the campaign's content, including everything marked DM-only. Treat it exactly like a password: don't commit it, don't paste it into a shared doc, and pass it only through your MCP client's env-var mechanism (never as a CLI arg that ends up in shell history or `ps`). |
+
+If any of the three is missing, the server refuses to start and prints an
+actionable message to stderr instead of starting and failing opaquely on the
+first tool call — see [Troubleshooting](#troubleshooting).
+
+## Registering the server
+
+The server is a single file: `mcp/hexcrawl-mcp.mjs` in this repo, requiring
+only Node ≥ 18 (no `npm install` needed — it has zero runtime dependencies).
+`mcp/package.json` exists so it can also be run via `npx`/`node` with a clean
+`bin` entry if you copy/vendor the `mcp/` directory elsewhere, but the
+simplest setup just points your MCP client at the file's path in a checkout
+of this repo.
+
+### Claude Code
+
+```bash
+claude mcp add hexcrawl \
+  -e HEXCRAWL_URL=https://hex-crawl.example.com \
+  -e HEXCRAWL_CAMPAIGN=<campaign id> \
+  -e HEXCRAWL_TOKEN=<campaign DM key> \
+  -- node /path/to/hex-crawl-app/mcp/hexcrawl-mcp.mjs
+```
+
+Verify with `claude mcp list` — `hexcrawl` should show as connected. Remove
+with `claude mcp remove hexcrawl`.
+
+### opencode
+
+Add to `opencode.jsonc` (project or global config):
+
+```jsonc
+{
+  "mcp": {
+    "hexcrawl": {
+      "type": "local",
+      "command": ["node", "/path/to/hex-crawl-app/mcp/hexcrawl-mcp.mjs"],
+      "environment": {
+        "HEXCRAWL_URL": "https://hex-crawl.example.com",
+        "HEXCRAWL_CAMPAIGN": "<campaign id>",
+        "HEXCRAWL_TOKEN": "<campaign DM key>",
+      },
+      "enabled": true,
+    },
+  },
+}
+```
+
+### Generic stdio MCP client
+
+Any client that supports launching a local stdio MCP server needs the same
+three things: a command (`node /path/to/hex-crawl-app/mcp/hexcrawl-mcp.mjs`),
+no arguments, and the three env vars above set in the subprocess's
+environment. The server speaks standard MCP JSON-RPC (`initialize`,
+`tools/list`, `tools/call`) with no extensions.
+
+Sanity-check it stand-alone before wiring it into a client:
+
+```bash
+HEXCRAWL_URL=https://hex-crawl.example.com \
+HEXCRAWL_CAMPAIGN=<id> HEXCRAWL_TOKEN=<key> \
+node mcp/hexcrawl-mcp.mjs --version   # prints the server version, exits 0
+
+node mcp/hexcrawl-mcp.mjs --help      # usage, works with no env set
+```
+
+Running it with no arguments and incomplete env prints the missing-variable
+error and exits `1` immediately, without trying to read stdin — that's the
+expected failure mode when a client is misconfigured.
+
+## Tool reference
+
+Call `tools/list` for the authoritative, always-current schemas (each
+description embeds the coordinate-frame and merge-semantics notes below in
+full) — this section is a human-readable summary.
+
+### `list_maps`
+
+No arguments. Returns each map's id, name, `milesPerHex`, and grid geometry
+(`hexSize`, `orientation`, `originX`/`originY` — the basis `upsert_location`
+uses to convert pixel coordinates to hexes). Every other tool needs a map id
+from here.
+
+### `list_locations`
+
+```json
+{ "mapId": "4wkAfquT_v" }
+```
+
+Returns every location on that map: hex coordinates, type, clues (with
+gates), wiki page, and visibility flags. Use it to find a `contentId` for
+`delete_location`, or to read a location's current `type` /
+`scaleVisibility` / `showLabel` / `enabled` / `knownLocation` before an
+update that must preserve them (see the merge-semantics warning below).
+
+### `upsert_location`
+
+Create or update a location, matched to an existing one by **`(mapId,
+title)`, case-insensitively** — call it again with the same title (e.g.
+after editing a wiki page) and it updates that location instead of creating
+a duplicate.
+
+```json
+{
+  "mapId": "4wkAfquT_v",
+  "title": "Grimhollow",
+  "x": 812,
+  "y": 401,
+  "type": "settlement",
+  "glyph": "🏘️",
+  "wikiPage": "Grimhollow",
+  "scaleVisibility": 2,
+  "clues": [
+    { "text": "Smoke rises from chimneys along the ridge.", "gate": { "kind": "auto" } },
+    {
+      "text": "Rumor in Waterdeep names Grimhollow as a haven for smugglers.",
+      "gate": { "kind": "skill", "skill": "Insight", "dc": 12, "maxDistance": 0, "mode": "passive" },
+      "revealsLocation": false
+    }
+  ]
+}
+```
+
+**Coordinate frames** — give **either** `x`/`y` **or** `q`/`r`, not both:
+
+- `x`/`y`: pixel coordinates on the raw map image, **the same frame as wiki
+  DataMap marker positions**. The server converts these to hex coordinates
+  using the map's grid geometry (`hexSize`/`orientation`/`origin` from
+  `list_maps`). This is the natural choice when a position is sourced from a
+  wiki DataMap.
+- `q`/`r`: axial hex coordinates directly — use when you already know the
+  hex, e.g. copied from `list_locations`.
+
+**Gate** (on each clue, and on trails — see below) is a discriminated union:
+
+| `kind` | Fields | Meaning |
+|---|---|---|
+| `auto` | — | Revealed the instant a character's token enters the hex. Default. |
+| `skill` | `skill`, `dc`, `maxDistance`, `mode` | Revealed once a character within `maxDistance` hexes has that passive skill ≥ `dc`. `mode: "passive"` (default) evaluates continuously as tokens move; `mode: "active"` instead waits for the DM to trigger a roll. |
+| `manual` | — | Never auto-reveals; only a DM action in the app reveals it. |
+
+**Upsert semantics — not uniform, read carefully.** This is the sharpest
+edge in the whole API and the thing most likely to surprise a first-time
+integrator:
+
+- `dmNotes`, `glyph`, `wikiPage`, `quest`: replaced only if you pass a
+  **non-empty** value. An empty string or an omitted field **keeps the
+  existing value**.
+- `clues`: passing a **non-empty** array **fully replaces** the existing
+  clue list. Passing `clues: []`, or omitting `clues` entirely, **keeps the
+  existing clues untouched**. There is no way to clear every clue through
+  this endpoint — delete and recreate the location, or edit it in the app.
+- `type`, `showLabel`, `scaleVisibility`, `enabled`, `knownLocation`: **do
+  NOT merge.** Every call sets these to whatever you pass, or to the schema
+  default (`type: "landmark"`, `showLabel: false`, `scaleVisibility: 1`,
+  `enabled: true`, `knownLocation: false`) if you omit them — **even when
+  updating an existing location that had different values.** This is a
+  server-side quirk, not intentional design (see
+  [Troubleshooting](#troubleshooting) and the note in this PR's description)
+  — until it's fixed, updating just the notes on an existing settlement
+  will silently reset its type to "landmark" unless you re-pass `type:
+  "settlement"` on every call. **Always call `list_locations` first and
+  re-pass the current value of these five fields on any update**, unless you
+  genuinely want them reset to defaults.
+
+`knownLocation: true` means players always see the pin's name and position
+even with zero discoveries (for well-known settlements); its clues stay
+gated as normal — players learn *where* it is, not what's *true* about it.
+`dmNotes` and any content behind a `manual`/unmet `skill` gate are never
+sent to players regardless of this flag.
+
+### `delete_location`
+
+```json
+{ "contentId": "VuARZUC4oB" }
+```
+
+Permanently deletes a location by id (from `list_locations`). Irreversible.
+
+### `upsert_trail`
+
+Create or update a trail — tracks/spoor players can discover and follow — as
+an ordered path of hexes. Matched by **`(mapId, name)`, case-insensitively**,
+same upsert-by-title pattern as locations.
+
+```json
+{
+  "mapId": "4wkAfquT_v",
+  "name": "Old King's Road",
+  "glyph": "👣",
+  "gate": { "kind": "skill", "skill": "Survival", "dc": 13, "maxDistance": 1, "mode": "passive" },
+  "cells": [{ "q": 0, "r": 0 }, { "q": 1, "r": 0 }, { "q": 2, "r": -1 }]
+}
+```
+
+`cells` is the ordered hex path (axial q/r), at least 2 cells. There is
+currently no `list_trails`/read endpoint in the integration API — see
+[Troubleshooting](#troubleshooting).
+
+### `generate_settlement_clues`
+
+```json
+{ "mapId": "4wkAfquT_v" }
+```
+
+Auto-generates the standard sensory discovery clues (smoke on the horizon,
+road noise, etc.) for every `settlement`-type location on the map that
+doesn't already have clues. **Idempotent** — settlements that already have
+clues are left alone, so it's safe to call again after adding new
+settlements. Returns the count and titles of settlements it touched. Useful
+right after bulk-creating settlements with `upsert_location`.
+
+## REST integration API reference
+
+The MCP tools are a thin wrapper over these endpoints
+(`packages/server/src/http/app.ts`), campaign-scoped and DM-key-authenticated.
+Call them directly from a script or another tool if you don't need MCP.
+
+**Auth:** `Authorization: Bearer <campaign DM key>` on every request. A
+missing/wrong key returns `401 {"error": "Unauthorized"}`.
+
+**Base path:** `{HEXCRAWL_URL}/api/integration/campaigns/{campaignId}`
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `GET` | `/maps` | — | List maps + grid geometry. |
+| `GET` | `/maps/:mapId/content` | — | List all locations on a map. |
+| `POST` | `/content` | `IntegrationContentSchema` (see below) | Upsert by `(mapId, title)`. See merge-semantics warning above. |
+| `DELETE` | `/content/:contentId` | — | Delete a location. |
+| `POST` | `/trails` | `{mapId, name, glyph?, dmNotes?, gate?, cells}` | Upsert by `(mapId, name)`. |
+| `POST` | `/generate-settlement-clues` | `{mapId}` | Generate standard clues for settlements missing them. |
+
+`IntegrationContentSchema` fields: `mapId`, `title`, `x?`/`y?` or `q?`/`r?`,
+`type?` (one of `lair`, `dungeon`, `settlement`, `ruin`, `landmark`,
+`region`, `lore`, `hazard`, `cache`, `other`), `glyph?`, `dmNotes?`,
+`wikiPage?`, `showLabel?`, `scaleVisibility?` (0-2), `enabled?`,
+`knownLocation?`, `quest?`, `clues?` (array of `{text, gate?,
+indicatesDirection?, revealsLocation?}`).
+
+**The wrong-path-returns-SPA-200 gotcha:** when a build serves the client
+(`CLIENT_DIST` set — true of every production deployment), the app falls
+back to `index.html` for any unmatched `GET` route so client-side routing
+works. That means a **typo'd `GET` integration path** (wrong campaign id
+segment, missing `/api/integration` prefix, a route that doesn't exist)
+doesn't 404 — it returns **`200` with an HTML page** in the body. If your
+integration code, or a script, expects JSON and gets a `200`, don't assume
+success: check `Content-Type` (`application/json` vs `text/html`) or that
+the parsed body has the shape you expect before treating a `200` as
+confirmation. This only affects `GET`; `POST`/`DELETE` to a wrong path either
+hits a real 404 JSON handler or a method-not-allowed, since the SPA fallback
+only registers a catch-all `GET`. The MCP server itself is not affected — it
+always calls known, hardcoded paths — but a hand-rolled integration script
+probing paths should know this.
+
+## Troubleshooting
+
+**"fetch failed" (or `ECONNREFUSED`/`ENOTFOUND`) on the first tool call —
+env not populated.** If `HEXCRAWL_URL`, `HEXCRAWL_CAMPAIGN`, or
+`HEXCRAWL_TOKEN` aren't actually reaching the server process — a typo'd
+`-e` flag, an MCP client that silently drops env vars with special
+characters, a shell profile that didn't export the variable — the server
+used to start fine and only fail once an assistant tried to call a tool,
+with an opaque network error that gives no hint the *cause* was
+configuration. As of this change, the server checks all three variables at
+startup and refuses to start with a specific "missing environment variable"
+message instead. If you still see a raw fetch failure, the variables are
+present but wrong (bad host/port, firewall, TLS mismatch) — verify with
+`curl {HEXCRAWL_URL}/api/health` from the same machine/container the MCP
+server runs in.
+
+**`401 Unauthorized` on every call.** `HEXCRAWL_TOKEN` doesn't match the
+campaign's current DM key, or `HEXCRAWL_CAMPAIGN` points at a different
+campaign than the key belongs to. Re-fetch both from the DM link / Setup tab
+— DM keys are not rotated automatically, but a copy-paste across the wrong
+campaign is the most common cause.
+
+**Tool calls succeed but the map doesn't seem to update.** The integration
+API writes straight into campaign state and schedules a snapshot sync same
+as any other command — there's no separate "publish" step. If a DM's browser
+doesn't reflect a change, check that the DM is viewing the same `mapId` you
+wrote to (campaigns can have multiple maps) and that `enabled` wasn't
+accidentally reset to `false` by the merge-semantics quirk above.
+
+**A location's type/visibility keeps reverting.** See the merge-semantics
+warning under `upsert_location` above — `type`, `showLabel`,
+`scaleVisibility`, `enabled`, and `knownLocation` reset to their schema
+defaults on any update that doesn't explicitly re-pass them. Always
+`list_locations` first and carry those five fields forward.
+
+**No way to read back a trail, or list existing trails.** The integration
+API has `POST /trails` (upsert) but no `GET` to list or read trails back —
+unlike locations, which have both `GET /maps/:mapId/content` and `POST
+/content`. If you need to know whether a trail with a given name already
+exists (rather than relying on upsert-by-name to just do the right thing),
+there's currently no way to check via the integration API short of asking a
+DM to look in the app. Tracked as a gap for a follow-up, not something this
+change fixes (see the PR description).
+
+**Wiki integration is unconfigured and that's fine.** The MCP server and the
+`/api/integration/*` endpoints have no dependency on `WIKI_API_URL` /
+`WIKI_BOT_USER` / `WIKI_BOT_PASSWORD` from `.env.example` — those are
+reserved for a possible future server-side wiki integration and are not read
+by any code today. Wiring an assistant to maintain both a wiki and a
+HexCrawl map (as described in
+[`docs/skills/hexcrawl-campaign-assistant.md`](skills/hexcrawl-campaign-assistant.md))
+is entirely the assistant's job, coordinating two separate tools/APIs — the
+map side works with zero wiki configuration.

--- a/docs/skills/hexcrawl-campaign-assistant.md
+++ b/docs/skills/hexcrawl-campaign-assistant.md
@@ -1,0 +1,226 @@
+# HexCrawl campaign assistant
+
+Instructions for an AI assistant with access to a HexCrawl VTT campaign
+through the `hexcrawl` MCP server (or the `/api/integration/*` REST API
+directly). Hand this document to whatever assistant you connect — Claude
+Code with the MCP server registered, a custom GPT briefed with this text, an
+opencode agent, or anything else that can call the tools described in
+[`docs/MCP.md`](../MCP.md).
+
+You are typically invoked by a DM (or a wiki-maintenance process working on
+the DM's behalf) to keep a campaign's map in sync with prep work — new
+locations from a wiki page, a trail the party might follow, clues for a
+settlement. **You act with full DM authority over this campaign's content.**
+That is a lot of trust; the rules below exist so you don't accidentally leak
+information to players or corrupt content a DM is relying on.
+
+## The knowledge model (read this first)
+
+HexCrawl's entire trust model rests on one distinction: **DM-only vs
+player-visible**, enforced server-side by the app, not by convention. You
+are writing directly into DM-authority data — the server will apply its own
+filtering when it sends state to players, but that filtering only protects
+*existing* fields correctly; it cannot save you from putting a spoiler in
+the wrong field to begin with.
+
+- **A location's pin** (title, hex position, icon) is invisible to players
+  by default. It becomes visible either when a character *discovers* a clue
+  that `revealsLocation` (the normal case), or immediately if you set
+  `knownLocation: true` — meant for places common knowledge already knows
+  about (a capital city, a famous landmark), where hiding the pin would be
+  silly. **Even with `knownLocation: true`, clues stay gated as normal** —
+  players learn *where* a place is, not what's *true* about it. Don't treat
+  `knownLocation` as "this is safe to be less careful with."
+- **`dmNotes`** on a location or trail is never sent to players, under any
+  circumstance, regardless of `enabled`/`knownLocation`/anything else. It is
+  the one field genuinely safe for module spoilers, stat blocks, secret
+  motivations, "the mayor is secretly a doppelganger" — anything the DM
+  needs to remember but players must never see.
+- **`clue.text`** is the opposite: it is exactly what gets shown to a player
+  who satisfies the clue's gate. Never put DM-only information in clue text.
+  If you're unsure whether a fact belongs in `dmNotes` or a clue, ask: "if a
+  player read this verbatim in their journal right now, would that spoil
+  something?" If yes, it's `dmNotes`, not a clue.
+- **A clue's gate** controls *when* a player earns that clue text, not
+  whether they eventually will — `manual` gates never auto-reveal, `skill`
+  gates reveal to individual characters as their tokens move and their
+  passive score qualifies, `auto` gates reveal on arrival. Getting a gate
+  wrong doesn't corrupt data, but it does change the pacing of what a DM
+  intended to be a slow reveal into an instant one (or vice versa) — when a
+  wiki page or prep note doesn't say how a piece of information should be
+  discovered, default to `manual` (DM decides live) rather than guessing
+  `auto`, and say so in your response so the DM can adjust it.
+- **Trails** follow the same `dmNotes`/gate model as locations, just for a
+  path instead of a point.
+
+**When you're not sure whether something is safe for a clue**, put it in
+`dmNotes` and tell the DM you left it there for them to turn into a clue by
+hand. Under-sharing costs a DM thirty seconds of editing; over-sharing spoils
+their game.
+
+## Spoiler hygiene
+
+If you also maintain a campaign wiki (MediaWiki or similar) as your source
+of truth for locations, the same DM-only/player-visible split applies there,
+and it is **your job to keep the two systems' visibility rules aligned** —
+HexCrawl has no idea your wiki exists.
+
+- **Module canon and DM truth never belong on a player-visible wiki page or
+  in HexCrawl clue text.** If a wiki page for a dungeon names its final boss,
+  its treasure, or a twist the party hasn't discovered, that content is
+  DM-only — it goes in HexCrawl's `dmNotes`, not in a clue, and ideally not
+  on a player-facing wiki page either. A useful mental model if you also
+  maintain player-facing wiki pages: those pages should record what the
+  party currently *believes* or has *learned*, not objective DM truth —
+  keep a separate DM-only page (or section) for canon, and only promote
+  facts to the player-facing page once the party has actually discovered
+  them in play.
+- **A `wikiPage` value on a location is shown to players once they discover
+  it** (as a "read more" link). Only put a wiki page there if that specific
+  page is safe for players to read in full — if the page mixes
+  player-appropriate description with DM secrets, either split the page or
+  leave `wikiPage` blank and keep the reference in `dmNotes` for the DM's
+  own use.
+- **Never infer new spoiler content from context and write it down as
+  established fact.** If a wiki page doesn't say what's in a dungeon's final
+  room, don't invent one and put it in `dmNotes` as if the DM decided it —
+  say what you don't know, or leave the field blank.
+- **Encounter checks and campaign log/timeline data are out of scope for
+  this integration entirely** — the integration API is content-only (maps,
+  locations, trails). You have no access to party position, session logs, or
+  live campaign state, and shouldn't need any to do content prep.
+
+## Content upsert-by-title semantics
+
+Every write tool (`upsert_location`, `upsert_trail`) matches an **existing**
+record by title/name, case-insensitively, scoped to one map. This means:
+
+- Calling `upsert_location` again with the same `title` on the same `mapId`
+  **updates that location**, not creates a duplicate. This is what makes it
+  safe to re-run content sync after editing a wiki page — same title in,
+  same location updated.
+- Title matching is **case-insensitive** and **per-map** — "Grimhollow" and
+  "grimhollow" are the same location, but "Grimhollow" on map A and
+  "Grimhollow" on map B are different locations (useful for a location that
+  legitimately exists on both an overland map and a zoomed-in local map, but
+  a trap if you meant one location and typo'd the map id).
+- **Not every field merges the same way on update** — see the "Upsert
+  semantics" section of [`docs/MCP.md`](../MCP.md#upsert_location) for the
+  full breakdown. The two things most likely to bite you:
+  - `clues: []` (or omitting `clues`) **keeps existing clues**; it does not
+    clear them. To replace a location's clues, pass the **complete** new
+    clue list — there's no "add one clue" operation, only "replace all" or
+    "leave alone."
+  - `type`, `showLabel`, `scaleVisibility`, `enabled`, and `knownLocation`
+    do **not** carry forward from the existing record — omitting them on an
+    update resets them to defaults. Before updating a location for any
+    reason, call `list_locations` and re-pass its current values for these
+    five fields unless you specifically mean to change them.
+
+## Coordinate frames
+
+Locations and trail cells can be placed two ways:
+
+- **Pixel coordinates** (`x`, `y` on `upsert_location`) — position on the raw
+  map image, in the same pixel frame a wiki DataMap uses for its markers.
+  Use this when you're translating a position from a wiki DataMap (or any
+  other pixel-based source) — the server converts it to hex coordinates
+  using that map's grid geometry (from `list_maps`).
+- **Axial hex coordinates** (`q`, `r`) — the game's native coordinate system.
+  Use this when you already know the hex, e.g. you read it off
+  `list_locations`, or a prep document already speaks in hex coordinates.
+  Trail `cells` are always `q`/`r` (there's no pixel form for trails).
+
+Never guess pixel coordinates from a description ("somewhere near the
+coast") — either extract them from an actual source (a DataMap marker, a
+prep doc with hex references), or ask the DM to place the pin in the app and
+tell you the title once it exists so you can attach clues to it.
+
+## When to use MCP tools vs REST directly
+
+Use the **MCP tools** (`list_maps`, `list_locations`, `upsert_location`,
+`delete_location`, `upsert_trail`, `generate_settlement_clues`) for anything
+an assistant does interactively — they're the intended interface, with tool
+descriptions that spell out the merge-semantics gotchas above.
+
+Reach for the **REST API directly** (documented in
+[`docs/MCP.md`](../MCP.md#rest-integration-api-reference)) only if you're
+writing a standalone script or batch job outside an MCP-capable client — for
+example, a nightly sync job with no LLM in the loop. The two are equivalent;
+the MCP server is a thin wrapper with no extra logic of its own.
+
+## Worked examples
+
+### Add a location with gated clues
+
+A wiki page describes a smugglers' den the party hasn't found yet. The page
+itself says where it is (a DataMap marker at pixel `(812, 401)` on the
+overland map) and what a passive-Perception character would notice from a
+distance, but the page also names the smuggler crew's employer — that's DM
+truth, not for players yet.
+
+1. `list_maps` → find the overland map's id.
+2. `upsert_location`:
+   ```json
+   {
+     "mapId": "<overland map id>",
+     "title": "Grimhollow",
+     "x": 812,
+     "y": 401,
+     "type": "settlement",
+     "glyph": "🏘️",
+     "wikiPage": "Grimhollow",
+     "scaleVisibility": 1,
+     "dmNotes": "Smuggler crew answers to House Talvane (see wiki: House Talvane). Not for players until discovered independently.",
+     "clues": [
+       {
+         "text": "Smoke rises from chimneys along the ridge, more than a hamlet this size should need.",
+         "gate": { "kind": "skill", "skill": "Perception", "dc": 12, "maxDistance": 2, "mode": "passive" },
+         "indicatesDirection": true
+       }
+     ]
+   }
+   ```
+   The employer name goes in `dmNotes`, never in `clue.text` or `wikiPage`
+   (unless the wiki page itself is split so the linked page omits it).
+
+### Add a trail
+
+The party might track cart wheels leading away from a raided caravan, if
+someone makes a Survival check.
+
+```json
+{
+  "mapId": "<overland map id>",
+  "name": "Caravan wheel ruts",
+  "glyph": "👣",
+  "gate": { "kind": "skill", "skill": "Survival", "dc": 13, "maxDistance": 0, "mode": "passive" },
+  "cells": [{ "q": 4, "r": -1 }, { "q": 5, "r": -1 }, { "q": 6, "r": -2 }]
+}
+```
+
+Re-running this with the same `name` later (e.g. extending the trail once
+prep continues) updates it in place — you don't need to know whether it
+already exists first.
+
+### Generate settlement clues in bulk
+
+After bulk-adding several settlements via `upsert_location` (each with
+`type: "settlement"` and no `clues`), generate the standard sensory
+discovery clues for all of them in one call instead of writing each by hand:
+
+```json
+{ "mapId": "<overland map id>" }
+```
+
+via `generate_settlement_clues`. It skips any settlement that already has
+clues, so it's safe to call again later after adding more settlements — you
+never need to track which ones you've already covered.
+
+## What you don't have access to
+
+Worth stating explicitly so you don't assume otherwise: the integration API
+has no read or write access to party/character state, live token positions,
+session logs, campaign settings, or encounter tables. If a task needs any of
+that, it needs a human at the DM's browser — say so rather than trying to
+work around it.

--- a/mcp/hexcrawl-mcp.mjs
+++ b/mcp/hexcrawl-mcp.mjs
@@ -2,48 +2,161 @@
 /**
  * HexCrawl VTT — MCP server (stdio) for campaign integrations.
  *
- * Lets an agent (e.g. the dnd-dm-companion) add and update map locations in a
- * HexCrawl campaign when it creates wiki pages. Wraps the app's integration
- * REST API; no dependencies.
+ * Lets any AI assistant (Claude Code, opencode, a wiki-manager agent, ...) add
+ * and update map locations, trails, and settlement clues in a HexCrawl
+ * campaign. Wraps the app's `/api/integration/*` REST API over JSON-RPC on
+ * stdin/stdout (the MCP stdio transport). Zero dependencies — plain Node.
  *
- * Env:
- *   HEXCRAWL_URL      e.g. https://hex-crawl.deeznuts.wiki
- *   HEXCRAWL_CAMPAIGN campaign id, e.g. 6h7ANf52rU
- *   HEXCRAWL_TOKEN    the campaign's DM key
+ * Env (all required — see docs/MCP.md for the full contract):
+ *   HEXCRAWL_URL      Base URL of your instance, e.g. https://hex-crawl.example.com
+ *   HEXCRAWL_CAMPAIGN Campaign id, from the DM link (…/c/<id>?key=…)
+ *   HEXCRAWL_TOKEN    The campaign's DM key. SECRET — grants full DM access.
  *
- * Register (Claude Code): claude mcp add hexcrawl -e HEXCRAWL_URL=... \
- *   -e HEXCRAWL_CAMPAIGN=... -e HEXCRAWL_TOKEN=... -- node /path/to/hexcrawl-mcp.mjs
+ * Register (Claude Code):
+ *   claude mcp add hexcrawl -e HEXCRAWL_URL=https://your-host \
+ *     -e HEXCRAWL_CAMPAIGN=<id> -e HEXCRAWL_TOKEN=<dm-key> \
+ *     -- node /path/to/hex-crawl-app/mcp/hexcrawl-mcp.mjs
+ *
+ * Run directly with --help or --version for CLI info; anything else assumes
+ * an MCP client is speaking JSON-RPC on stdin and blocks reading it.
  */
 import { createInterface } from 'node:readline';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
-const BASE = (process.env.HEXCRAWL_URL ?? 'http://localhost:3000').replace(/\/$/, '');
-const CAMPAIGN = process.env.HEXCRAWL_CAMPAIGN ?? '';
-const TOKEN = process.env.HEXCRAWL_TOKEN ?? '';
+const SERVER_NAME = 'hexcrawl';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf8')).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+function printHelp() {
+  process.stdout.write(`hexcrawl-mcp — MCP (stdio) server for a HexCrawl VTT campaign
+
+Usage:
+  node hexcrawl-mcp.mjs            Start the MCP server (reads JSON-RPC on stdin)
+  node hexcrawl-mcp.mjs --help     Show this help
+  node hexcrawl-mcp.mjs --version  Show the server version
+
+This process is not interactive — it is meant to be launched by an MCP
+client (Claude Code, opencode, etc.), not run by hand. See docs/MCP.md for
+registration examples.
+
+Required environment variables:
+  HEXCRAWL_URL       Base URL of your HexCrawl instance
+                      e.g. https://hex-crawl.example.com or http://localhost:3000
+  HEXCRAWL_CAMPAIGN  Campaign id (from the DM link, .../c/<id>?key=...)
+  HEXCRAWL_TOKEN     The campaign's DM key (SECRET — treat like a password;
+                      it grants full DM access to that campaign)
+
+Tools exposed: list_maps, list_locations, upsert_location, delete_location,
+upsert_trail, generate_settlement_clues. Call tools/list over the MCP
+protocol for full schemas, or see docs/MCP.md.
+`);
+}
+
+function printVersion() {
+  process.stdout.write(`${SERVER_VERSION}\n`);
+}
+
+function fail(message) {
+  process.stderr.write(`hexcrawl-mcp: ${message}\n`);
+  process.exit(1);
+}
+
+function checkEnv() {
+  const missing = ['HEXCRAWL_URL', 'HEXCRAWL_CAMPAIGN', 'HEXCRAWL_TOKEN'].filter(
+    (name) => !process.env[name] || !process.env[name].trim(),
+  );
+  if (missing.length === 0) return;
+  fail(
+    `missing required environment variable${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}.\n\n` +
+      'This server needs all three of HEXCRAWL_URL, HEXCRAWL_CAMPAIGN, and HEXCRAWL_TOKEN set\n' +
+      "before it starts — otherwise every tool call fails later with an opaque \"fetch failed\"\n" +
+      'or 401 once an assistant actually tries to use it. Set them when registering the server,\n' +
+      'e.g.:\n\n' +
+      '  claude mcp add hexcrawl \\\n' +
+      '    -e HEXCRAWL_URL=https://your-host \\\n' +
+      '    -e HEXCRAWL_CAMPAIGN=<campaign id from the DM link> \\\n' +
+      '    -e HEXCRAWL_TOKEN=<campaign DM key> \\\n' +
+      '    -- node /path/to/hex-crawl-app/mcp/hexcrawl-mcp.mjs\n\n' +
+      'See docs/MCP.md for the full env contract and other clients (opencode, generic stdio).',
+  );
+}
+
+// --- CLI entry: --help / --version bypass the env check and the stdio loop.
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+if (argv.includes('--version') || argv.includes('-v')) {
+  printVersion();
+  process.exit(0);
+}
+checkEnv();
+
+const BASE = process.env.HEXCRAWL_URL.replace(/\/$/, '');
+const CAMPAIGN = process.env.HEXCRAWL_CAMPAIGN;
+const TOKEN = process.env.HEXCRAWL_TOKEN;
 
 async function api(method, path, body) {
-  const res = await fetch(`${BASE}/api/integration/campaigns/${CAMPAIGN}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${TOKEN}`,
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  let res;
+  try {
+    res = await fetch(`${BASE}/api/integration/campaigns/${CAMPAIGN}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    throw new Error(
+      `Could not reach ${BASE} (${err.message}). Check HEXCRAWL_URL points at a running ` +
+        'HexCrawl instance and is reachable from this process.',
+    );
+  }
   const data = await res.json().catch(() => ({}));
+  if (res.status === 401) {
+    throw new Error('Unauthorized (401) — HEXCRAWL_TOKEN is not this campaign\'s DM key, or HEXCRAWL_CAMPAIGN is wrong.');
+  }
   if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
   return data;
 }
+
+// Discriminated-union gate shape shared by location clues and trails. Kept as
+// a loose `object` in JSON Schema (MCP clients render z.discriminatedUnion
+// poorly) but documented precisely in each tool's description.
+const GATE_DESCRIPTION =
+  'How this is revealed to players. {kind:"auto"} — revealed the instant a character\'s ' +
+  'token enters the hex. {kind:"skill", skill, dc, maxDistance, mode:"passive"|"active"} — ' +
+  'revealed once a character within maxDistance hexes has that passive skill score >= dc ' +
+  '(mode "passive", the default, is evaluated continuously as tokens move); mode "active" ' +
+  'instead waits for the DM to trigger a roll. {kind:"manual"} — never auto-reveals; only a ' +
+  'DM action in the app can reveal it. Default: {kind:"auto"}.';
 
 const TOOLS = [
   {
     name: 'list_maps',
     description:
-      'List the maps in the HexCrawl campaign (id, name, miles per hex, grid geometry). Use the map id with the other tools. Pixel coordinates for locations are in the map image frame (same frame as the wiki DataMaps).',
+      'List the maps in the HexCrawl campaign: id, name, miles per hex, and grid geometry ' +
+      '(hexSize, orientation, originX/originY — the pixel-to-hex conversion basis used by ' +
+      'upsert_location). Use a map id from here with every other tool.',
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
   },
   {
     name: 'list_locations',
-    description: 'List all content/locations on one map, including their hex coordinates, wiki pages, and clues.',
+    description:
+      'List all content/locations on one map: hex coordinates (q/r), type, clues (with their ' +
+      'gates), wiki page, and visibility settings. Use this before upsert_location to see what ' +
+      'already exists (matching is by title, case-insensitive) or to get a contentId for ' +
+      'delete_location.',
     inputSchema: {
       type: 'object',
       properties: { mapId: { type: 'string', description: 'Map id from list_maps' } },
@@ -54,37 +167,76 @@ const TOOLS = [
   {
     name: 'upsert_location',
     description:
-      'Create or update a location on a map (matched by title, case-insensitive — safe to call again after editing a wiki page). Give EITHER x/y pixel coordinates on the map image (preferred; same frame as the wiki DataMap markers) OR q/r hex coordinates. Set wikiPage to the wiki article title so players get a "read more" link. scaleVisibility: 0 = only visible when zoomed to fine hexes (hidden/small sites), 1 = fine+regional (default), 2 = visible at every zoom (cities, major landmarks). Clues control what players can learn: gate {kind:"auto"} reveals on arrival; {kind:"skill",skill,dc,maxDistance,mode:"passive"} reveals to characters whose passive skill beats the DC within range; {kind:"manual"} only when the DM reveals it.',
+      'Create or update a location (a pin on the hex map). Matched to an existing location by ' +
+      '(mapId, title) case-insensitively — calling this again with the same title after editing ' +
+      'a wiki page updates that same location in place rather than creating a duplicate.\n\n' +
+      'Coordinate frames — give EITHER x/y OR q/r, not both: x/y are pixel coordinates on the ' +
+      'raw map image, the SAME frame as wiki DataMap marker positions, and are converted to hex ' +
+      'coordinates server-side using the map\'s grid geometry (from list_maps) — this is the ' +
+      'preferred way to pass a position sourced from a DataMap. q/r are axial hex coordinates ' +
+      'directly, for when you already know the hex (e.g. copied from list_locations).\n\n' +
+      'Field-merge semantics on update — READ CAREFULLY, this is not uniform: dmNotes, glyph, ' +
+      'wikiPage, and quest are replaced only if you pass a non-empty value (an empty ' +
+      'string/omitted field leaves the existing value alone). clues is similar in spirit but ' +
+      'stronger: passing a non-empty clues array fully REPLACES the existing clue list, while ' +
+      'clues:[] or an omitted clues field KEEPS the existing clues untouched (there is no way to ' +
+      'clear every clue through this tool — delete and recreate the location, or edit it in the ' +
+      'app). type, showLabel, scaleVisibility, enabled, and knownLocation are DIFFERENT and do ' +
+      'NOT merge: every call sets them to whatever you pass, or to their schema default ' +
+      '(type="landmark", showLabel=false, scaleVisibility=1, enabled=true, knownLocation=false) ' +
+      'if you omit them — even on an update to an existing location. Omitting one of these five ' +
+      'on a follow-up call SILENTLY RESETS it. To only touch dmNotes/glyph/wikiPage/quest/clues ' +
+      'on an existing location, you must still re-pass its current type, showLabel, ' +
+      'scaleVisibility, enabled, and knownLocation (read them first with list_locations) or they ' +
+      'will revert to defaults.\n\n' +
+      'scaleVisibility controls the coarsest hex-zoom level the pin appears at: 0 = only visible ' +
+      'zoomed all the way into fine hexes (hidden/small sites), 1 = fine + mid zoom (default), ' +
+      '2 = visible at every zoom including the coarsest (cities, major landmarks).\n\n' +
+      'knownLocation: true means players always see this pin\'s name and position even with zero ' +
+      'discoveries — use for well-known settlements. Its clues stay gated as normal: players ' +
+      'learn WHERE it is, not what is true about it (dmNotes and ungated clue content are never ' +
+      'sent to players regardless of this flag).\n\n' +
+      'Each clue has a gate (' +
+      GATE_DESCRIPTION +
+      ') plus optional indicatesDirection (appends an auto-computed compass bearing from the ' +
+      'discovering character to this hex, e.g. "... — to the north-east") and revealsLocation ' +
+      '(default true; set false for a clue that reveals information/rumor text without pinning ' +
+      'down the location itself — e.g. a rumor overheard in a tavern that names a threat but not ' +
+      'its lair).',
     inputSchema: {
       type: 'object',
       properties: {
-        mapId: { type: 'string' },
-        title: { type: 'string' },
-        x: { type: 'number', description: 'Pixel x on the map image' },
-        y: { type: 'number', description: 'Pixel y on the map image' },
-        q: { type: 'integer', description: 'Axial hex q (alternative to x/y)' },
-        r: { type: 'integer', description: 'Axial hex r (alternative to x/y)' },
+        mapId: { type: 'string', description: 'Map id from list_maps' },
+        title: { type: 'string', description: 'Match key for upsert — case-insensitive' },
+        x: { type: 'number', description: 'Pixel x on the map image (wiki DataMap frame). Alternative to q/r.' },
+        y: { type: 'number', description: 'Pixel y on the map image (wiki DataMap frame). Alternative to q/r.' },
+        q: { type: 'integer', description: 'Axial hex q. Alternative to x/y.' },
+        r: { type: 'integer', description: 'Axial hex r. Alternative to x/y.' },
         type: {
           type: 'string',
-          enum: ['lair', 'dungeon', 'settlement', 'ruin', 'landmark', 'lore', 'hazard', 'cache', 'other'],
+          enum: ['lair', 'dungeon', 'settlement', 'ruin', 'landmark', 'region', 'lore', 'hazard', 'cache', 'other'],
+          description: 'Does NOT merge — omitting this on an update resets it to "landmark".',
         },
-        glyph: { type: 'string', description: 'Emoji pin glyph, e.g. 🏰 🛖 🏚️ 🌲' },
-        dmNotes: { type: 'string' },
-        wikiPage: { type: 'string', description: 'Wiki article title (or full URL)' },
-        showLabel: { type: 'boolean', description: 'Always show the name on the map' },
-        scaleVisibility: { type: 'integer', minimum: 0, maximum: 2 },
+        glyph: { type: 'string', description: 'Emoji pin glyph, e.g. 🏰 🛖 🏚️ 🌲. Empty string keeps the existing glyph on update.' },
+        dmNotes: { type: 'string', description: 'DM-only notes. NEVER sent to players. Empty string keeps the existing value on update.' },
+        wikiPage: { type: 'string', description: 'Wiki article title (or full URL). Players get a "read more" link once they discover the location. Empty string keeps the existing value on update.' },
+        showLabel: { type: 'boolean', description: 'Always render the title as a map label, not just an icon. Does NOT merge — omitting this on an update resets it to false.' },
+        scaleVisibility: { type: 'integer', minimum: 0, maximum: 2, description: '0=fine only, 1=fine+mid, 2=every zoom. Does NOT merge — omitting this on an update resets it to 1.' },
+        enabled: { type: 'boolean', description: 'Disabled content does not exist yet for players: no pin, no clues. Does NOT merge — omitting this on an update resets it to true. Re-pass the current value from list_locations if you only mean to change other fields.' },
+        knownLocation: { type: 'boolean', description: 'Players always see the pin/name even with no discoveries; clues still gated. Does NOT merge — omitting this on an update resets it to false. Re-pass the current value from list_locations if you only mean to change other fields.' },
+        quest: { type: 'string', description: 'Free-form quest tag for grouping. Empty string keeps the existing value on update.' },
         clues: {
           type: 'array',
+          description:
+            'FULLY REPLACES the existing clue list when provided (including a non-empty array). ' +
+            'Omit this field, or pass clues:[], to leave existing clues untouched.',
           items: {
             type: 'object',
             properties: {
-              text: { type: 'string' },
-              gate: { type: 'object' },
-              indicatesDirection: {
-                type: 'boolean',
-                description:
-                  'Append an auto-computed compass bearing (from the character toward this location) to the delivered clue text, e.g. "… — to the north-east"',
-              },
+              text: { type: 'string', description: 'Player-facing text delivered on discovery. Never put DM-only/spoiler information here.' },
+              gate: { type: 'object', description: GATE_DESCRIPTION },
+              indicatesDirection: { type: 'boolean', description: 'Append an auto-computed compass bearing to the delivered text. Default: false.' },
+              revealsLocation: { type: 'boolean', description: 'Whether discovering this clue pins down the location on the map. Default: true; set false for rumor/info-only clues.' },
             },
             required: ['text'],
           },
@@ -96,11 +248,58 @@ const TOOLS = [
   },
   {
     name: 'delete_location',
-    description: 'Delete a location by its content id (from list_locations).',
+    description: 'Permanently delete a location by its content id (from list_locations). Irreversible.',
     inputSchema: {
       type: 'object',
       properties: { contentId: { type: 'string' } },
       required: ['contentId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'upsert_trail',
+    description:
+      'Create or update a trail (tracks/spoor players can discover and follow) — an ordered ' +
+      'path of hexes, matched to an existing trail by (mapId, name) case-insensitively so ' +
+      'calling this again with the same name updates that trail\'s path and settings in place. ' +
+      'Cells are axial q/r hex coordinates, at least 2, given in path order. Gate (' +
+      GATE_DESCRIPTION +
+      ') controls how the trail itself is discovered.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mapId: { type: 'string', description: 'Map id from list_maps' },
+        name: { type: 'string', description: 'Match key for upsert — case-insensitive' },
+        glyph: { type: 'string', description: 'Emoji marker for the trail. Default: 👣' },
+        dmNotes: { type: 'string', description: 'DM-only notes. NEVER sent to players.' },
+        gate: { type: 'object', description: GATE_DESCRIPTION },
+        cells: {
+          type: 'array',
+          description: 'Ordered hex path, at least 2 cells.',
+          items: {
+            type: 'object',
+            properties: { q: { type: 'integer' }, r: { type: 'integer' } },
+            required: ['q', 'r'],
+          },
+          minItems: 2,
+        },
+      },
+      required: ['mapId', 'name', 'cells'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'generate_settlement_clues',
+    description:
+      'Auto-generate the standard set of sensory discovery clues (smoke on the horizon, road ' +
+      'noise, etc.) for every location of type "settlement" on a map that does not already have ' +
+      'clues. Useful right after bulk-creating settlements with upsert_location. Idempotent — ' +
+      'settlements that already have clues are left untouched, so it is safe to call again after ' +
+      'adding new settlements.',
+    inputSchema: {
+      type: 'object',
+      properties: { mapId: { type: 'string', description: 'Map id from list_maps' } },
+      required: ['mapId'],
       additionalProperties: false,
     },
   },
@@ -116,6 +315,10 @@ async function callTool(name, args) {
       return api('POST', '/content', args);
     case 'delete_location':
       return api('DELETE', `/content/${encodeURIComponent(args.contentId)}`);
+    case 'upsert_trail':
+      return api('POST', '/trails', args);
+    case 'generate_settlement_clues':
+      return api('POST', '/generate-settlement-clues', args);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
@@ -139,7 +342,7 @@ rl.on('line', async (line) => {
       result: {
         protocolVersion: params?.protocolVersion ?? '2024-11-05',
         capabilities: { tools: {} },
-        serverInfo: { name: 'hexcrawl', version: '1.0.0' },
+        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
       },
     });
   } else if (method === 'tools/list') {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@hexcrawl/mcp",
+  "version": "1.0.0",
+  "description": "Dependency-free stdio MCP server bridging any AI assistant to a HexCrawl VTT campaign's integration API",
+  "type": "module",
+  "private": true,
+  "license": "UNLICENSED",
+  "bin": {
+    "hexcrawl-mcp": "./hexcrawl-mcp.mjs"
+  },
+  "files": [
+    "hexcrawl-mcp.mjs"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
Closes #72

## Summary

- Polished `mcp/hexcrawl-mcp.mjs`: fails fast at startup with an actionable
  error when `HEXCRAWL_URL`/`HEXCRAWL_CAMPAIGN`/`HEXCRAWL_TOKEN` are missing
  (instead of an opaque `fetch failed` on the first tool call); added
  `--help`/`--version`; wrapped `network`-level fetch/401 errors with clearer
  messages; added tools for the two existing REST endpoints that weren't
  exposed yet (`upsert_trail`, `generate_settlement_clues`); rewrote every
  tool description to precisely state coordinate frames (pixel/DataMap frame
  vs axial q/r) and upsert-by-title merge semantics.
- Added `mcp/package.json` (name, version, `bin`, `type: module`) for clean
  `npx`/direct-`node` invocation — no runtime dependencies added; the file
  lives outside the pnpm workspace glob (`packages/*`) so it doesn't affect
  `pnpm -r` commands.
- Added `docs/MCP.md`: what the MCP server is/isn't, the env contract table,
  registration examples for Claude Code, opencode, and generic stdio
  clients, the full tool reference, the REST integration API reference
  (including the wrong-path-returns-SPA-200 gotcha), and troubleshooting.
- Added `docs/skills/hexcrawl-campaign-assistant.md`: an instructions
  document an operator can hand to any AI assistant — the knowledge model
  (clues gated per character, `dmNotes` never sent to players), spoiler
  hygiene for wiki-backed workflows, upsert-by-title semantics, coordinate
  frames, MCP-vs-REST guidance, and worked examples (location with gated
  clues, a trail, bulk settlement-clue generation).
- README: added a short "AI integration" section linking both new docs.

## Docs notes

While writing the upsert-semantics section I found and verified (against a
running dev server) a real bug in the existing integration API, not touched
by this PR per the file-territory split with the other agents working in
`packages/**`:

**`POST /api/integration/campaigns/:id/content` does not merge `type`,
`showLabel`, `scaleVisibility`, `enabled`, or `knownLocation` on update.**
Unlike `dmNotes`/`glyph`/`wikiPage`/`quest` (which correctly fall back to
the existing value when omitted/empty), these five fields are always set to
whatever the request passes — or to the zod schema default
(`type: "landmark"`, `showLabel: false`, `scaleVisibility: 1`,
`enabled: true`, `knownLocation: false"`) when omitted, even when updating
an existing location. In `packages/server/src/http/app.ts` the `enabled`/
`knownLocation` lines use `input.enabled ?? existing?.enabled ?? true` —
but since the zod schema already applies `.default()`, `input.enabled` is
never `undefined` post-parse, so the `??` fallback is dead code and looks
intentional but isn't. Concretely: calling `upsert_location` a second time
with only `dmNotes` set silently resets the location's `type` to
`"landmark"`, its `showLabel`/`knownLocation` to `false`, and its
`scaleVisibility` to `1`. I worked around this by documenting the exact
behavior prominently in both new docs and in the tool's MCP description
(callers must `list_locations` first and re-pass all five fields on every
update), but the server-side fix — presumably making these five fields
merge the same way as `dmNotes`/`glyph`/`wikiPage`/`quest`, or explicitly
using `??`/`undefined`-preserving zod schemas so the existing fallback
logic actually runs — belongs in a follow-up touching `packages/server`.

Also noted as a gap (not a bug, just missing): there is no `GET` endpoint to
list or read back trails (`POST /trails` upsert exists, but nothing mirrors
`GET /maps/:mapId/content` for trails), so the MCP server/skill doc can't
offer a `list_trails` tool. Flagged in `docs/MCP.md`'s troubleshooting
section.

Also fixed a smaller drift: the MCP tool's `type` enum was missing the
`"region"` content type that already exists in
`packages/shared/src/domain.ts`'s `ContentTypeSchema` — added it to keep the
tool schema in sync with the shared schema (no server changes needed, since
the REST endpoint validates against the real schema already).

## Test plan

- [x] `pnpm typecheck && pnpm test` — green, untouched (no changes under
      `packages/**`)
- [x] `node mcp/hexcrawl-mcp.mjs` with no env — prints the actionable
      missing-variable error and exits 1
- [x] `node mcp/hexcrawl-mcp.mjs --help` / `--version` — work with no env set
- [x] Manually verified every tool (`list_maps`, `list_locations`,
      `upsert_location`, `upsert_trail`, `generate_settlement_clues`,
      `delete_location`) against a real dev server instance, including the
      `clues: []` keeps-existing-clues behavior and the merge-semantics bug
      noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)