### PR TITLE
Session boundaries and auto-generated recaps

### DIFF
--- a/packages/client/src/components/panels/JournalTab.tsx
+++ b/packages/client/src/components/panels/JournalTab.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { CONTENT_TYPE_GLYPHS, isFullContent, type ContentPlayerView } from '@hexcrawl/shared';
+import {
+  CONTENT_TYPE_GLYPHS,
+  computeRecap,
+  computeSessions,
+  isFullContent,
+  recapHighlights,
+  type ContentPlayerView,
+} from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { useUi } from '../../stores/ui.js';
 import { EmptyNote, Section, cx } from '../../ui/kit.js';
@@ -30,6 +37,8 @@ export function JournalTab() {
 
   return (
     <div>
+      <PreviouslyOnCard />
+
       <Section title="Discoveries">
         {contents.length === 0 && (
           <EmptyNote>
@@ -111,12 +120,56 @@ export function JournalTab() {
         {narrations.length === 0 && <EmptyNote>No narration shared yet.</EmptyNote>}
         <div className="space-y-1.5">
           {narrations.map((n) => (
-            <div key={n.id} className="text-xs bg-ink-850 border border-ink-700 rounded-md px-2.5 py-2">
+            <div
+              key={n.id}
+              className="text-xs bg-ink-850 border border-ink-700 rounded-md px-2.5 py-2"
+            >
               <p className="text-ink-100 whitespace-pre-wrap">{n.text}</p>
             </div>
           ))}
         </div>
       </Section>
+    </div>
+  );
+}
+
+/**
+ * A small "previously on…" teaser at the top of the journal (issue #78): as
+ * soon as the DM starts a new session, players get a quick reminder of the
+ * highlights from the one before it. Deliberately simple — no per-player
+ * "seen this already" tracking, it just shows whenever the most recent
+ * session mark is a 'start'. Runs on `state.log`, which is already filtered
+ * to what this viewer is allowed to see, so the recap it builds respects the
+ * same security boundary as the rest of the journal.
+ */
+function PreviouslyOnCard() {
+  const state = useSession((s) => s.state);
+  if (!state) return null;
+
+  const lastMark = [...state.log].reverse().find((e) => e.kind === 'session');
+  const lastAction = (lastMark?.data as { action?: string } | undefined)?.action;
+  if (lastAction !== 'start') return null;
+
+  const sessions = computeSessions(state.log);
+  const previous = sessions[sessions.length - 2];
+  if (!previous) return null;
+
+  const recap = computeRecap(state.log, { fromAt: previous.fromAt, toAt: previous.toAt });
+  const highlights = recapHighlights(recap, 3);
+  if (highlights.length === 0) return null;
+
+  return (
+    <div className="mb-4 bg-brass-500/10 border border-brass-500/30 rounded-lg p-2.5">
+      <div className="text-[11px] uppercase tracking-wider text-brass-300 font-semibold mb-1.5">
+        Previously on…
+      </div>
+      <ul className="space-y-1">
+        {highlights.map((h) => (
+          <li key={h.id} className="text-xs text-ink-100">
+            {h.text}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -157,7 +210,9 @@ function TrackRow({
           {trail.cells.length} place{trail.cells.length === 1 ? '' : 's'} spotted
         </span>
       </div>
-      {highlighted && <span className="block text-[11px] text-brass-300 mt-0.5">highlighted on map</span>}
+      {highlighted && (
+        <span className="block text-[11px] text-brass-300 mt-0.5">highlighted on map</span>
+      )}
     </button>
   );
 }

--- a/packages/client/src/components/panels/LogTab.tsx
+++ b/packages/client/src/components/panels/LogTab.tsx
@@ -1,4 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
+import {
+  computeRecap,
+  computeSessions,
+  formatClock,
+  formatDuration,
+  type LogEntry,
+  type Recap,
+  type SessionBoundary,
+} from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { Button, EmptyNote, Input, cx } from '../../ui/kit.js';
@@ -10,33 +19,47 @@ const KIND_META: Record<string, { icon: string; label: string }> = {
   narration: { icon: '📜', label: 'Narration' },
   share: { icon: '🤝', label: 'Shared' },
   time: { icon: '🕐', label: 'Time' },
+  session: { icon: '🎬', label: 'Session' },
 };
 
-const FILTERS = ['all', 'discovery', 'check', 'encounter', 'narration', 'share', 'time'] as const;
+const FILTERS = [
+  'all',
+  'discovery',
+  'check',
+  'encounter',
+  'narration',
+  'share',
+  'time',
+  'session',
+] as const;
 
 export function LogTab() {
   const state = useSession((s) => s.state);
   const role = useSession((s) => s.role);
   const [filter, setFilter] = useState<(typeof FILTERS)[number]>('all');
+  const [mode, setMode] = useState<'log' | 'recaps'>('log');
   const scrollRef = useRef<HTMLDivElement>(null);
   const entries = state?.log ?? [];
   const filtered = filter === 'all' ? entries : entries.filter((e) => e.kind === filter);
 
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [entries.length]);
+    if (mode === 'log') scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [entries.length, mode]);
 
   return (
     <div className="flex flex-col h-full">
-      {role === 'dm' && (
-        <div className="flex gap-1 mb-2 flex-wrap">
-          {FILTERS.map((f) => (
+      <div className="flex gap-1 mb-2 flex-wrap items-center">
+        {role === 'dm' &&
+          FILTERS.map((f) => (
             <button
               key={f}
-              onClick={() => setFilter(f)}
+              onClick={() => {
+                setFilter(f);
+                setMode('log');
+              }}
               className={cx(
                 'px-2 py-0.5 rounded-full text-[11px] capitalize cursor-pointer border',
-                filter === f
+                mode === 'log' && filter === f
                   ? 'border-brass-500 bg-brass-500/15 text-brass-300'
                   : 'border-ink-700 text-ink-300 hover:bg-ink-700',
               )}
@@ -44,30 +67,199 @@ export function LogTab() {
               {f}
             </button>
           ))}
+        <button
+          onClick={() => setMode(mode === 'recaps' ? 'log' : 'recaps')}
+          className={cx(
+            'px-2 py-0.5 rounded-full text-[11px] cursor-pointer border ml-auto',
+            mode === 'recaps'
+              ? 'border-brass-500 bg-brass-500/15 text-brass-300'
+              : 'border-ink-700 text-ink-300 hover:bg-ink-700',
+          )}
+        >
+          🎬 Recaps
+        </button>
+      </div>
+
+      {mode === 'recaps' ? (
+        <RecapsView entries={entries} />
+      ) : (
+        <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-1.5 min-h-0">
+          {filtered.length === 0 && <EmptyNote>Nothing logged yet.</EmptyNote>}
+          {filtered.map((entry) => {
+            const meta = KIND_META[entry.kind] ?? { icon: '·', label: entry.kind };
+            return (
+              <div
+                key={entry.id}
+                className="text-xs bg-ink-850 border border-ink-700 rounded-md px-2.5 py-2"
+              >
+                <div className="flex items-center gap-1.5 text-ink-400 mb-0.5">
+                  <span>{meta.icon}</span>
+                  <span className="uppercase tracking-wider text-[10px] font-semibold">
+                    {meta.label}
+                  </span>
+                  {role === 'dm' && entry.visibility === 'dm' && (
+                    <span className="text-[10px] text-ember-500/80">DM only</span>
+                  )}
+                  <span className="ml-auto">{formatTime(entry.at)}</span>
+                </div>
+                <p className="text-ink-100 whitespace-pre-wrap">{entry.text}</p>
+              </div>
+            );
+          })}
         </div>
       )}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-1.5 min-h-0">
-        {filtered.length === 0 && <EmptyNote>Nothing logged yet.</EmptyNote>}
-        {filtered.map((entry) => {
-          const meta = KIND_META[entry.kind] ?? { icon: '·', label: entry.kind };
-          return (
-            <div key={entry.id} className="text-xs bg-ink-850 border border-ink-700 rounded-md px-2.5 py-2">
-              <div className="flex items-center gap-1.5 text-ink-400 mb-0.5">
-                <span>{meta.icon}</span>
-                <span className="uppercase tracking-wider text-[10px] font-semibold">{meta.label}</span>
-                {role === 'dm' && entry.visibility === 'dm' && (
-                  <span className="text-[10px] text-ember-500/80">DM only</span>
-                )}
-                <span className="ml-auto">{formatTime(entry.at)}</span>
-              </div>
-              <p className="text-ink-100 whitespace-pre-wrap">{entry.text}</p>
-            </div>
-          );
-        })}
-      </div>
-      {role === 'dm' && <NarrateBox />}
+
+      {role === 'dm' && (
+        <div className="pt-2 mt-2 border-t border-ink-700 space-y-1.5 shrink-0">
+          <SessionMarkButton entries={entries} />
+          <NarrateBox />
+        </div>
+      )}
     </div>
   );
+}
+
+/** Start/End session toggle — shows whichever action makes sense after the last mark. */
+function SessionMarkButton({ entries }: { entries: LogEntry[] }) {
+  const lastMark = [...entries].reverse().find((e) => e.kind === 'session');
+  const lastAction = (lastMark?.data as { action?: string } | undefined)?.action;
+  const nextAction: 'start' | 'end' = lastAction === 'start' ? 'end' : 'start';
+  return (
+    <Button
+      size="sm"
+      variant={nextAction === 'start' ? 'primary' : 'default'}
+      onClick={() => send({ kind: 'session.mark', action: nextAction })}
+    >
+      {nextAction === 'start' ? '▶ Start session' : '■ End session'}
+    </Button>
+  );
+}
+
+/**
+ * Sessions newest first, each expandable into its computed recap. Runs
+ * entirely on `entries` — for a player that's already their filtered log
+ * (the security boundary in `filterStateForViewer` applied before this ever
+ * runs), so a player's recap only ever shows what they were allowed to see.
+ */
+function RecapsView({ entries }: { entries: LogEntry[] }) {
+  const sessions = [...computeSessions(entries)].reverse();
+  const [expanded, setExpanded] = useState<number | null>(sessions[0]?.index ?? null);
+
+  return (
+    <div className="flex-1 overflow-y-auto space-y-1.5 min-h-0">
+      {sessions.length === 0 && <EmptyNote>No sessions yet.</EmptyNote>}
+      {sessions.map((session) => (
+        <SessionRecapRow
+          key={session.index}
+          session={session}
+          entries={entries}
+          isOpen={expanded === session.index}
+          onToggle={() => setExpanded(expanded === session.index ? null : session.index)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SessionRecapRow({
+  session,
+  entries,
+  isOpen,
+  onToggle,
+}: {
+  session: SessionBoundary;
+  entries: LogEntry[];
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const recap = computeRecap(entries, { fromAt: session.fromAt, toAt: session.toAt });
+  const startAtMinutes = (session.startMark?.data as { atMinutes?: number } | undefined)?.atMinutes;
+  const endAtMinutes = (session.endMark?.data as { atMinutes?: number } | undefined)?.atMinutes;
+  const span =
+    startAtMinutes !== undefined
+      ? `${formatClock(startAtMinutes)} — ${endAtMinutes !== undefined ? formatClock(endAtMinutes) : 'ongoing'}`
+      : null;
+
+  return (
+    <div className="bg-ink-850 border border-ink-700 rounded-md overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left cursor-pointer hover:bg-ink-800"
+      >
+        <span>🎬</span>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-ink-100">{session.label}</div>
+          {span && <div className="text-[11px] text-ink-400">{span}</div>}
+        </div>
+        <span className="text-[11px] text-ink-400 shrink-0">{recap.entryCount} entries</span>
+        <span className="text-ink-400 shrink-0">{isOpen ? '▾' : '▸'}</span>
+      </button>
+      {isOpen && (
+        <div className="px-2.5 pb-2.5 space-y-2 border-t border-ink-700 pt-2">
+          <RecapBody recap={recap} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Compact rendering of a computed recap, shared by the log's Recaps view and the Journal's teaser. */
+export function RecapBody({ recap }: { recap: Recap }) {
+  const sections: { label: string; icon: string; texts: string[] }[] = [
+    { label: 'Discoveries', icon: '👁️', texts: recap.discoveries.items.map((i) => i.text) },
+    {
+      label: 'Encounters',
+      icon: '🎲',
+      texts: [
+        ...recap.encounters.triggered.map((i) => i.text),
+        ...recap.encounters.quiet.map((i) => `(quiet) ${i.text}`),
+      ],
+    },
+    { label: 'Checks', icon: '🎯', texts: recap.checks.items.map((i) => i.text) },
+    { label: 'Shared', icon: '🤝', texts: recap.shares.items.map((i) => i.text) },
+    { label: 'Narration', icon: '📜', texts: recap.narrations.items.map((i) => i.text) },
+  ];
+
+  return (
+    <>
+      <div className="text-[11px] text-ink-300">
+        Time advanced: {formatDuration(recap.timeAdvancedMinutes)}
+        {recap.wallClockMs > 0 && <> · session ran {formatWallClock(recap.wallClockMs)}</>}
+      </div>
+      {sections.map(
+        (s) =>
+          s.texts.length > 0 && (
+            <div key={s.label}>
+              <div className="text-[10px] uppercase tracking-wider text-ink-400 font-semibold mb-0.5 flex items-center gap-1">
+                <span>{s.icon}</span>
+                <span>
+                  {s.label} ({s.texts.length})
+                </span>
+              </div>
+              <ul className="space-y-0.5">
+                {s.texts.map((t, i) => (
+                  <li key={i} className="text-xs text-ink-100">
+                    {t}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ),
+      )}
+      {sections.every((s) => s.texts.length === 0) && (
+        <EmptyNote>Nothing notable happened.</EmptyNote>
+      )}
+    </>
+  );
+}
+
+function formatWallClock(ms: number): string {
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 1) return 'under a minute';
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours === 0) return `${mins}m`;
+  return `${hours}h ${mins}m`;
 }
 
 function NarrateBox() {
@@ -81,7 +273,7 @@ function NarrateBox() {
     setText('');
   };
   return (
-    <div className="pt-2 mt-2 border-t border-ink-700 space-y-1.5 shrink-0">
+    <div className="space-y-1.5">
       <div className="flex gap-1.5">
         <Input
           value={text}

--- a/packages/server/src/sessions.test.ts
+++ b/packages/server/src/sessions.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { seededRng } from '@hexcrawl/shared';
+import type { ClientCommand } from '@hexcrawl/shared';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { CampaignRuntime, type SeatRecord } from './state/runtime.js';
+import { Hub } from './ws/hub.js';
+import { dispatchCommand } from './ws/handlers.js';
+
+/**
+ * Session-mark command (issue #78): DM-only, appends a 'session' log entry
+ * carrying {action, atMinutes}. Recap grouping itself is pure logic tested
+ * in packages/shared/src/rules/recap.test.ts against this entry shape.
+ */
+
+let store: Store;
+let runtime: CampaignRuntime;
+let dmSeat: SeatRecord;
+let hub: Hub;
+let cmdCounter = 0;
+
+function dm(cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `c${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat: dmSeat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+function asSeat(seat: SeatRecord, cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `c${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+beforeEach(() => {
+  store = new Store(createTestDb());
+  const created = store.createCampaign('Test Campaign', 'The DM');
+  runtime = created.runtime;
+  dmSeat = created.dmSeat;
+  hub = new Hub();
+});
+
+describe('session.mark', () => {
+  it('is DM-only', () => {
+    const player = runtime.createSeat('player', 'Mallory');
+    expect(() => asSeat(player, { kind: 'session.mark', action: 'start' } as never)).toThrow(/DM/);
+    expect(runtime.log.filter((e) => e.kind === 'session')).toHaveLength(0);
+  });
+
+  it('appends a "session" log entry visible to all, carrying action and the current clock reading', () => {
+    // Default campaign clock starts at 8:00 AM Day 1 (480 minutes) — advance
+    // it so the mark's atMinutes is distinguishable from the initial value.
+    dm({ kind: 'time.advance', minutes: 100 } as never);
+    const clockBefore = runtime.campaign.time.minutes;
+
+    dm({ kind: 'session.mark', action: 'start' } as never);
+
+    const entries = runtime.log.filter((e) => e.kind === 'session');
+    expect(entries).toHaveLength(1);
+    const entry = entries[0]!;
+    expect(entry.visibility).toBe('all');
+    expect(entry.data).toMatchObject({ action: 'start', atMinutes: clockBefore });
+    expect(entry.text).toContain('Session started');
+    expect(entry.text).toContain('Day');
+  });
+
+  it('records start and end marks independently, each stamped with the clock at that moment', () => {
+    dm({ kind: 'session.mark', action: 'start' } as never);
+    dm({ kind: 'time.advance', minutes: 240 } as never);
+    dm({ kind: 'session.mark', action: 'end' } as never);
+
+    const [start, end] = runtime.log.filter((e) => e.kind === 'session');
+    expect(start!.data.action).toBe('start');
+    expect(end!.data.action).toBe('end');
+    expect((end!.data.atMinutes as number) - (start!.data.atMinutes as number)).toBe(240);
+    expect(end!.text).toContain('Session ended');
+  });
+
+  it('accepts either action repeatedly — the client decides which button to show', () => {
+    dm({ kind: 'session.mark', action: 'start' } as never);
+    dm({ kind: 'session.mark', action: 'start' } as never);
+    dm({ kind: 'session.mark', action: 'end' } as never);
+    expect(runtime.log.filter((e) => e.kind === 'session')).toHaveLength(3);
+  });
+});

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -999,6 +999,18 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       }
     }
   }) as Handler,
+
+  // -- sessions (issue #78) ---------------------------------------------------
+  'session.mark': ((cmd: Extract<ClientCommand, { kind: 'session.mark' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const atMinutes = ctx.runtime.campaign.time.minutes;
+    const label = cmd.action === 'start' ? 'Session started' : 'Session ended';
+    const entry = ctx.runtime.appendLog('session', `${label} — ${formatClock(atMinutes)}`, 'all', {
+      action: cmd.action,
+      atMinutes,
+    });
+    notifyLog(ctx, entry);
+  }) as Handler,
 };
 
 /**

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -560,6 +560,13 @@ export const NarrateCommand = z.object({
   seatIds: z.array(z.string()),
 });
 
+/** DM: mark a session boundary (issue #78) — drives recap grouping. */
+export const SessionMarkCommand = z.object({
+  ...base,
+  kind: z.literal('session.mark'),
+  action: z.union([z.literal('start'), z.literal('end')]),
+});
+
 // ---------------------------------------------------------------------------
 
 export const ClientCommandSchema = z.discriminatedUnion('kind', [
@@ -610,6 +617,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   TimeConfigCommand,
   UndoCommand,
   NarrateCommand,
+  SessionMarkCommand,
 ]);
 
 export type ClientCommand = z.infer<typeof ClientCommandSchema>;

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -2,3 +2,4 @@ export * from './dice.js';
 export * from './gates.js';
 export * from './filter.js';
 export * from './time.js';
+export * from './recap.js';

--- a/packages/shared/src/rules/recap.test.ts
+++ b/packages/shared/src/rules/recap.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { computeRecap, computeSessions, recapHighlights } from './recap.js';
+import type { LogEntry } from '../domain.js';
+
+function entry(
+  at: number,
+  kind: string,
+  text: string,
+  data: Record<string, unknown> = {},
+): LogEntry {
+  return { id: `e${at}`, at, kind, text, visibility: 'all', data };
+}
+
+describe('computeRecap', () => {
+  it('groups entries by kind and counts them', () => {
+    const log: LogEntry[] = [
+      entry(1, 'discovery', 'Found the shrine clue'),
+      entry(2, 'discovery', 'Found the bandit camp clue'),
+      entry(3, 'check', 'Perception DC 12: Ash: 15 ✓'),
+      entry(4, 'narration', 'The fog rolls in.'),
+      entry(5, 'share', 'Ash shared with the party: a bandit camp lies north'),
+      entry(6, 'encounter', 'Wolves attack!', { triggered: true }),
+      entry(7, 'encounter', 'Nothing stirs.', { triggered: false }),
+    ];
+    const recap = computeRecap(log, { fromAt: -Infinity, toAt: Infinity });
+
+    expect(recap.entryCount).toBe(7);
+    expect(recap.discoveries.count).toBe(2);
+    expect(recap.discoveries.items.map((i) => i.text)).toEqual([
+      'Found the shrine clue',
+      'Found the bandit camp clue',
+    ]);
+    expect(recap.checks.count).toBe(1);
+    expect(recap.narrations.count).toBe(1);
+    expect(recap.shares.count).toBe(1);
+    expect(recap.encounters.triggered).toHaveLength(1);
+    expect(recap.encounters.triggered[0]!.text).toBe('Wolves attack!');
+    expect(recap.encounters.quiet).toHaveLength(1);
+    expect(recap.encounters.quiet[0]!.text).toBe('Nothing stirs.');
+  });
+
+  it('restricts to the [fromAt, toAt) window', () => {
+    const log: LogEntry[] = [
+      entry(1, 'narration', 'before'),
+      entry(10, 'narration', 'inside'),
+      entry(20, 'narration', 'boundary'), // excluded: toAt is exclusive
+      entry(30, 'narration', 'after'),
+    ];
+    const recap = computeRecap(log, { fromAt: 10, toAt: 20 });
+    expect(recap.narrations.items.map((i) => i.text)).toEqual(['inside']);
+  });
+
+  it('sums advancedBy from time entries as the logged-time fallback', () => {
+    const log: LogEntry[] = [
+      entry(1, 'time', 'Time advances 1 hour', { advancedBy: 60 }),
+      entry(2, 'time', 'Time advances 2 hours', { advancedBy: 120 }),
+      entry(3, 'time', 'Clock set to Day 2', { minutes: 1440 }), // time.set: no advancedBy
+    ];
+    const recap = computeRecap(log, { fromAt: -Infinity, toAt: Infinity });
+    expect(recap.timeLoggedMinutes).toBe(180);
+    expect(recap.clockDeltaMinutes).toBeNull();
+    expect(recap.timeAdvancedMinutes).toBe(180);
+  });
+
+  it('prefers the session-mark clock delta over the logged-time sum when both marks bound the window exactly', () => {
+    const log: LogEntry[] = [
+      entry(0, 'session', 'Session started — Day 1, 8:00 AM', { action: 'start', atMinutes: 480 }),
+      entry(1, 'time', 'Time advances 1 hour', { advancedBy: 60 }),
+      // travel time silently advances the clock without a 'time' entry — the
+      // logged sum (60) undercounts the true 300-minute session.
+      entry(2, 'discovery', 'Found something while travelling'),
+      entry(3, 'session', 'Session ended — Day 1, 1:00 PM', { action: 'end', atMinutes: 780 }),
+    ];
+    const recap = computeRecap(log, { fromAt: 0, toAt: 3 });
+    expect(recap.timeLoggedMinutes).toBe(60);
+    expect(recap.clockDeltaMinutes).toBe(300);
+    expect(recap.timeAdvancedMinutes).toBe(300);
+  });
+
+  it('reports wall-clock span and null bounds for an empty window', () => {
+    const log: LogEntry[] = [entry(100, 'narration', 'a'), entry(250, 'narration', 'b')];
+    const recap = computeRecap(log, { fromAt: -Infinity, toAt: Infinity });
+    expect(recap.wallClockStart).toBe(100);
+    expect(recap.wallClockEnd).toBe(250);
+    expect(recap.wallClockMs).toBe(150);
+
+    const empty = computeRecap(log, { fromAt: 1000, toAt: 2000 });
+    expect(empty.wallClockStart).toBeNull();
+    expect(empty.wallClockEnd).toBeNull();
+    expect(empty.wallClockMs).toBe(0);
+    expect(empty.entryCount).toBe(0);
+  });
+});
+
+describe('computeSessions', () => {
+  it('treats an unmarked log as one "before records began" session', () => {
+    const log: LogEntry[] = [entry(1, 'narration', 'a'), entry(2, 'narration', 'b')];
+    const sessions = computeSessions(log);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ index: 0, fromAt: -Infinity, toAt: Infinity });
+  });
+
+  it('splits on start/end marks, keeping pre-mark entries as Session 0', () => {
+    const log: LogEntry[] = [
+      entry(1, 'narration', 'before any session'),
+      entry(5, 'session', 'Session started', { action: 'start', atMinutes: 480 }),
+      entry(6, 'narration', 'during session 1'),
+      entry(10, 'session', 'Session ended', { action: 'end', atMinutes: 600 }),
+      entry(15, 'session', 'Session started', { action: 'start', atMinutes: 600 }),
+      entry(16, 'narration', 'during session 2'),
+    ];
+    const sessions = computeSessions(log);
+    expect(sessions.map((s) => s.label)).toEqual([
+      'Session 0 — before records began',
+      'Session 1',
+      'Session 2',
+    ]);
+
+    const [s0, s1, s2] = sessions;
+    expect(s0).toMatchObject({ fromAt: -Infinity, toAt: 5 });
+    expect(s1).toMatchObject({ fromAt: 5, toAt: 10 });
+    expect(s1!.endMark).not.toBeNull();
+    expect(s2).toMatchObject({ fromAt: 15, toAt: Infinity });
+    expect(s2!.endMark).toBeNull();
+
+    const recap1 = computeRecap(log, { fromAt: s1!.fromAt, toAt: s1!.toAt });
+    expect(recap1.narrations.items.map((i) => i.text)).toEqual(['during session 1']);
+
+    const recap2 = computeRecap(log, { fromAt: s2!.fromAt, toAt: s2!.toAt });
+    expect(recap2.narrations.items.map((i) => i.text)).toEqual(['during session 2']);
+  });
+
+  it('falls back to the next start mark when a session has no explicit end', () => {
+    const log: LogEntry[] = [
+      entry(1, 'session', 'Session started', { action: 'start', atMinutes: 0 }),
+      entry(2, 'narration', 'session 1'),
+      entry(3, 'session', 'Session started', { action: 'start', atMinutes: 100 }),
+      entry(4, 'narration', 'session 2'),
+    ];
+    const sessions = computeSessions(log);
+    expect(sessions).toHaveLength(3); // Session 0 (empty) + 1 + 2
+    expect(sessions[1]).toMatchObject({ fromAt: 1, toAt: 3, endMark: null });
+    expect(sessions[2]).toMatchObject({ fromAt: 3, toAt: Infinity, endMark: null });
+  });
+});
+
+describe('recapHighlights', () => {
+  it('prioritizes discoveries, then triggered encounters, shares, narrations, quiet encounters', () => {
+    const log: LogEntry[] = [
+      entry(1, 'narration', 'narration text'),
+      entry(2, 'encounter', 'quiet encounter', { triggered: false }),
+      entry(3, 'share', 'shared clue text'),
+      entry(4, 'discovery', 'discovery one'),
+      entry(5, 'discovery', 'discovery two'),
+      entry(6, 'encounter', 'wolves attack', { triggered: true }),
+    ];
+    const recap = computeRecap(log, { fromAt: -Infinity, toAt: Infinity });
+    const highlights = recapHighlights(recap, 3);
+    expect(highlights.map((h) => h.text)).toEqual([
+      'discovery one',
+      'discovery two',
+      'wolves attack',
+    ]);
+  });
+
+  it('respects a custom limit and fills in from lower-priority sections when higher ones run out', () => {
+    const log: LogEntry[] = [
+      entry(1, 'discovery', 'only discovery'),
+      entry(2, 'share', 'shared clue'),
+      entry(3, 'narration', 'story beat'),
+    ];
+    const recap = computeRecap(log, { fromAt: -Infinity, toAt: Infinity });
+    expect(recapHighlights(recap, 5).map((h) => h.text)).toEqual([
+      'only discovery',
+      'shared clue',
+      'story beat',
+    ]);
+  });
+});

--- a/packages/shared/src/rules/recap.ts
+++ b/packages/shared/src/rules/recap.ts
@@ -1,0 +1,197 @@
+import type { LogEntry } from '../domain.js';
+
+/**
+ * Session boundaries + recap computation (issue #78).
+ *
+ * Pure functions only — this runs identically on the server (full log, for
+ * wiki export) and in the client (a viewer's already-filtered log, so the
+ * security boundary in `filter.ts` applies automatically: a player's recap
+ * is built only from entries they were allowed to see).
+ */
+
+export interface RecapItem {
+  id: string;
+  at: number;
+  text: string;
+}
+
+export interface RecapSection {
+  count: number;
+  items: RecapItem[];
+}
+
+export interface EncounterRecapSection {
+  triggered: RecapItem[];
+  quiet: RecapItem[];
+}
+
+export interface Recap {
+  fromAt: number;
+  toAt: number;
+  /** Total log entries in range (including kinds not broken out below). */
+  entryCount: number;
+  /** Timestamp of the first/last entry actually in range, or null if empty. */
+  wallClockStart: number | null;
+  wallClockEnd: number | null;
+  /** Real-world span the session covered, in ms (0 when fewer than 2 entries). */
+  wallClockMs: number;
+  discoveries: RecapSection;
+  encounters: EncounterRecapSection;
+  checks: RecapSection;
+  narrations: RecapSection;
+  shares: RecapSection;
+  /** Minutes advanced via explicit `time.advance` log entries in range. Undercounts
+   * travel time, which moves the clock without logging a 'time' entry. */
+  timeLoggedMinutes: number;
+  /** Minutes advanced per the campaign clock, from this session's start/end marks
+   * (when both carry `atMinutes`) — the accurate figure, travel included. */
+  clockDeltaMinutes: number | null;
+  /** Best available estimate: clockDeltaMinutes when known, else timeLoggedMinutes. */
+  timeAdvancedMinutes: number;
+}
+
+export interface RecapRange {
+  /** Inclusive lower bound on entry.at. Use -Infinity for "since the start of the log". */
+  fromAt: number;
+  /** Exclusive upper bound on entry.at. Use Infinity for "still ongoing". */
+  toAt: number;
+}
+
+function toItem(e: LogEntry): RecapItem {
+  return { id: e.id, at: e.at, text: e.text };
+}
+
+/** Grouped, readable summary of everything that happened in a log window. */
+export function computeRecap(log: LogEntry[], range: RecapRange): Recap {
+  const { fromAt, toAt } = range;
+  const inRange = log.filter((e) => e.at >= fromAt && e.at < toAt).sort((a, b) => a.at - b.at);
+
+  const discoveries = inRange.filter((e) => e.kind === 'discovery');
+  const encounters = inRange.filter((e) => e.kind === 'encounter');
+  const checks = inRange.filter((e) => e.kind === 'check');
+  const narrations = inRange.filter((e) => e.kind === 'narration');
+  const shares = inRange.filter((e) => e.kind === 'share');
+  const timeEntries = inRange.filter((e) => e.kind === 'time');
+
+  const triggered: RecapItem[] = [];
+  const quiet: RecapItem[] = [];
+  for (const e of encounters) {
+    const item = toItem(e);
+    if ((e.data as { triggered?: unknown } | undefined)?.triggered) triggered.push(item);
+    else quiet.push(item);
+  }
+
+  const timeLoggedMinutes = timeEntries.reduce((sum, e) => {
+    const advancedBy = (e.data as { advancedBy?: unknown } | undefined)?.advancedBy;
+    return sum + (typeof advancedBy === 'number' ? advancedBy : 0);
+  }, 0);
+
+  // Session marks that bound this exact window carry the campaign clock
+  // reading at the moment they were made — a more accurate "time advanced"
+  // than summing 'time' entries, since travel advances the clock silently.
+  const startMark = log.find((e) => e.kind === 'session' && e.at === fromAt);
+  const endMark = log.find((e) => e.kind === 'session' && e.at === toAt);
+  const startMinutes = (startMark?.data as { atMinutes?: unknown } | undefined)?.atMinutes;
+  const endMinutes = (endMark?.data as { atMinutes?: unknown } | undefined)?.atMinutes;
+  const clockDeltaMinutes =
+    typeof startMinutes === 'number' && typeof endMinutes === 'number'
+      ? endMinutes - startMinutes
+      : null;
+
+  const wallClockStart = inRange.length ? inRange[0]!.at : null;
+  const wallClockEnd = inRange.length ? inRange[inRange.length - 1]!.at : null;
+
+  return {
+    fromAt,
+    toAt,
+    entryCount: inRange.length,
+    wallClockStart,
+    wallClockEnd,
+    wallClockMs:
+      wallClockStart !== null && wallClockEnd !== null ? wallClockEnd - wallClockStart : 0,
+    discoveries: { count: discoveries.length, items: discoveries.map(toItem) },
+    encounters: { triggered, quiet },
+    checks: { count: checks.length, items: checks.map(toItem) },
+    narrations: { count: narrations.length, items: narrations.map(toItem) },
+    shares: { count: shares.length, items: shares.map(toItem) },
+    timeLoggedMinutes,
+    clockDeltaMinutes,
+    timeAdvancedMinutes: clockDeltaMinutes ?? timeLoggedMinutes,
+  };
+}
+
+export interface SessionBoundary {
+  /** 0 = "before records began"; 1, 2, ... follow log order of 'start' marks. */
+  index: number;
+  label: string;
+  fromAt: number;
+  toAt: number;
+  startMark: LogEntry | null;
+  endMark: LogEntry | null;
+}
+
+/**
+ * Split a log into sessions using its 'session' kind entries. Everything
+ * before the first 'start' mark is "Session 0". Each session runs from a
+ * 'start' mark to the next 'end' mark (if the DM remembered to click it),
+ * else to the next 'start' mark, else it's still ongoing (`toAt: Infinity`).
+ */
+export function computeSessions(log: LogEntry[]): SessionBoundary[] {
+  const marks = log
+    .filter((e) => e.kind === 'session')
+    .map((e) => ({
+      entry: e,
+      action: (e.data as { action?: unknown } | undefined)?.action,
+    }))
+    .filter(
+      (m): m is { entry: LogEntry; action: 'start' | 'end' } =>
+        m.action === 'start' || m.action === 'end',
+    )
+    .sort((a, b) => a.entry.at - b.entry.at);
+
+  const starts = marks.filter((m) => m.action === 'start');
+  const firstStartAt = starts[0]?.entry.at ?? Infinity;
+
+  const boundaries: SessionBoundary[] = [
+    {
+      index: 0,
+      label: 'Session 0 — before records began',
+      fromAt: -Infinity,
+      toAt: firstStartAt,
+      startMark: null,
+      endMark: null,
+    },
+  ];
+
+  starts.forEach((start, i) => {
+    const nextStartAt = starts[i + 1]?.entry.at ?? Infinity;
+    const end = marks.find(
+      (m) => m.action === 'end' && m.entry.at > start.entry.at && m.entry.at <= nextStartAt,
+    );
+    boundaries.push({
+      index: i + 1,
+      label: `Session ${i + 1}`,
+      fromAt: start.entry.at,
+      toAt: end ? end.entry.at : nextStartAt,
+      startMark: start.entry,
+      endMark: end ? end.entry : null,
+    });
+  });
+
+  return boundaries;
+}
+
+/**
+ * The handful of items worth surfacing in a "previously on…" teaser:
+ * discoveries and triggered encounters read as the most narratively
+ * interesting, then shared clues and narration, then quiet encounter checks.
+ */
+export function recapHighlights(recap: Recap, limit = 3): RecapItem[] {
+  return [
+    ...recap.discoveries.items,
+    ...recap.encounters.triggered,
+    ...recap.shares.items,
+    ...recap.narrations.items,
+    ...recap.encounters.quiet,
+  ].slice(0, limit);
+}


### PR DESCRIPTION
Closes #78

## Summary

- New DM command `session.mark { action: 'start' | 'end' }` — logs a `session` kind entry (`visibility: 'all'`) with text like "Session started — Day 3, 6:40 PM" and `data: {action, atMinutes}` (the campaign clock reading at the moment of the mark). DM-only.
- New pure module `shared/src/rules/recap.ts`:
  - `computeRecap(log, {fromAt, toAt})` — groups a log window into discoveries, encounters (triggered vs quiet), checks, narrations, shares, and time advanced.
  - `computeSessions(log)` — splits a log into sessions from its `session` marks; entries before the first mark form "Session 0 — before records began".
  - `recapHighlights(recap, limit)` — the top N items for a teaser (discoveries, then triggered encounters, then shares/narration/quiet encounters).
- `LogTab`: a "🎬 Recaps" toggle chip lists sessions newest-first, each expandable into its computed recap. A Start/End session button (shown near the narrate box, DM-only) toggles based on the last session mark in the log.
- `JournalTab`: a "Previously on…" card at the top, shown to players whenever the most recent session mark is a `start` — renders the top 3 highlights from the session just before it.
- `session: {icon: '🎬', label: 'Session'}` registered in `KIND_META` + `FILTERS`.

## Decisions

- **Time-advanced accuracy**: travel silently advances the campaign clock (`executePartyMove` calls `advanceTime` without logging a `'time'` entry), so summing `'time'` entries alone undercounts a session's actual elapsed game-time. `computeRecap` prefers the clock delta between a session's own start/end marks (`atMinutes` on each) when both are present, falling back to the summed `'time'`-entry total (`timeLoggedMinutes`) otherwise. Both figures are exposed on the `Recap` type so a caller can show either.
- **Session boundary robustness**: a session runs from a `start` mark to the next explicit `end` mark if the DM clicked it, else to the next `start` mark, else it's ongoing (`toAt: Infinity`). This tolerates a DM forgetting to click "End".
- **Security boundary reused, not reimplemented**: `computeRecap`/`computeSessions` are pure functions over whatever log array they're given. The client always calls them with `state.log`, which `filterStateForViewer` has already filtered per viewer — so a player's Recaps view and "Previously on…" card automatically only ever surface what that player was allowed to see. No new filtering logic was needed.
- **"Previously on…" is intentionally stateless**: per the issue's own "keep it simple," it shows whenever the last session mark is a `start`, with no per-player "already seen" tracking.

## Docs notes

No changes to `docs/AI-DEVELOPMENT.md` were needed — this feature follows the standard "Adding a feature" shape exactly (schema → server handler → client), and doesn't introduce any new gotcha class (no new persisted column, no new player-visibility filter branch — the log's existing visibility rules already cover the new `session` kind).

## Test plan

- [x] `pnpm typecheck` (all 3 workspaces)
- [x] `pnpm test` — shared 47/47, server 73/73 (69 existing + 4 new in `sessions.test.ts`)
- [x] `pnpm build`
- [ ] Manual click-through of Start/End session buttons and the Recaps view (not done — no running dev server was exercised for this change)