### PR TITLE
fix: integration upsert no longer resets omitted fields

### DIFF
--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -364,14 +364,17 @@ export function createApp(store: Store, hub: Hub): Hono {
     /** Or explicit hex coordinates. */
     q: z.number().int().optional(),
     r: z.number().int().optional(),
-    type: ContentTypeSchema.default('landmark'),
+    // Optional (no zod defaults): an omitted field must MERGE with the
+    // existing content on update rather than reset to a default — defaults
+    // here made `?? existing` dead code (issue #72 audit finding).
+    type: ContentTypeSchema.optional(),
     glyph: z.string().max(8).default(''),
     dmNotes: z.string().max(10000).default(''),
     wikiPage: z.string().max(300).default(''),
-    showLabel: z.boolean().default(false),
-    scaleVisibility: z.number().int().min(0).max(2).default(1),
-    enabled: z.boolean().default(true),
-    knownLocation: z.boolean().default(false),
+    showLabel: z.boolean().optional(),
+    scaleVisibility: z.number().int().min(0).max(2).optional(),
+    enabled: z.boolean().optional(),
+    knownLocation: z.boolean().optional(),
     quest: z.string().max(120).default(''),
     clues: z
       .array(
@@ -419,12 +422,12 @@ export function createApp(store: Store, hub: Hub): Hono {
       mapId: input.mapId,
       q,
       r,
-      type: input.type,
+      type: input.type ?? existing?.type ?? 'landmark',
       title: input.title,
       dmNotes: input.dmNotes || existing?.dmNotes || '',
       glyph: input.glyph || existing?.glyph || '',
-      showLabel: input.showLabel,
-      scaleVisibility: input.scaleVisibility,
+      showLabel: input.showLabel ?? existing?.showLabel ?? false,
+      scaleVisibility: input.scaleVisibility ?? existing?.scaleVisibility ?? 1,
       wikiPage: input.wikiPage || existing?.wikiPage || '',
       enabled: input.enabled ?? existing?.enabled ?? true,
       knownLocation: input.knownLocation ?? existing?.knownLocation ?? false,

--- a/packages/server/src/integration-api.test.ts
+++ b/packages/server/src/integration-api.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { Hub } from './ws/hub.js';
+import { createApp } from './http/app.js';
+import type { CampaignRuntime } from './state/runtime.js';
+
+let store: Store;
+let runtime: CampaignRuntime;
+let app: ReturnType<typeof createApp>;
+
+beforeEach(() => {
+  store = new Store(createTestDb());
+  runtime = store.createCampaign('Integration Test', 'DM').runtime;
+  app = createApp(store, new Hub());
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return await app.request(path, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${runtime.dmSecret}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('integration content upsert merge semantics (issue #72 finding)', () => {
+  it('an update omitting a field keeps the existing value instead of resetting it', async () => {
+    const mapId = runtime.campaign.activeMapId!;
+    const created = await post(`/api/integration/campaigns/${runtime.id}/content`, {
+      mapId,
+      title: 'Boareskyr Bridge',
+      q: 2,
+      r: -1,
+      type: 'settlement',
+      enabled: false,
+      knownLocation: true,
+      showLabel: true,
+      scaleVisibility: 2,
+    });
+    expect(created.status).toBe(200);
+
+    // A dmNotes-only sync must not clobber the curated fields.
+    const updated = await post(`/api/integration/campaigns/${runtime.id}/content`, {
+      mapId,
+      title: 'Boareskyr Bridge',
+      q: 2,
+      r: -1,
+      dmNotes: 'Bhaal and Cyric fought here.',
+    });
+    expect(updated.status).toBe(200);
+
+    const content = [...runtime.requireMap(mapId).contents.values()].find(
+      (ct) => ct.title === 'Boareskyr Bridge',
+    )!;
+    expect(content.type).toBe('settlement');
+    expect(content.enabled).toBe(false);
+    expect(content.knownLocation).toBe(true);
+    expect(content.showLabel).toBe(true);
+    expect(content.scaleVisibility).toBe(2);
+    expect(content.dmNotes).toBe('Bhaal and Cyric fought here.');
+  });
+
+  it('creates still get sane defaults when fields are omitted', async () => {
+    const mapId = runtime.campaign.activeMapId!;
+    const res = await post(`/api/integration/campaigns/${runtime.id}/content`, {
+      mapId,
+      title: 'Fresh Pin',
+      q: 0,
+      r: 0,
+    });
+    expect(res.status).toBe(200);
+    const content = [...runtime.requireMap(mapId).contents.values()].find(
+      (ct) => ct.title === 'Fresh Pin',
+    )!;
+    expect(content.type).toBe('landmark');
+    expect(content.enabled).toBe(true);
+    expect(content.knownLocation).toBe(false);
+    expect(content.scaleVisibility).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the merge-semantics bug found during #72's documentation audit (see PR #92 body). Tests in a new integration-api.test.ts — per-issue test files are the new convention, since parallel appends to server.test.ts kept conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)