### PR TITLE
DM map manager dialog with thumbnails and settings inheritance

### DIFF
--- a/docs/AI-DEVELOPMENT.md
+++ b/docs/AI-DEVELOPMENT.md
@@ -73,6 +73,14 @@ player-facing data).
   column means updating the CREATE TABLE, `ensureColumn`, the load mapping,
   and BOTH statements' argument lists — they desync silently. Prefer JSON
   blob columns for new map settings.
+- **Map settings inheritance is propagation-on-write** (#60): a map field named
+  in `MapInfo.inheritedFields` follows `campaign.settings.mapDefaults`, but the
+  map still stores a concrete value. `campaign.update` propagates changed
+  defaults (`runtime.propagateMapDefaults`), `map.update` drops any patched
+  field from `inheritedFields`, `map.setInherit` toggles one field. Add a new
+  shareable setting to `INHERITABLE_MAP_FIELDS` + `MapDefaultsSchema` (shared
+  `domain.ts`) and everything else follows; nothing resolves inheritance at
+  read time.
 - **Pixi v8 hit-testing:** any Graphics whose geometry covers the pointer
   terminates the hit search even when non-interactive. Every engine layer
   except `tokensC` must have `eventMode = 'none'` — new layers go in that

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -59,6 +59,13 @@ Right for personal-group use; role checks still happen on every server command.
   swamp, water, tundra, jungle, urban…) with color fill + pattern at configurable
   opacity. Brush paint for the DM. Terrain feeds encounter tables and travel pace.
 - Pan (drag) and zoom (wheel/pinch), 60fps with thousands of hexes via culling.
+- **Map manager dialog** (DM): every map with a thumbnail, its settings, ordering,
+  rename/activate/delete. Shareable settings (sight radius, fog mode/decay, move
+  mode/approval, miles per hex, encounter check) have **campaign defaults**
+  (`settings.mapDefaults`) that each map either follows or overrides per field
+  (`MapInfo.inheritedFields`). Inheritance is resolved *on write*: changing a
+  default immediately writes it into every map that follows it, so map values are
+  always concrete.
 
 ### Fog of war
 - Three per-hex states: **hidden** (opaque to players), **explored** (terrain visible,

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -51,6 +51,21 @@ export async function joinCampaign(
   return jsonOrThrow(res);
 }
 
+export interface MapThumb {
+  mapId: string;
+  /** Path of the first visible image layer, or null. */
+  image: string | null;
+  hexCount: number;
+}
+
+/** DM only: per-map summaries for the map manager (maps you aren't viewing). */
+export async function fetchMapThumbs(campaignId: string): Promise<MapThumb[]> {
+  const body = await jsonOrThrow<{ maps: MapThumb[] }>(
+    await fetch(`/api/campaigns/${campaignId}/map-thumbs`),
+  );
+  return body.maps;
+}
+
 export async function uploadMapImage(
   campaignId: string,
   mapId: string,

--- a/packages/client/src/components/MapManagerDialog.tsx
+++ b/packages/client/src/components/MapManagerDialog.tsx
@@ -1,0 +1,568 @@
+import React, { useEffect, useState } from 'react';
+import type { InheritableMapField, MapInfo } from '@hexcrawl/shared';
+import { fetchMapThumbs, type MapThumb } from '../api.js';
+import { useSession } from '../stores/session.js';
+import { send } from '../ws.js';
+import { Button, EmptyNote, Input, Select, cx } from '../ui/kit.js';
+
+/**
+ * DM map manager (issue #60): every map in one place, with thumbnails, and
+ * per-setting "linked to the campaign default" vs "map-specific".
+ *
+ * Inheritance is resolved server-side on write — a map's values are always
+ * concrete, `inheritedFields` only records which ones follow the campaign
+ * default. So this dialog reads plain map values and toggles links.
+ */
+export function MapManagerDialog({
+  campaignId,
+  onClose,
+}: {
+  campaignId: string;
+  onClose: () => void;
+}) {
+  const state = useSession((s) => s.state);
+  const maps = state?.maps ?? [];
+  const [selectedId, setSelectedId] = useState<string | null>(
+    state?.campaign.activeMapId ?? maps[0]?.id ?? null,
+  );
+  const [thumbs, setThumbs] = useState<Record<string, MapThumb>>({});
+  const [showDefaults, setShowDefaults] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Snapshots only carry the viewed map's image layers, so per-map summaries
+  // come from a small DM-only endpoint. Refetch when the map set changes.
+  const mapIds = maps.map((m) => m.id).join(',');
+  useEffect(() => {
+    let live = true;
+    void fetchMapThumbs(campaignId)
+      .then((rows) => {
+        if (!live) return;
+        setThumbs(Object.fromEntries(rows.map((r) => [r.mapId, r])));
+      })
+      .catch(() => {
+        /* thumbnails are cosmetic — a failure just leaves placeholders */
+      });
+    return () => {
+      live = false;
+    };
+  }, [campaignId, mapIds]);
+
+  const selected = maps.find((m) => m.id === selectedId) ?? maps[0] ?? null;
+
+  const move = (map: MapInfo, delta: number) => {
+    const ordered = [...maps].sort((a, b) => a.sortOrder - b.sortOrder);
+    const i = ordered.findIndex((m) => m.id === map.id);
+    const j = i + delta;
+    if (i < 0 || j < 0 || j >= ordered.length) return;
+    const other = ordered[j]!;
+    send({ kind: 'map.update', mapId: map.id, patch: { sortOrder: other.sortOrder } });
+    send({ kind: 'map.update', mapId: other.id, patch: { sortOrder: map.sortOrder } });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-ink-850 border border-ink-600 rounded-xl shadow-2xl w-full max-w-5xl h-[85vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-ink-700 shrink-0">
+          <h2 className="font-semibold text-ink-100">Maps</h2>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant={showDefaults ? 'primary' : 'ghost'}
+              onClick={() => setShowDefaults((v) => !v)}
+              title="Settings every linked map follows"
+            >
+              🔗 Campaign defaults
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close">
+              ✕
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 flex">
+          <div className="w-64 shrink-0 border-r border-ink-700 overflow-y-auto p-2 space-y-1.5">
+            {maps.length === 0 && <EmptyNote>No maps yet.</EmptyNote>}
+            {[...maps]
+              .sort((a, b) => a.sortOrder - b.sortOrder)
+              .map((m, i, arr) => (
+                <MapCard
+                  key={m.id}
+                  map={m}
+                  thumb={thumbs[m.id]}
+                  active={m.id === state?.campaign.activeMapId}
+                  selected={m.id === selected?.id}
+                  first={i === 0}
+                  last={i === arr.length - 1}
+                  onSelect={() => setSelectedId(m.id)}
+                  onMove={(d) => move(m, d)}
+                />
+              ))}
+          </div>
+
+          <div className="flex-1 min-w-0 overflow-y-auto p-4">
+            {showDefaults && <CampaignDefaults />}
+            {selected ? (
+              <MapSettingsForm key={selected.id} map={selected} canDelete={maps.length > 1} />
+            ) : (
+              <EmptyNote>Create a map in the Maps panel to configure it here.</EmptyNote>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MapCard({
+  map,
+  thumb,
+  active,
+  selected,
+  first,
+  last,
+  onSelect,
+  onMove,
+}: {
+  map: MapInfo;
+  thumb: MapThumb | undefined;
+  active: boolean;
+  selected: boolean;
+  first: boolean;
+  last: boolean;
+  onSelect: () => void;
+  onMove: (delta: number) => void;
+}) {
+  return (
+    <div
+      className={cx(
+        'rounded-lg border cursor-pointer overflow-hidden',
+        selected ? 'border-brass-500 bg-brass-500/10' : 'border-ink-700 hover:bg-ink-800',
+      )}
+      onClick={onSelect}
+    >
+      <Thumbnail map={map} thumb={thumb} />
+      <div className="flex items-center gap-1 px-2 py-1.5">
+        <span
+          className={cx('flex-1 min-w-0 truncate text-sm', selected ? 'text-brass-300' : 'text-ink-200')}
+        >
+          {map.name}
+        </span>
+        {active && <span className="text-[10px] text-brass-300">ACTIVE</span>}
+        <button
+          className="text-ink-400 hover:text-ink-100 text-xs cursor-pointer disabled:opacity-25"
+          disabled={first}
+          title="Move up"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMove(-1);
+          }}
+        >
+          ▲
+        </button>
+        <button
+          className="text-ink-400 hover:text-ink-100 text-xs cursor-pointer disabled:opacity-25"
+          disabled={last}
+          title="Move down"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMove(1);
+          }}
+        >
+          ▼
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** v1 thumbnail: the first visible image layer, else a placeholder tile. */
+function Thumbnail({ map, thumb }: { map: MapInfo; thumb: MapThumb | undefined }) {
+  if (thumb?.image) {
+    return (
+      <img
+        src={thumb.image}
+        alt=""
+        className="w-full h-20 object-cover bg-ink-900"
+        draggable={false}
+      />
+    );
+  }
+  return (
+    <div className="w-full h-20 bg-ink-900 flex flex-col items-center justify-center gap-0.5">
+      <span
+        className="text-lg text-ink-500 leading-none"
+        style={map.orientation === 'flat' ? { transform: 'rotate(90deg)' } : undefined}
+        title={map.orientation === 'flat' ? 'Flat-top hexes' : 'Pointy-top hexes'}
+      >
+        ⬡
+      </span>
+      <span className="text-[10px] text-ink-400">
+        {thumb ? `${thumb.hexCount} hex${thumb.hexCount === 1 ? '' : 'es'} painted` : 'no image'}
+      </span>
+    </div>
+  );
+}
+
+function num(v: string, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * One settings row with its link toggle. When linked, the control is disabled
+ * and the value shown is whatever the campaign default last wrote.
+ */
+function Row({
+  label,
+  field,
+  map,
+  children,
+  hint,
+}: {
+  label: string;
+  field: InheritableMapField | null;
+  map: MapInfo;
+  children: (disabled: boolean) => React.ReactNode;
+  hint?: string;
+}) {
+  const inherited = field !== null && map.inheritedFields.includes(field);
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="w-40 shrink-0 text-[11px] uppercase tracking-wider text-ink-400" title={hint}>
+        {label}
+      </span>
+      <div className={cx('flex-1 min-w-0', inherited && 'opacity-60')}>{children(inherited)}</div>
+      {field && (
+        <button
+          className={cx(
+            'text-xs w-7 shrink-0 cursor-pointer',
+            inherited ? 'text-brass-300' : 'text-ink-500 hover:text-ink-200',
+          )}
+          title={
+            inherited
+              ? 'Linked to the campaign default — click to make it map-specific'
+              : 'Map-specific — click to link it to the campaign default'
+          }
+          onClick={() => send({ kind: 'map.setInherit', mapId: map.id, field, inherit: !inherited })}
+        >
+          {inherited ? '🔗' : '✎'}
+        </button>
+      )}
+      {!field && <span className="w-7 shrink-0" />}
+    </div>
+  );
+}
+
+function MapSettingsForm({ map, canDelete }: { map: MapInfo; canDelete: boolean }) {
+  const patch = (p: Record<string, unknown>) =>
+    send({ kind: 'map.update', mapId: map.id, patch: p });
+  const active = useSession((s) => s.state?.campaign.activeMapId) === map.id;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 mb-3">
+        <Input
+          key={`name-${map.name}`}
+          defaultValue={map.name}
+          onBlur={(e) =>
+            e.target.value.trim() && e.target.value !== map.name && patch({ name: e.target.value.trim() })
+          }
+        />
+        <Button
+          size="sm"
+          variant={active ? 'ghost' : 'primary'}
+          disabled={active}
+          onClick={() => send({ kind: 'map.setActive', mapId: map.id })}
+        >
+          {active ? 'Active' : 'Set active'}
+        </Button>
+        <Button
+          size="sm"
+          variant="danger"
+          disabled={!canDelete}
+          title={canDelete ? undefined : 'A campaign needs at least one map'}
+          onClick={() => {
+            if (confirm(`Delete map "${map.name}" and everything on it?`)) {
+              send({ kind: 'map.delete', mapId: map.id });
+            }
+          }}
+        >
+          Delete
+        </Button>
+      </div>
+
+      <Row label="Orientation" field={null} map={map}>
+        {() => (
+          <Select value={map.orientation} onChange={(e) => patch({ orientation: e.target.value })}>
+            <option value="flat">Flat-top</option>
+            <option value="pointy">Pointy-top</option>
+          </Select>
+        )}
+      </Row>
+      <Row label="Hex size (px)" field={null} map={map}>
+        {() => (
+          <Input
+            type="number"
+            min={4}
+            max={512}
+            key={`hs-${map.hexSize}`}
+            defaultValue={map.hexSize}
+            onBlur={(e) => patch({ hexSize: Math.min(512, Math.max(4, num(e.target.value, map.hexSize))) })}
+          />
+        )}
+      </Row>
+      <Row label="Miles per hex" field="milesPerHex" map={map}>
+        {(disabled) => (
+          <Input
+            type="number"
+            disabled={disabled}
+            key={`mph-${map.milesPerHex}`}
+            defaultValue={map.milesPerHex}
+            onBlur={(e) => patch({ milesPerHex: Math.max(0, num(e.target.value, map.milesPerHex)) })}
+          />
+        )}
+      </Row>
+      <Row label="Sight radius" field="sightRadius" map={map}>
+        {(disabled) => (
+          <Input
+            type="number"
+            min={0}
+            max={10}
+            disabled={disabled}
+            key={`sr-${map.sightRadius}`}
+            defaultValue={map.sightRadius}
+            onBlur={(e) =>
+              patch({ sightRadius: Math.min(10, Math.max(0, Math.round(num(e.target.value, map.sightRadius)))) })
+            }
+          />
+        )}
+      </Row>
+      <Row label="Fog mode" field="fogMode" map={map}>
+        {(disabled) => (
+          <Select disabled={disabled} value={map.fogMode} onChange={(e) => patch({ fogMode: e.target.value })}>
+            <option value="auto">Auto-reveal</option>
+            <option value="manual">Manual only</option>
+          </Select>
+        )}
+      </Row>
+      <Row label="Fog decay" field="fogDecay" map={map} hint="Fade to explored when out of sight">
+        {(disabled) => (
+          <CheckLine
+            disabled={disabled}
+            checked={map.fogDecay}
+            label="Fade to explored when out of sight"
+            onChange={(v) => patch({ fogDecay: v })}
+          />
+        )}
+      </Row>
+      <Row label="Movement" field="moveMode" map={map}>
+        {(disabled) => (
+          <Select disabled={disabled} value={map.moveMode} onChange={(e) => patch({ moveMode: e.target.value })}>
+            <option value="free">Free drag</option>
+            <option value="step">One hex/step</option>
+          </Select>
+        )}
+      </Row>
+      <Row label="Move approval" field="moveApproval" map={map}>
+        {(disabled) => (
+          <CheckLine
+            disabled={disabled}
+            checked={map.moveApproval}
+            label="DM approves player movement"
+            onChange={(v) => patch({ moveApproval: v })}
+          />
+        )}
+      </Row>
+      <Row label="Encounter check" field="encounterCheck" map={map} hint="Die, threshold, and auto-check cadence">
+        {(disabled) => (
+          <EncounterFields
+            disabled={disabled}
+            value={map.encounterCheck}
+            onChange={(p) => patch({ encounterCheck: p })}
+          />
+        )}
+      </Row>
+    </div>
+  );
+}
+
+function CheckLine({
+  checked,
+  label,
+  disabled,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  disabled: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className={cx('flex items-center gap-2 text-sm', disabled ? 'text-ink-400' : 'text-ink-200 cursor-pointer')}>
+      <input
+        type="checkbox"
+        disabled={disabled}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+}
+
+function EncounterFields({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: { die: string; threshold: number; autoEvery: number };
+  disabled: boolean;
+  onChange: (patch: { die?: string; threshold?: number; autoEvery?: number }) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-1.5">
+      <Input
+        disabled={disabled}
+        key={`die-${value.die}`}
+        defaultValue={value.die}
+        title="Die rolled for the encounter check"
+        onBlur={(e) => e.target.value.trim() && e.target.value !== value.die && onChange({ die: e.target.value.trim() })}
+      />
+      <Input
+        type="number"
+        disabled={disabled}
+        key={`th-${value.threshold}`}
+        defaultValue={value.threshold}
+        title="An encounter occurs on a roll at or above this"
+        onBlur={(e) => onChange({ threshold: Math.round(num(e.target.value, value.threshold)) })}
+      />
+      <Input
+        type="number"
+        min={0}
+        max={99}
+        disabled={disabled}
+        key={`ae-${value.autoEvery}`}
+        defaultValue={value.autoEvery}
+        title="Auto-roll a check every N hexes travelled (0 = off)"
+        onBlur={(e) =>
+          onChange({ autoEvery: Math.min(99, Math.max(0, Math.round(num(e.target.value, value.autoEvery)))) })
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * The campaign-wide defaults. Saving one pushes it straight into every map
+ * that still has that field linked.
+ */
+function CampaignDefaults() {
+  const defaults = useSession((s) => s.state?.campaign.settings.mapDefaults);
+  const maps = useSession((s) => s.state?.maps) ?? [];
+  if (!defaults) return null;
+  const set = (p: Record<string, unknown>) =>
+    send({ kind: 'campaign.update', settings: { mapDefaults: p } });
+  const linked = (field: InheritableMapField) =>
+    maps.filter((m) => m.inheritedFields.includes(field)).length;
+
+  return (
+    <div className="mb-4 rounded-lg border border-brass-500/40 bg-brass-500/5 p-3">
+      <p className="text-[11px] uppercase tracking-wider text-brass-300 font-semibold mb-1">
+        Campaign defaults
+      </p>
+      <p className="text-xs text-ink-400 mb-2">
+        Changing one of these updates every map with that setting linked ({maps.length} map
+        {maps.length === 1 ? '' : 's'} total).
+      </p>
+      <div className="space-y-1">
+        <DefaultRow label="Miles per hex" count={linked('milesPerHex')}>
+          <Input
+            type="number"
+            key={`d-mph-${defaults.milesPerHex}`}
+            defaultValue={defaults.milesPerHex}
+            onBlur={(e) => set({ milesPerHex: Math.max(0, num(e.target.value, defaults.milesPerHex)) })}
+          />
+        </DefaultRow>
+        <DefaultRow label="Sight radius" count={linked('sightRadius')}>
+          <Input
+            type="number"
+            min={0}
+            max={10}
+            key={`d-sr-${defaults.sightRadius}`}
+            defaultValue={defaults.sightRadius}
+            onBlur={(e) =>
+              set({ sightRadius: Math.min(10, Math.max(0, Math.round(num(e.target.value, defaults.sightRadius)))) })
+            }
+          />
+        </DefaultRow>
+        <DefaultRow label="Fog mode" count={linked('fogMode')}>
+          <Select value={defaults.fogMode} onChange={(e) => set({ fogMode: e.target.value })}>
+            <option value="auto">Auto-reveal</option>
+            <option value="manual">Manual only</option>
+          </Select>
+        </DefaultRow>
+        <DefaultRow label="Fog decay" count={linked('fogDecay')}>
+          <CheckLine
+            disabled={false}
+            checked={defaults.fogDecay}
+            label="Fade to explored when out of sight"
+            onChange={(v) => set({ fogDecay: v })}
+          />
+        </DefaultRow>
+        <DefaultRow label="Movement" count={linked('moveMode')}>
+          <Select value={defaults.moveMode} onChange={(e) => set({ moveMode: e.target.value })}>
+            <option value="free">Free drag</option>
+            <option value="step">One hex/step</option>
+          </Select>
+        </DefaultRow>
+        <DefaultRow label="Move approval" count={linked('moveApproval')}>
+          <CheckLine
+            disabled={false}
+            checked={defaults.moveApproval}
+            label="DM approves player movement"
+            onChange={(v) => set({ moveApproval: v })}
+          />
+        </DefaultRow>
+        <DefaultRow label="Encounter check" count={linked('encounterCheck')}>
+          <EncounterFields
+            disabled={false}
+            value={defaults.encounterCheck}
+            onChange={(p) => set({ encounterCheck: p })}
+          />
+        </DefaultRow>
+      </div>
+    </div>
+  );
+}
+
+function DefaultRow({
+  label,
+  count,
+  children,
+}: {
+  label: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="w-40 shrink-0 text-[11px] uppercase tracking-wider text-ink-400">{label}</span>
+      <div className="flex-1 min-w-0">{children}</div>
+      <span className="w-16 shrink-0 text-right text-[10px] text-ink-500" title="Maps following this default">
+        🔗 {count}
+      </span>
+    </div>
+  );
+}

--- a/packages/client/src/components/panels/MapsTab.tsx
+++ b/packages/client/src/components/panels/MapsTab.tsx
@@ -3,12 +3,14 @@ import type { ImageLayer, MapInfo } from '@hexcrawl/shared';
 import { activeMap, useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { uploadMapImage } from '../../api.js';
-import { Button, EmptyNote, Field, Input, Section, Select, Toggle, cx } from '../../ui/kit.js';
+import { Button, EmptyNote, Field, Input, Section, cx } from '../../ui/kit.js';
+import { MapManagerDialog } from '../MapManagerDialog.js';
 
 export function MapsTab({ campaignId }: { campaignId: string }) {
   const state = useSession((s) => s.state);
   const map = activeMap(state);
   const [newName, setNewName] = useState('');
+  const [managing, setManaging] = useState(false);
 
   if (!state) return null;
 
@@ -20,7 +22,22 @@ export function MapsTab({ campaignId }: { campaignId: string }) {
 
   return (
     <div>
-      <Section title="Maps">
+      {managing && (
+        <MapManagerDialog campaignId={campaignId} onClose={() => setManaging(false)} />
+      )}
+      <Section
+        title="Maps"
+        actions={
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setManaging(true)}
+            title="Thumbnails, per-map settings, and campaign defaults in one place"
+          >
+            Manage maps
+          </Button>
+        }
+      >
         <ul className="space-y-1 mb-2">
           {state.maps.map((m) => (
             <li
@@ -81,89 +98,18 @@ function MapSettings({ map, campaignId }: { map: MapInfo; campaignId: string }) 
 
   return (
     <>
-      <Section title="Map settings">
-        <div className="space-y-2.5">
-          <Field label="Name">
-            <Input
-              defaultValue={map.name}
-              onBlur={(e) => e.target.value.trim() && e.target.value !== map.name && patch({ name: e.target.value.trim() })}
-            />
-          </Field>
-          <div className="grid grid-cols-2 gap-2">
-            <Field label="Orientation">
-              <Select
-                value={map.orientation}
-                onChange={(e) => patch({ orientation: e.target.value })}
-              >
-                <option value="flat">Flat-top</option>
-                <option value="pointy">Pointy-top</option>
-              </Select>
-            </Field>
-            <Field label="Hex size (px)">
-              <Input
-                type="number"
-                min={4}
-                max={512}
-                defaultValue={map.hexSize}
-                onBlur={(e) => patch({ hexSize: Math.min(512, Math.max(4, num(e.target.value, map.hexSize))) })}
-              />
-            </Field>
-            <Field label="Miles per hex">
-              <Input
-                type="number"
-                defaultValue={map.milesPerHex}
-                onBlur={(e) => patch({ milesPerHex: Math.max(0, num(e.target.value, map.milesPerHex)) })}
-              />
-            </Field>
-            <Field label="Movement">
-              <Select value={map.moveMode} onChange={(e) => patch({ moveMode: e.target.value })}>
-                <option value="free">Free drag</option>
-                <option value="step">One hex/step</option>
-              </Select>
-            </Field>
-          </div>
-        </div>
-      </Section>
-
-      <Section title="Fog & sight">
-        <div className="space-y-2.5">
-          <div className="grid grid-cols-2 gap-2">
-            <Field label="Fog mode">
-              <Select value={map.fogMode} onChange={(e) => patch({ fogMode: e.target.value })}>
-                <option value="auto">Auto-reveal</option>
-                <option value="manual">Manual only</option>
-              </Select>
-            </Field>
-            <Field label="Sight radius">
-              <Input
-                type="number"
-                min={0}
-                max={10}
-                defaultValue={map.sightRadius}
-                onBlur={(e) => patch({ sightRadius: Math.min(10, Math.max(0, Math.round(num(e.target.value, map.sightRadius)))) })}
-              />
-            </Field>
-          </div>
-          <Toggle
-            checked={map.fogDecay}
-            onChange={(v) => patch({ fogDecay: v })}
-            label="Fade to explored when out of sight"
-          />
-          <Toggle
-            checked={map.moveApproval}
-            onChange={(v) => patch({ moveApproval: v })}
-            label="DM approves player movement (turn-based travel)"
-          />
-          <Button
-            size="sm"
-            variant="ghost"
-            className="w-full"
-            title="Add smoke/din/smell clues (with auto compass bearings) to every settlement on this map that doesn't have them. Safe to run again."
-            onClick={() => send({ kind: 'clues.generateSettlements', mapId: map.id })}
-          >
-            🏘️ Generate settlement sensory clues
-          </Button>
-        </div>
+      {/* Name, orientation, hex size, fog, movement, miles per hex and the
+          encounter check all live in the map manager dialog (issue #60). */}
+      <Section title="Clues">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full"
+          title="Add smoke/din/smell clues (with auto compass bearings) to every settlement on this map that doesn't have them. Safe to run again."
+          onClick={() => send({ kind: 'clues.generateSettlements', mapId: map.id })}
+        >
+          🏘️ Generate settlement sensory clues
+        </Button>
       </Section>
 
       <Section title="Grid style">

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -239,6 +239,9 @@ function migrate(d: DB): void {
   ensureColumn(d, 'content', 'known_location', 'INTEGER NOT NULL DEFAULT 0');
   // Campaign clock (issue #57): JSON blob, zod defaults make it migration-free.
   ensureColumn(d, 'campaign', 'time', "TEXT NOT NULL DEFAULT '{}'");
+  // Map settings inherited from campaign.settings.mapDefaults (issue #60):
+  // JSON array of field names. Existing maps inherit nothing.
+  ensureColumn(d, 'map', 'inherited_fields', "TEXT NOT NULL DEFAULT '[]'");
 }
 
 function ensureColumn(d: DB, table: string, column: string, decl: string): void {

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -199,6 +199,24 @@ export function createApp(store: Store, hub: Hub): Hono {
     return c.json({ layer });
   });
 
+  /**
+   * DM only: one summary row per map for the map manager's thumbnails.
+   * Snapshots only carry the viewed map's layers, so this fills the gap for
+   * every other map without bloating (or leaking) the state sync.
+   */
+  app.get('/api/campaigns/:id/map-thumbs', (c) => {
+    const runtime = store.getCampaign(c.req.param('id'));
+    if (!runtime) return c.json({ error: 'Campaign not found' }, 404);
+    const seat = getSeat(c, runtime);
+    if (!seat || seat.role !== 'dm') return c.json({ error: 'DM only' }, 403);
+    const maps = [...runtime.maps.values()].map((m) => ({
+      mapId: m.id,
+      image: runtime.imageLayersFor(m.id).find((l) => l.visible)?.path ?? null,
+      hexCount: runtime.mapStates.get(m.id)?.hexes.size ?? 0,
+    }));
+    return c.json({ maps });
+  });
+
   // -- uploaded files (images are not secret; ids are unguessable) -----------
 
   app.get('/uploads/:campaignId/:file', (c) => {

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -1078,3 +1078,109 @@ describe('campaign clock (issue #57)', () => {
     expect(playerView.campaign.time.minutes).toBe(runtime.campaign.time.minutes);
   });
 });
+
+describe('campaign map defaults + per-map inheritance (issue #60)', () => {
+  const mapById = (id: string) => runtime.maps.get(id)!;
+
+  it('new maps follow every campaign default, keeping the pre-inheritance values', () => {
+    const map = mapById(activeMapId());
+    expect(map.inheritedFields).toEqual([
+      'sightRadius',
+      'fogMode',
+      'fogDecay',
+      'moveMode',
+      'moveApproval',
+      'milesPerHex',
+      'encounterCheck',
+    ]);
+    expect(map).toMatchObject({
+      sightRadius: 1,
+      fogMode: 'auto',
+      fogDecay: false,
+      moveMode: 'free',
+      moveApproval: false,
+      milesPerHex: 6,
+    });
+  });
+
+  it('(a) changing a campaign default propagates to every inheriting map', () => {
+    const mapId = activeMapId();
+    dm({ kind: 'map.create', name: 'Dungeon', orientation: 'pointy', hexSize: 32 } as never);
+    const otherId = [...runtime.maps.values()].find((m) => m.name === 'Dungeon')!.id;
+
+    dm({
+      kind: 'campaign.update',
+      settings: { mapDefaults: { sightRadius: 4, encounterCheck: { autoEvery: 3 } } },
+    } as never);
+
+    expect(runtime.campaign.settings.mapDefaults.sightRadius).toBe(4);
+    for (const id of [mapId, otherId]) {
+      expect(mapById(id).sightRadius).toBe(4);
+      expect(mapById(id).encounterCheck.autoEvery).toBe(3);
+      // A one-field patch is not a reset of its siblings.
+      expect(mapById(id).milesPerHex).toBe(6);
+      expect(mapById(id).encounterCheck.threshold).toBe(18);
+    }
+
+    // Defaults and links survive a restart.
+    const db = (store as unknown as { db: unknown }).db;
+    const reloaded = new Store(db as never).getCampaign(runtime.id)!;
+    expect(reloaded.campaign.settings.mapDefaults.sightRadius).toBe(4);
+    expect(reloaded.maps.get(mapId)!.sightRadius).toBe(4);
+    expect(reloaded.maps.get(mapId)!.inheritedFields).toContain('sightRadius');
+  });
+
+  it('(b) editing a field on a map overrides it — the default stops flowing', () => {
+    const mapId = activeMapId();
+    dm({ kind: 'map.update', mapId, patch: { sightRadius: 7 } } as never);
+    expect(mapById(mapId).sightRadius).toBe(7);
+    expect(mapById(mapId).inheritedFields).not.toContain('sightRadius');
+    expect(mapById(mapId).inheritedFields).toContain('milesPerHex');
+
+    dm({
+      kind: 'campaign.update',
+      settings: { mapDefaults: { sightRadius: 2, milesPerHex: 24 } },
+    } as never);
+    expect(mapById(mapId).sightRadius).toBe(7);
+    expect(mapById(mapId).milesPerHex).toBe(24);
+  });
+
+  it('(c) map.setInherit unlinks a field and relinks it to the current default', () => {
+    const mapId = activeMapId();
+    dm({ kind: 'campaign.update', settings: { mapDefaults: { fogMode: 'manual' } } } as never);
+    expect(mapById(mapId).fogMode).toBe('manual');
+
+    // Unlinked: the map keeps its value and ignores later defaults.
+    dm({ kind: 'map.setInherit', mapId, field: 'fogMode', inherit: false } as never);
+    expect(mapById(mapId).inheritedFields).not.toContain('fogMode');
+    dm({ kind: 'campaign.update', settings: { mapDefaults: { fogMode: 'auto' } } } as never);
+    expect(mapById(mapId).fogMode).toBe('manual');
+
+    // Relinked: the current default lands on the map immediately.
+    dm({ kind: 'map.setInherit', mapId, field: 'fogMode', inherit: true } as never);
+    expect(mapById(mapId).fogMode).toBe('auto');
+    expect(mapById(mapId).inheritedFields).toContain('fogMode');
+
+    // encounterCheck relinks its shareable keys, leaving server bookkeeping.
+    dm({ kind: 'map.update', mapId, patch: { encounterCheck: { threshold: 11 } } } as never);
+    expect(mapById(mapId).inheritedFields).not.toContain('encounterCheck');
+    dm({ kind: 'map.setInherit', mapId, field: 'encounterCheck', inherit: true } as never);
+    expect(mapById(mapId).encounterCheck.threshold).toBe(18);
+    expect(mapById(mapId).encounterCheck.hexesSinceCheck).toBe(0);
+  });
+
+  it('players cannot touch map defaults or inheritance', () => {
+    const player = runtime.createSeat('player', 'Mallory');
+    const mapId = activeMapId();
+    expect(() =>
+      asSeat(player, {
+        kind: 'campaign.update',
+        settings: { mapDefaults: { sightRadius: 9 } },
+      } as never),
+    ).toThrow(/DM/);
+    expect(() =>
+      asSeat(player, { kind: 'map.setInherit', mapId, field: 'fogMode', inherit: false } as never),
+    ).toThrow(/DM/);
+    expect(mapById(mapId).sightRadius).toBe(1);
+  });
+});

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -15,7 +15,9 @@ import type {
   HexCell,
   HexVisit,
   ImageLayer,
+  InheritableMapField,
   LogEntry,
+  MapDefaults,
   MapInfo,
   MapState,
   Marker,
@@ -30,6 +32,7 @@ import {
   EncounterCheckConfigSchema,
   GateSchema,
   GridStyleSchema,
+  INHERITABLE_MAP_FIELDS,
   SkillsSchema,
   hexKey,
   parseHexKey,
@@ -44,6 +47,13 @@ export interface SeatRecord {
   token: string;
   characterId: string | null;
 }
+
+/** Nested patch shape for campaign settings (mapDefaults merges field-wise). */
+export type CampaignSettingsPatch = Partial<Omit<CampaignSettings, 'mapDefaults'>> & {
+  mapDefaults?: Partial<Omit<MapDefaults, 'encounterCheck'>> & {
+    encounterCheck?: Partial<MapDefaults['encounterCheck']>;
+  };
+};
 
 export interface MapRuntime {
   hexes: Map<string, TerrainId>;
@@ -187,6 +197,9 @@ export class CampaignRuntime {
         milesPerHex: m.miles_per_hex as number,
         encounterCheck: EncounterCheckConfigSchema.parse(safeJson(m.encounter_check as string)),
         sortOrder: m.sort_order as number,
+        inheritedFields: (safeJson(m.inherited_fields as string, []) as unknown[]).filter(
+          (f): f is string => typeof f === 'string',
+        ),
       };
       this.maps.set(info.id, info);
       this.mapStates.set(info.id, this.loadMapRuntime(info.id));
@@ -482,9 +495,25 @@ export class CampaignRuntime {
 
   // -- campaign / seats / characters ----------------------------------------
 
-  updateCampaign(patch: { name?: string; settings?: Partial<CampaignSettings> }): void {
+  updateCampaign(patch: { name?: string; settings?: CampaignSettingsPatch }): void {
     if (patch.name !== undefined) this.campaign.name = patch.name;
-    if (patch.settings) this.campaign.settings = { ...this.campaign.settings, ...patch.settings };
+    if (patch.settings) {
+      const { mapDefaults, ...rest } = patch.settings;
+      const next: CampaignSettings = { ...this.campaign.settings, ...rest };
+      if (mapDefaults) {
+        // mapDefaults is a nested patch: merge field-wise (and its own
+        // encounterCheck sub-object) so a one-field patch isn't a reset.
+        next.mapDefaults = {
+          ...this.campaign.settings.mapDefaults,
+          ...mapDefaults,
+          encounterCheck: {
+            ...this.campaign.settings.mapDefaults.encounterCheck,
+            ...(mapDefaults.encounterCheck ?? {}),
+          },
+        };
+      }
+      this.campaign.settings = next;
+    }
     this.db
       .prepare('UPDATE campaign SET name = ?, settings = ? WHERE id = ?')
       .run(this.campaign.name, JSON.stringify(this.campaign.settings), this.id);
@@ -655,8 +684,9 @@ export class CampaignRuntime {
     this.db
       .prepare(
         `INSERT INTO map (id, campaign_id, name, orientation, hex_size, origin_x, origin_y, grid_style,
-          sight_radius, fog_mode, fog_decay, move_mode, miles_per_hex, encounter_check, sort_order, move_approval)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          sight_radius, fog_mode, fog_decay, move_mode, miles_per_hex, encounter_check, sort_order, move_approval,
+          inherited_fields)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
       )
       .run(
         info.id,
@@ -675,6 +705,7 @@ export class CampaignRuntime {
         JSON.stringify(info.encounterCheck),
         info.sortOrder,
         info.moveApproval ? 1 : 0,
+        JSON.stringify(info.inheritedFields),
       );
   }
 
@@ -692,7 +723,8 @@ export class CampaignRuntime {
     this.db
       .prepare(
         `UPDATE map SET name=?, orientation=?, hex_size=?, origin_x=?, origin_y=?, grid_style=?,
-          sight_radius=?, fog_mode=?, fog_decay=?, move_mode=?, miles_per_hex=?, encounter_check=?, sort_order=?, move_approval=?
+          sight_radius=?, fog_mode=?, fog_decay=?, move_mode=?, miles_per_hex=?, encounter_check=?, sort_order=?, move_approval=?,
+          inherited_fields=?
          WHERE id=?`,
       )
       .run(
@@ -710,9 +742,71 @@ export class CampaignRuntime {
         JSON.stringify(updated.encounterCheck),
         updated.sortOrder,
         updated.moveApproval ? 1 : 0,
+        JSON.stringify(updated.inheritedFields),
         mapId,
       );
     return updated;
+  }
+
+  // -- campaign map defaults (inheritance, issue #60) -------------------------
+
+  /**
+   * Push the campaign defaults for `fields` into every map that inherits
+   * them. Propagation-on-write: maps always hold concrete values, so nothing
+   * downstream has to resolve inheritance. Returns the ids of maps changed.
+   */
+  propagateMapDefaults(fields: readonly InheritableMapField[] = INHERITABLE_MAP_FIELDS): string[] {
+    const defaults = this.campaign.settings.mapDefaults;
+    const touched: string[] = [];
+    for (const map of [...this.maps.values()]) {
+      const patch: Partial<MapInfo> = {};
+      for (const field of fields) {
+        if (!map.inheritedFields.includes(field)) continue;
+        if (field === 'encounterCheck') {
+          patch.encounterCheck = { ...map.encounterCheck, ...defaults.encounterCheck };
+        } else {
+          Object.assign(patch, { [field]: defaults[field] });
+        }
+      }
+      if (Object.keys(patch).length > 0) {
+        this.updateMap(map.id, patch);
+        touched.push(map.id);
+      }
+    }
+    return touched;
+  }
+
+  /**
+   * Link one map setting to the campaign default (copying the default in
+   * right away) or cut it loose as map-specific.
+   */
+  setMapInherit(mapId: string, field: InheritableMapField, inherit: boolean): MapInfo {
+    const map = this.maps.get(mapId);
+    if (!map) throw new Error('Map not found');
+    const inheritedFields = map.inheritedFields.filter((f) => f !== field);
+    if (!inherit) return this.updateMap(mapId, { inheritedFields });
+    const defaults = this.campaign.settings.mapDefaults;
+    const patch: Partial<MapInfo> = { inheritedFields: [...inheritedFields, field] };
+    if (field === 'encounterCheck') {
+      patch.encounterCheck = { ...map.encounterCheck, ...defaults.encounterCheck };
+    } else {
+      Object.assign(patch, { [field]: defaults[field] });
+    }
+    return this.updateMap(mapId, patch);
+  }
+
+  /** A map's settings as the campaign defaults would have them. */
+  mapDefaultsForNewMap(): Pick<MapInfo, InheritableMapField> {
+    const d = this.campaign.settings.mapDefaults;
+    return {
+      sightRadius: d.sightRadius,
+      fogMode: d.fogMode,
+      fogDecay: d.fogDecay,
+      moveMode: d.moveMode,
+      moveApproval: d.moveApproval,
+      milesPerHex: d.milesPerHex,
+      encounterCheck: EncounterCheckConfigSchema.parse({ ...d.encounterCheck }),
+    };
   }
 
   deleteMap(mapId: string): void {

--- a/packages/server/src/state/store.ts
+++ b/packages/server/src/state/store.ts
@@ -1,5 +1,9 @@
 import { nanoid } from 'nanoid';
-import { EncounterCheckConfigSchema, GridStyleSchema } from '@hexcrawl/shared';
+import {
+  EncounterCheckConfigSchema,
+  GridStyleSchema,
+  INHERITABLE_MAP_FIELDS,
+} from '@hexcrawl/shared';
 import type { DB } from '../db/index.js';
 import { CampaignRuntime, type SeatRecord } from './runtime.js';
 
@@ -57,6 +61,7 @@ export class Store {
       milesPerHex: 6,
       encounterCheck: EncounterCheckConfigSchema.parse({}),
       sortOrder: 0,
+      inheritedFields: [...INHERITABLE_MAP_FIELDS],
     });
     runtime.setActiveMap(mapId);
     return { runtime, dmSeat };

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -3,6 +3,7 @@ import type {
   ClientCommand,
   Clue,
   Content,
+  InheritableMapField,
   LogEntry,
   MapInfo,
   Rng,
@@ -10,11 +11,11 @@ import type {
 } from '@hexcrawl/shared';
 import {
   compassDirection,
-  EncounterCheckConfigSchema,
   formatClock,
   formatDuration,
   GridStyleSchema,
   hexDistance,
+  INHERITABLE_MAP_FIELDS,
   hexKey,
   hexLine,
   minutesPerHex,
@@ -159,6 +160,13 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     requireDm(ctx);
     const wasPaused = ctx.runtime.campaign.settings.pausePlayerMapSync;
     ctx.runtime.updateCampaign({ name: cmd.name, settings: cmd.settings });
+    // Changed map defaults flow straight into every map inheriting them.
+    if (cmd.settings?.mapDefaults) {
+      const changed = Object.keys(cmd.settings.mapDefaults).filter((f): f is InheritableMapField =>
+        (INHERITABLE_MAP_FIELDS as readonly string[]).includes(f),
+      );
+      if (changed.length > 0) ctx.runtime.propagateMapDefaults(changed);
+    }
     const nowPaused = ctx.runtime.campaign.settings.pausePlayerMapSync;
     // Entering prep mode freezes what players currently see; leaving it
     // releases the snapshot so the next sync shows everything at once.
@@ -169,6 +177,8 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
   // -- maps ------------------------------------------------------------------
   'map.create': ((cmd: Extract<ClientCommand, { kind: 'map.create' }>, ctx: Ctx) => {
     requireDm(ctx);
+    // New maps start out following every campaign default; the DM unlinks
+    // whichever settings should be map-specific (or just edits them).
     const map: MapInfo = {
       id: nanoid(10),
       name: cmd.name,
@@ -177,14 +187,9 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       originX: 0,
       originY: 0,
       gridStyle: GridStyleSchema.parse({}),
-      sightRadius: 1,
-      fogMode: 'auto',
-      fogDecay: false,
-      moveMode: 'free',
-      moveApproval: false,
-      milesPerHex: 6,
-      encounterCheck: EncounterCheckConfigSchema.parse({}),
+      ...ctx.runtime.mapDefaultsForNewMap(),
       sortOrder: ctx.runtime.maps.size,
+      inheritedFields: [...INHERITABLE_MAP_FIELDS],
     };
     ctx.runtime.createMap(map);
     if (!ctx.runtime.campaign.activeMapId) ctx.runtime.setActiveMap(map.id);
@@ -192,7 +197,23 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
 
   'map.update': ((cmd: Extract<ClientCommand, { kind: 'map.update' }>, ctx: Ctx) => {
     requireDm(ctx);
-    ctx.runtime.updateMap(cmd.mapId, cmd.patch as Partial<MapInfo>);
+    const map = ctx.runtime.maps.get(cmd.mapId);
+    if (!map) throw new Error('Map not found');
+    // Editing a field explicitly means this map now owns it: drop it from the
+    // fields following the campaign defaults.
+    const overridden = Object.keys(cmd.patch).filter((f) => map.inheritedFields.includes(f));
+    const patch = cmd.patch as Partial<MapInfo>;
+    ctx.runtime.updateMap(
+      cmd.mapId,
+      overridden.length > 0
+        ? { ...patch, inheritedFields: map.inheritedFields.filter((f) => !overridden.includes(f)) }
+        : patch,
+    );
+  }) as Handler,
+
+  'map.setInherit': ((cmd: Extract<ClientCommand, { kind: 'map.setInherit' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    ctx.runtime.setMapInherit(cmd.mapId, cmd.field, cmd.inherit);
   }) as Handler,
 
   'map.delete': ((cmd: Extract<ClientCommand, { kind: 'map.delete' }>, ctx: Ctx) => {

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -91,6 +91,42 @@ export const CustomTravelModeSchema = z.object({
 });
 export type CustomTravelMode = z.infer<typeof CustomTravelModeSchema>;
 
+/**
+ * Map settings that can be shared campaign-wide. A map lists the ones it
+ * follows in `MapInfo.inheritedFields`; the server propagates a changed
+ * default into every map inheriting that field (see the map manager, #60).
+ * Defaults here mirror the values `map.create` used before inheritance
+ * existed, so a brand-new campaign behaves exactly as it always did.
+ */
+const MapEncounterDefaultsSchema = z.object({
+  die: z.string().default('1d20'),
+  threshold: z.number().int().default(18),
+  autoEvery: z.number().int().min(0).max(99).default(0),
+});
+
+export const MapDefaultsSchema = z.object({
+  sightRadius: z.number().int().min(0).max(10).default(1),
+  fogMode: z.enum(['manual', 'auto']).default('auto'),
+  fogDecay: z.boolean().default(false),
+  moveMode: z.enum(['step', 'free']).default('free'),
+  moveApproval: z.boolean().default(false),
+  milesPerHex: z.number().min(0).max(1000).default(6),
+  encounterCheck: MapEncounterDefaultsSchema.default(() => MapEncounterDefaultsSchema.parse({})),
+});
+export type MapDefaults = z.infer<typeof MapDefaultsSchema>;
+
+/** The map fields that can follow the campaign defaults. */
+export const INHERITABLE_MAP_FIELDS = [
+  'sightRadius',
+  'fogMode',
+  'fogDecay',
+  'moveMode',
+  'moveApproval',
+  'milesPerHex',
+  'encounterCheck',
+] as const;
+export type InheritableMapField = (typeof INHERITABLE_MAP_FIELDS)[number];
+
 export const CampaignSettingsSchema = z.object({
   /** Free text shown on the join screen. */
   description: z.string().max(2000).default(''),
@@ -109,6 +145,8 @@ export const CampaignSettingsSchema = z.object({
    * log stay live throughout.
    */
   pausePlayerMapSync: z.boolean().default(false),
+  /** Campaign-wide map settings; maps opt in per field via inheritedFields. */
+  mapDefaults: MapDefaultsSchema.default(() => MapDefaultsSchema.parse({})),
 });
 export type CampaignSettings = z.infer<typeof CampaignSettingsSchema>;
 
@@ -224,6 +262,13 @@ export const MapInfoSchema = z.object({
   milesPerHex: z.number().min(0).max(1000).default(6),
   encounterCheck: EncounterCheckConfigSchema,
   sortOrder: z.number().int().default(0),
+  /**
+   * Names of settings this map takes from `campaign.settings.mapDefaults`
+   * (see INHERITABLE_MAP_FIELDS). The value below is always concrete — the
+   * server writes the default through on change — so readers never resolve
+   * inheritance themselves. Editing a field here drops it from this list.
+   */
+  inheritedFields: z.array(z.string()).default([]),
 });
 export type MapInfo = z.infer<typeof MapInfoSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -7,6 +7,7 @@ import {
   TravelPaceSchema,
   EncounterTableSchema,
   FogStateSchema,
+  INHERITABLE_MAP_FIELDS,
   MarkerSchema,
   TerrainIdSchema,
   TokenKindSchema,
@@ -41,6 +42,19 @@ const EncounterCheckPatchSchema = z
   })
   .partial();
 
+/** Campaign-wide map defaults; propagated to maps inheriting each field. */
+const MapDefaultsPatchSchema = z
+  .object({
+    sightRadius: z.number().int().min(0).max(10),
+    fogMode: z.enum(['manual', 'auto']),
+    fogDecay: z.boolean(),
+    moveMode: z.enum(['step', 'free']),
+    moveApproval: z.boolean(),
+    milesPerHex: z.number().min(0).max(1000),
+    encounterCheck: EncounterCheckPatchSchema,
+  })
+  .partial();
+
 const CampaignSettingsPatchSchema = z
   .object({
     description: z.string().max(2000),
@@ -49,6 +63,7 @@ const CampaignSettingsPatchSchema = z
     customTravelModes: z.array(CustomTravelModeSchema),
     sunriseHour: z.number().min(0).max(23),
     sunsetHour: z.number().min(0).max(24),
+    mapDefaults: MapDefaultsPatchSchema,
   })
   .partial();
 
@@ -109,6 +124,18 @@ export const MapUpdateCommand = z.object({
       sortOrder: z.number().int(),
     })
     .partial(),
+});
+
+/**
+ * Link a map setting to the campaign default (`inherit: true` copies the
+ * current default in immediately) or cut it loose as map-specific.
+ */
+export const MapSetInheritCommand = z.object({
+  ...base,
+  kind: z.literal('map.setInherit'),
+  mapId: z.string(),
+  field: z.enum(INHERITABLE_MAP_FIELDS),
+  inherit: z.boolean(),
 });
 
 export const MapDeleteCommand = z.object({
@@ -519,6 +546,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   CampaignUpdateCommand,
   MapCreateCommand,
   MapUpdateCommand,
+  MapSetInheritCommand,
   MapDeleteCommand,
   MapSetActiveCommand,
   ImageLayerUpdateCommand,

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -14,6 +14,7 @@ import {
   travelModes,
 } from './time.js';
 import type { CampaignState, Character } from '../domain.js';
+import { MapDefaultsSchema } from '../domain.js';
 
 describe('dice', () => {
   it('parses notation', () => {
@@ -92,6 +93,7 @@ function fullState(): CampaignState {
         customTravelModes: [],
         sunriseHour: 6,
         sunsetHour: 20,
+        mapDefaults: MapDefaultsSchema.parse({}),
       },
       time: { minutes: 8 * 60, travelMode: 'foot', pace: 'normal', partyHex: null },
     },


### PR DESCRIPTION
Closes #60

## Summary

A DM-only **map manager dialog** (new `packages/client/src/components/MapManagerDialog.tsx`, opened from "Manage maps" in the Maps panel): every map in one place with a thumbnail, its settings, ordering, rename, set-active and delete.

**Campaign defaults + per-field inheritance.** `CampaignSettingsSchema` gains `mapDefaults` (sight radius, fog mode/decay, move mode/approval, miles per hex, encounter check die/threshold/autoEvery). Each map records which of those it follows in `MapInfo.inheritedFields`; every settings row in the dialog has a link toggle — 🔗 *linked to the campaign default* (value shown, disabled) vs ✎ *map-specific* (editable).

**Inheritance is propagation-on-write, not read-time resolution** — maps always hold concrete values, so nothing downstream (canvas, engine, filter, MCP) has to resolve anything:

- `campaign.update` with a `settings.mapDefaults` patch → `runtime.propagateMapDefaults(changedFields)` writes each changed default into every map inheriting it, through the normal `updateMap` path so snapshots flow as usual.
- `map.update` patching a field → that field is dropped from the map's `inheritedFields` (editing = overriding), in the same write.
- new `map.setInherit {mapId, field, inherit}` → toggles one field; linking copies the current default in immediately.

New maps start out following every default. The default values mirror exactly what `map.create` hard-coded before, so nothing changes for existing campaigns — and existing maps inherit nothing (`inherited_fields` defaults to `'[]'`).

**Thumbnails (v1):** the map's first visible image layer via `<img>` `object-fit: cover`, else a placeholder tile with the hex count and an orientation glyph. Snapshots only carry the *viewed* map's image layers, so per-map summaries come from a new DM-only `GET /api/campaigns/:id/map-thumbs`; it's fetched when the dialog opens and when the map set changes, keeping the snapshot free of other maps' (possibly DM-only) layer data.

### Also

- `MapsTab` keeps map creation/selection, grid style, alignment, images and quests; the settings that moved into the dialog were trimmed so there's one home for them.
- Escape and backdrop close the dialog (ContentDialog conventions).
- Migration: `ensureColumn(map, inherited_fields TEXT NOT NULL DEFAULT '[]')`; both positional statements in `createMap`/`updateMap` updated together (the documented desync trap).

### Tests

`pnpm typecheck && pnpm test` green — 82 tests, 5 new covering (a) a changed default propagating to every inheriting map and surviving a restart, (b) an explicit map edit overriding and stopping the flow, (c) `map.setInherit` unlinking/relinking (including `encounterCheck` merging only its shareable keys), plus DM-only authorization. Also verified by hand in a browser against a built client: default → map propagation is live, unlinking cuts it, link counts update.

## Docs notes

- `docs/DESIGN.md` — map manager and the inheritance model added to "Map & grid".
- `docs/AI-DEVELOPMENT.md` — new gotcha entry: inheritance is propagation-on-write; to add a shareable setting, extend `INHERITABLE_MAP_FIELDS` + `MapDefaultsSchema` in shared `domain.ts` and the rest follows.

### Known limits / follow-ups

- Thumbnails are the raw image layer, not a rendered terrain+image composite (issue #60 mentions a generated PNG); a newly uploaded image shows on the next dialog open.
- Grid style and origin stay map-specific (not in `mapDefaults`) — easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
