### PR TITLE
Weather and fantasy calendar (Harptos)

### DIFF
--- a/docs/AI-DEVELOPMENT.md
+++ b/docs/AI-DEVELOPMENT.md
@@ -138,6 +138,15 @@ player-facing data).
   That's the intended forcing function: you must decide player visibility.
 - **New log `kind` strings** just need `KIND_META` + `FILTERS` entries in
   `LogTab.tsx`; unknown kinds render with a `·` fallback.
+- **Calendar/weather ride on the clock** (#79): `shared/rules/calendar.ts`
+  imports `time.ts` and never the reverse, so `formatDay`/`formatClock` stay
+  calendar-free and anything holding a campaign reaches for
+  `formatCalendarDate`/`formatCalendarClock` (they fall back to "Day N" when
+  `settings.calendar` is null). Weather rerolls in one place — `logDailyWeather`
+  in `handlers.ts`, called after every clock advance (`time.advance` and
+  `advanceTravelClock`) with the pre-advance reading; a new path that moves the
+  clock must call it too or that day's sky never turns. `time.set` deliberately
+  does not (it can move the clock backwards).
 - **The side panels are compositions, not screens** (#61): `PanelShell.tsx`
   owns the right-edge heading rail and one open pop-out at a time
   (`ui.openPanel`, swap-on-click, `panelWidth` still drag-resizable). The

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -122,6 +122,20 @@ Right for personal-group use; role checks still happen on every server command.
   narrate/share text to players and/or spawn a token at the party's hex.
 - All rolls (encounter + skill) are server-side, seeded RNG, appended to the session log.
 
+### Clock, calendar & weather
+- The campaign clock is one integer: in-game minutes since campaign start. Travel
+  spends it (hexes crossed × map scale ÷ pace); rests and downtime advance it
+  explicitly. Everyone sees it.
+- **Calendar** (`settings.calendar`, issue #79) is naming laid over that integer,
+  never a change to the arithmetic. Equal-length months plus intercalary
+  festivals that belong to no month; `null` renders the original "Day N". Harptos
+  ships as a preset (Shieldmeet leap days are not modelled).
+- **Weather** rolls once per in-game day off `settings.weatherTable` (or a
+  built-in temperate d20 table), stored on the campaign `time` blob and logged
+  for everyone as a `weather` entry. Crossing midnight — by travel or by a manual
+  advance — rerolls it; the DM can force a roll any time. It is fiction only for
+  now: no pace or encounter-threshold effects.
+
 ### Real-time & persistence
 - Single WebSocket per client. Every mutation is a **command** message; the server
   validates (zod + role), applies to SQLite, and broadcasts **events** filtered

--- a/packages/client/src/components/TopBar.tsx
+++ b/packages/client/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   SUPER_SCALE,
   TRAVEL_PACES,
-  formatDay,
+  formatCalendarDate,
   formatTimeOfDay,
   isNight,
   minutesPerHex,
@@ -99,7 +99,7 @@ function TimeControl() {
       >
         <span>{night ? '🌙' : '☀️'}</span>
         <span className="whitespace-nowrap">
-          {formatDay(time.minutes)} · {formatTimeOfDay(time.minutes)}
+          {formatCalendarDate(time.minutes, settings?.calendar)} · {formatTimeOfDay(time.minutes)}
         </span>
       </button>
 
@@ -215,9 +215,47 @@ function TimeControl() {
               </Button>
             </form>
           </div>
+
+          <div>
+            <span className="block text-[10px] uppercase tracking-wider text-ink-400 mb-1">
+              Weather
+            </span>
+            <div className="flex items-center gap-2">
+              <span className="flex-1 text-[11px] text-ink-200 truncate">
+                {time.weather ? `${time.weather.icon} ${time.weather.text}` : 'Not yet rolled'}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="!px-1 border border-ink-600"
+                onClick={() => send({ kind: 'weather.roll' })}
+                title="Roll a fresh sky from the campaign weather table (it rerolls on its own each new day)"
+              >
+                Reroll
+              </Button>
+            </div>
+          </div>
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Today's weather, next to the clock. Everyone sees it — the sky is not a DM
+ * secret — and the DM rerolls it from the clock popover.
+ */
+function WeatherReadout() {
+  const weather = useSession((s) => s.state?.campaign.time.weather);
+  if (!weather) return null;
+  return (
+    <span
+      className="hidden md:flex items-center gap-1 rounded-md border border-ink-600 px-2 py-1 text-[11px] text-ink-200 max-w-40"
+      title={`Weather: ${weather.text}`}
+    >
+      <span>{weather.icon}</span>
+      <span className="truncate">{weather.text}</span>
+    </span>
   );
 }
 
@@ -333,6 +371,7 @@ export function TopBar({
 
       {map && <ScaleControl baseMiles={map.milesPerHex} />}
       <TimeControl />
+      <WeatherReadout />
       <DayNightToggle />
 
       <div className="flex-1" />

--- a/packages/client/src/components/panels/LogTab.tsx
+++ b/packages/client/src/components/panels/LogTab.tsx
@@ -19,6 +19,7 @@ const KIND_META: Record<string, { icon: string; label: string }> = {
   narration: { icon: '📜', label: 'Narration' },
   share: { icon: '🤝', label: 'Shared' },
   time: { icon: '🕐', label: 'Time' },
+  weather: { icon: '🌦️', label: 'Weather' },
   session: { icon: '🎬', label: 'Session' },
 };
 
@@ -30,6 +31,7 @@ const FILTERS = [
   'narration',
   'share',
   'time',
+  'weather',
   'session',
 ] as const;
 

--- a/packages/client/src/components/panels/SettingsTab.tsx
+++ b/packages/client/src/components/panels/SettingsTab.tsx
@@ -1,8 +1,14 @@
 import React, { useEffect, useState } from 'react';
+import {
+  CALENDAR_PRESETS,
+  calendarDayOptions,
+  formatCalendarDate,
+  type CalendarConfig,
+} from '@hexcrawl/shared';
 import { useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { fetchInviteKeys, type InviteKeys } from '../../api.js';
-import { Button, Field, Input, Section, TextArea } from '../../ui/kit.js';
+import { Button, Field, Input, Section, Select, TextArea } from '../../ui/kit.js';
 
 export function SettingsTab({ campaignId }: { campaignId: string }) {
   const state = useSession((s) => s.state);
@@ -46,6 +52,8 @@ export function SettingsTab({ campaignId }: { campaignId: string }) {
           </Field>
         </div>
       </Section>
+
+      <CalendarSettings />
 
       <ShareLinks campaignId={campaignId} />
 
@@ -102,6 +110,83 @@ export function SettingsTab({ campaignId }: { campaignId: string }) {
         </ul>
       </Section>
     </div>
+  );
+}
+
+/**
+ * Calendar naming for the campaign clock (issue #79). Deliberately minimal:
+ * pick a preset (or none, which keeps the plain "Day N"), the year the
+ * campaign opens in, and which day of that year day 1 is. Everything else
+ * about the calendar — month names, lengths, festivals — comes from the preset
+ * and is stored on the campaign, so a hand-edited calendar keeps working.
+ */
+function CalendarSettings() {
+  const calendar = useSession((s) => s.state?.campaign.settings.calendar ?? null);
+  const preset = calendar ? CALENDAR_PRESETS.find((p) => p.name === calendar.name) : undefined;
+  const dayOptions = calendar ? calendarDayOptions(calendar) : [];
+
+  const patch = (next: CalendarConfig | null) =>
+    send({ kind: 'campaign.update', settings: { calendar: next } });
+
+  return (
+    <Section title="Calendar">
+      <div className="space-y-2.5">
+        <Field label="Calendar">
+          <Select
+            value={calendar?.name ?? ''}
+            onChange={(e) => {
+              const chosen = CALENDAR_PRESETS.find((p) => p.name === e.target.value);
+              patch(chosen ? { ...chosen } : null);
+            }}
+          >
+            <option value="">None — plain "Day 1, Day 2, …"</option>
+            {CALENDAR_PRESETS.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </Select>
+        </Field>
+
+        {calendar && (
+          <>
+            <Field label="Start year">
+              <Input
+                type="number"
+                defaultValue={calendar.startYear}
+                key={`${calendar.name}-${calendar.startYear}`}
+                onBlur={(e) => {
+                  const year = Math.trunc(Number(e.target.value));
+                  if (Number.isFinite(year) && year !== calendar.startYear) {
+                    patch({ ...calendar, startYear: year });
+                  }
+                }}
+              />
+            </Field>
+            <Field label="The campaign starts on">
+              <Select
+                value={String(calendar.startDayOfYear)}
+                onChange={(e) =>
+                  patch({ ...calendar, startDayOfYear: Number(e.target.value) })
+                }
+              >
+                {dayOptions.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+            <p className="text-xs text-ink-400">
+              Day 1 of the campaign clock is{' '}
+              <span className="text-ink-200">{formatCalendarDate(0, calendar)}</span>.{' '}
+              {preset?.name === 'Harptos' &&
+                'Harptos runs twelve 30-day months plus five festival days; leap-year Shieldmeet is not modelled.'}
+            </p>
+          </>
+        )}
+      </div>
+    </Section>
   );
 }
 

--- a/packages/server/src/engine/weather.ts
+++ b/packages/server/src/engine/weather.ts
@@ -1,0 +1,84 @@
+import type { DiceRoll, Rng, WeatherEntry, WeatherState } from '@hexcrawl/shared';
+import { DEFAULT_WEATHER_TABLE, MINUTES_PER_DAY, WEATHER_DIE, rollDice } from '@hexcrawl/shared';
+import type { CampaignRuntime } from '../state/runtime.js';
+
+/**
+ * Campaign weather (issue #79).
+ *
+ * One roll per in-game day off `settings.weatherTable` (or the built-in
+ * temperate table), stored on the campaign `time` blob so everyone — players
+ * included — sees the same sky. Purely fictional for now: nothing reads the
+ * weather to modify pace or encounter thresholds yet.
+ */
+
+/**
+ * A long advance rolls once per crossed day (weather is a per-day thing, and a
+ * DM who skips a week shouldn't get last week's storm), but only the final
+ * day's result is kept and logged — the intervening days are already history.
+ * The loop is capped so a `time.advance` of a year isn't 365 wasted rolls.
+ */
+const MAX_ROLLS_PER_ADVANCE = 30;
+
+export function weatherTableFor(runtime: CampaignRuntime): WeatherEntry[] {
+  const configured = runtime.campaign.settings.weatherTable;
+  return configured && configured.length > 0 ? configured : DEFAULT_WEATHER_TABLE;
+}
+
+export interface WeatherRollResult {
+  weather: WeatherState;
+  roll: DiceRoll;
+}
+
+/** Roll the campaign's weather table once. Does not touch state. */
+export function rollWeather(runtime: CampaignRuntime, rng: Rng): WeatherRollResult {
+  const table = weatherTableFor(runtime);
+  const roll = rollDice(WEATHER_DIE, rng);
+  const hit = table.find((e) => roll.total >= e.min && roll.total <= e.max) ?? table[0]!;
+  return {
+    weather: {
+      text: hit.text,
+      icon: hit.icon,
+      rolledAtMinutes: runtime.campaign.time.minutes,
+    },
+    roll,
+  };
+}
+
+/** Roll and store — the shared tail of every path that sets the weather. */
+export function setWeather(runtime: CampaignRuntime, rng: Rng): WeatherState {
+  const { weather } = rollWeather(runtime, rng);
+  runtime.updateTime({ weather });
+  return weather;
+}
+
+/** Day number (0-based) for a clock reading. */
+function dayNumber(minutes: number): number {
+  return Math.floor(Math.max(0, minutes) / MINUTES_PER_DAY);
+}
+
+/**
+ * Reroll the weather if the clock just crossed into a new day, or if the
+ * campaign has no weather yet (which seeds a sky on the party's first move
+ * rather than leaving the top bar blank until midnight).
+ *
+ * Returns the new weather to log, or null when nothing changed. Call AFTER the
+ * clock has advanced, with the reading from before it moved.
+ */
+export function rerollWeatherForNewDay(
+  runtime: CampaignRuntime,
+  beforeMinutes: number,
+  rng: Rng,
+): WeatherState | null {
+  const crossed = dayNumber(runtime.campaign.time.minutes) - dayNumber(beforeMinutes);
+  const seeding = runtime.campaign.time.weather === null;
+  if (crossed <= 0 && !seeding) return null;
+  const rolls = Math.min(Math.max(crossed, 1), MAX_ROLLS_PER_ADVANCE);
+  let weather: WeatherState | null = null;
+  for (let i = 0; i < rolls; i++) weather = setWeather(runtime, rng);
+  return weather;
+}
+
+/** The log line for a weather change: "The weather turns: Steady rain". */
+export function weatherLogText(weather: WeatherState): string {
+  return `The weather turns: ${weather.text}`;
+}

--- a/packages/server/src/weather.test.ts
+++ b/packages/server/src/weather.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_WEATHER_TABLE,
+  HARPTOS_PRESET,
+  MINUTES_PER_DAY,
+  filterStateForViewer,
+  rollDice,
+  seededRng,
+} from '@hexcrawl/shared';
+import type { ClientCommand, WeatherEntry } from '@hexcrawl/shared';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { CampaignRuntime, type SeatRecord } from './state/runtime.js';
+import { Hub } from './ws/hub.js';
+import { dispatchCommand } from './ws/handlers.js';
+
+/**
+ * Weather + calendar (issue #79).
+ *
+ * Every dispatch gets a FRESH `seededRng(1)`, exactly like the main test
+ * harness — so the nth weather roll inside one command is reproducible here by
+ * pulling n rolls off a fresh `seededRng(1)`, which is how "one roll per
+ * crossed day" is pinned down below.
+ */
+
+let store: Store;
+let runtime: CampaignRuntime;
+let dmSeat: SeatRecord;
+let hub: Hub;
+let cmdCounter = 0;
+
+function dm(cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `w${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat: dmSeat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+function asSeat(seat: SeatRecord, cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `w${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+/** A 1d20 table where every face has its own text, so rolls are identifiable. */
+const NUMBERED_TABLE: WeatherEntry[] = Array.from({ length: 20 }, (_, i) => ({
+  min: i + 1,
+  max: i + 1,
+  text: `W${i + 1}`,
+  icon: '🌡️',
+}));
+
+/** The text the nth 1d20 roll off a fresh seeded rng maps to in that table. */
+function nthRollText(n: number): string {
+  const rng = seededRng(1);
+  let total = 0;
+  for (let i = 0; i < n; i++) total = rollDice('1d20', rng).total;
+  return `W${total}`;
+}
+
+function weatherLog(): { text: string; visibility: string }[] {
+  return runtime.log.filter((e) => e.kind === 'weather');
+}
+
+beforeEach(() => {
+  cmdCounter = 0;
+  store = new Store(createTestDb());
+  const created = store.createCampaign('Weather Campaign', 'The DM');
+  runtime = created.runtime;
+  dmSeat = created.dmSeat;
+  hub = new Hub();
+  dm({ kind: 'map.create', name: 'Region', orientation: 'flat', hexSize: 48 } as never);
+  dm({ kind: 'campaign.update', settings: { weatherTable: NUMBERED_TABLE } } as never);
+});
+
+function activeMapId(): string {
+  return runtime.campaign.activeMapId!;
+}
+
+/** A claimed PC on the active map, ready to walk. */
+function setupParty(): { mapId: string; tokenId: string; playerSeat: SeatRecord } {
+  const mapId = activeMapId();
+  dm({
+    kind: 'character.create',
+    character: {
+      name: 'Scout', color: '#00aa00', glyph: '🏹', speed: 30, skills: {},
+      extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' },
+    },
+  } as never);
+  const charId = [...runtime.characters.keys()][0]!;
+  const playerSeat = runtime.createSeat('player', 'Alice');
+  asSeat(playerSeat, { kind: 'seat.claimCharacter', characterId: charId } as never);
+  playerSeat.characterId = runtime.seats.get(playerSeat.id)!.characterId;
+  dm({
+    kind: 'token.create', mapId, q: 0, r: 0, tokenKind: 'pc', characterId: charId,
+    label: '', color: '#00aa00', glyph: '', playerVisible: true,
+  } as never);
+  const tokenId = [...runtime.requireMap(mapId).tokens.keys()][0]!;
+  return { mapId, tokenId, playerSeat };
+}
+
+describe('weather rolling', () => {
+  it('starts with no weather and seeds a sky on the first clock advance', () => {
+    expect(runtime.campaign.time.weather).toBeNull();
+    expect(weatherLog()).toHaveLength(0);
+
+    // 8:00 AM + 1h stays inside day 1, but the campaign has no sky yet.
+    dm({ kind: 'time.advance', minutes: 60 } as never);
+    expect(runtime.campaign.time.weather).toMatchObject({
+      text: nthRollText(1),
+      rolledAtMinutes: 9 * 60,
+    });
+    expect(weatherLog()).toHaveLength(1);
+    expect(weatherLog()[0]!.text).toBe(`The weather turns: ${nthRollText(1)}`);
+    // The sky is not a DM secret.
+    expect(weatherLog()[0]!.visibility).toBe('all');
+  });
+
+  it('rerolls exactly once when an advance crosses into a new day', () => {
+    dm({ kind: 'time.advance', minutes: 60 } as never); // seeds (9:00 AM, day 1)
+    expect(weatherLog()).toHaveLength(1);
+
+    // Still day 1: no reroll.
+    dm({ kind: 'time.advance', minutes: 8 * 60 } as never); // 5:00 PM
+    expect(weatherLog()).toHaveLength(1);
+
+    // Over midnight into day 2: exactly one more roll and one more log line.
+    dm({ kind: 'time.advance', minutes: 8 * 60, note: 'camp' } as never); // 1:00 AM day 2
+    expect(runtime.campaign.time.minutes).toBe(MINUTES_PER_DAY + 60);
+    expect(weatherLog()).toHaveLength(2);
+    expect(runtime.campaign.time.weather!.rolledAtMinutes).toBe(MINUTES_PER_DAY + 60);
+  });
+
+  it('rolls once per crossed day but keeps and logs only the final day', () => {
+    dm({ kind: 'time.advance', minutes: 60 } as never); // seed, day 1
+    expect(weatherLog()).toHaveLength(1);
+
+    // Three midnights in one advance: three rolls, one surviving sky.
+    dm({ kind: 'time.advance', minutes: 3 * MINUTES_PER_DAY } as never);
+    expect(weatherLog()).toHaveLength(2);
+    expect(runtime.campaign.time.weather!.text).toBe(nthRollText(3));
+    expect(weatherLog()[1]!.text).toBe(`The weather turns: ${nthRollText(3)}`);
+  });
+
+  it('rerolls when travel itself crosses midnight', () => {
+    const { tokenId, playerSeat } = setupParty();
+    // Default 6 mi/hex on foot at normal pace = 120 minutes per hex.
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 1, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(10 * 60);
+    expect(weatherLog()).toHaveLength(1); // the seeding roll
+
+    // Park the clock just before midnight, then walk one hex over it.
+    dm({ kind: 'time.advance', minutes: 13 * 60 + 30 } as never); // 11:30 PM
+    expect(weatherLog()).toHaveLength(1);
+    asSeat(playerSeat, { kind: 'token.move', tokenId, q: 2, r: 0 } as never);
+    expect(runtime.campaign.time.minutes).toBe(MINUTES_PER_DAY + 90);
+    expect(weatherLog()).toHaveLength(2);
+    expect(runtime.campaign.time.weather!.rolledAtMinutes).toBe(MINUTES_PER_DAY + 90);
+  });
+
+  it('leaves the weather alone when time.set fixes the clock', () => {
+    dm({ kind: 'time.advance', minutes: 60 } as never);
+    const seeded = runtime.campaign.time.weather;
+    dm({ kind: 'time.set', minutes: 10 * MINUTES_PER_DAY } as never);
+    expect(runtime.campaign.time.weather).toEqual(seeded);
+    expect(weatherLog()).toHaveLength(1);
+  });
+});
+
+describe('weather.roll', () => {
+  it('forces a reroll at any time, logged for everyone', () => {
+    dm({ kind: 'weather.roll' } as never);
+    expect(runtime.campaign.time.weather).toMatchObject({
+      text: nthRollText(1),
+      icon: '🌡️',
+      rolledAtMinutes: 8 * 60,
+    });
+    const entries = weatherLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.visibility).toBe('all');
+    expect(runtime.log.at(-1)!.data.forced).toBe(true);
+
+    // A second forced roll re-rolls even though the day has not changed.
+    dm({ kind: 'weather.roll' } as never);
+    expect(weatherLog()).toHaveLength(2);
+  });
+
+  it('is DM-only', () => {
+    const { playerSeat } = setupParty();
+    const before = weatherLog().length;
+    expect(() => asSeat(playerSeat, { kind: 'weather.roll' } as never)).toThrow(/Only the DM/);
+    expect(weatherLog()).toHaveLength(before);
+  });
+});
+
+describe('weather tables', () => {
+  it('falls back to the built-in table when the campaign has none', () => {
+    dm({ kind: 'campaign.update', settings: { weatherTable: null } } as never);
+    dm({ kind: 'weather.roll' } as never);
+    const texts = DEFAULT_WEATHER_TABLE.map((e) => e.text);
+    expect(texts).toContain(runtime.campaign.time.weather!.text);
+    expect(runtime.campaign.time.weather!.icon).not.toBe('');
+  });
+
+  it('uses the campaign table, including a single catch-all row', () => {
+    dm({
+      kind: 'campaign.update',
+      settings: { weatherTable: [{ min: 1, max: 20, text: 'Ash falls', icon: '🌋' }] },
+    } as never);
+    dm({ kind: 'weather.roll' } as never);
+    expect(runtime.campaign.time.weather).toMatchObject({ text: 'Ash falls', icon: '🌋' });
+  });
+});
+
+describe('weather visibility and persistence', () => {
+  it('reaches players in their filtered snapshot', () => {
+    const { mapId, playerSeat } = setupParty();
+    dm({ kind: 'weather.roll' } as never);
+    const view = filterStateForViewer(runtime.buildFullState(mapId), {
+      seatId: playerSeat.id,
+      role: 'player',
+      characterId: playerSeat.characterId,
+    });
+    expect(view.campaign.time.weather).toEqual(runtime.campaign.time.weather);
+  });
+
+  it('survives a server restart', () => {
+    dm({ kind: 'time.advance', minutes: MINUTES_PER_DAY } as never);
+    const weather = runtime.campaign.time.weather!;
+    const db = (store as unknown as { db: unknown }).db;
+    const reloaded = new Store(db as never).getCampaign(runtime.id)!;
+    expect(reloaded.campaign.time.weather).toEqual(weather);
+    expect(reloaded.campaign.settings.weatherTable).toEqual(NUMBERED_TABLE);
+    // And a reloaded campaign does not re-seed: the sky is already set.
+    expect(reloaded.log.filter((e) => e.kind === 'weather')).toHaveLength(1);
+  });
+});
+
+describe('calendar-named log lines', () => {
+  it('names clock readouts by the campaign calendar once one is configured', () => {
+    dm({ kind: 'time.advance', minutes: 60 } as never);
+    expect(runtime.log.at(-2)!.text).toContain('Day 1, 9:00 AM');
+
+    dm({
+      kind: 'campaign.update',
+      settings: { calendar: { ...HARPTOS_PRESET, startYear: 1492, startDayOfYear: 285 } },
+    } as never);
+    dm({ kind: 'time.advance', minutes: 60, note: 'reading' } as never);
+    const entry = runtime.log.filter((e) => e.kind === 'time').at(-1)!;
+    expect(entry.text).toContain('Marpenoth 12, 1492 DR, 10:00 AM');
+  });
+});

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -14,7 +14,7 @@ import {
   compassDirection,
   contentCoversHex,
   distanceToContent,
-  formatClock,
+  formatCalendarClock,
   formatDuration,
   GridStyleSchema,
   hexDistance,
@@ -34,6 +34,7 @@ import { evaluateKnowledge, type NewDiscovery } from '../engine/knowledge.js';
 import { evaluateTrails, trailBearings, type TrailFind } from '../engine/trails.js';
 import { generateSettlementClues } from '../engine/settlements.js';
 import { rollEncounter } from '../engine/encounters.js';
+import { rerollWeatherForNewDay, setWeather, weatherLogText } from '../engine/weather.js';
 
 export interface Ctx {
   runtime: CampaignRuntime;
@@ -963,10 +964,11 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
   // -- campaign clock --------------------------------------------------------
   'time.advance': ((cmd: Extract<ClientCommand, { kind: 'time.advance' }>, ctx: Ctx) => {
     requireDm(ctx);
+    const before = ctx.runtime.campaign.time.minutes;
     const time = ctx.runtime.advanceTime(cmd.minutes);
     let text = `Time advances ${formatDuration(cmd.minutes)}`;
     if (cmd.note) text += ` (${cmd.note})`;
-    text += ` — ${formatClock(time.minutes)}`;
+    text += ` — ${campaignClock(ctx, time.minutes)}`;
     if (time.partyHex) {
       text += ` at ${hexLocationLabel(ctx.runtime, time.partyHex)}`;
     }
@@ -976,13 +978,32 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       note: cmd.note ?? null,
     });
     notifyLog(ctx, entry);
+    logDailyWeather(ctx, before);
   }) as Handler,
 
   'time.set': ((cmd: Extract<ClientCommand, { kind: 'time.set' }>, ctx: Ctx) => {
     requireDm(ctx);
     const time = ctx.runtime.setTime(cmd.minutes);
-    const entry = ctx.runtime.appendLog('time', `Clock set to ${formatClock(time.minutes)}`, 'dm', {
-      minutes: time.minutes,
+    // Deliberately no weather reroll: `time.set` is bookkeeping (fixing a
+    // mistyped advance), and it can move the clock backwards. The DM can force
+    // a fresh sky with `weather.roll`.
+    const entry = ctx.runtime.appendLog(
+      'time',
+      `Clock set to ${campaignClock(ctx, time.minutes)}`,
+      'dm',
+      { minutes: time.minutes },
+    );
+    notifyLog(ctx, entry);
+  }) as Handler,
+
+  'weather.roll': ((_cmd: Extract<ClientCommand, { kind: 'weather.roll' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const weather = setWeather(ctx.runtime, ctx.rng);
+    const entry = ctx.runtime.appendLog('weather', weatherLogText(weather), 'all', {
+      text: weather.text,
+      icon: weather.icon,
+      minutes: weather.rolledAtMinutes,
+      forced: true,
     });
     notifyLog(ctx, entry);
   }) as Handler,
@@ -1025,13 +1046,38 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     requireDm(ctx);
     const atMinutes = ctx.runtime.campaign.time.minutes;
     const label = cmd.action === 'start' ? 'Session started' : 'Session ended';
-    const entry = ctx.runtime.appendLog('session', `${label} — ${formatClock(atMinutes)}`, 'all', {
+    const entry = ctx.runtime.appendLog('session', `${label} — ${campaignClock(ctx, atMinutes)}`, 'all', {
       action: cmd.action,
       atMinutes,
     });
     notifyLog(ctx, entry);
   }) as Handler,
 };
+
+/**
+ * Clock readout for a log line, named by the campaign's calendar when it has
+ * one ("Marpenoth 12, 1492 DR, 6:40 PM") and by day number otherwise.
+ */
+function campaignClock(ctx: Ctx, minutes: number): string {
+  return formatCalendarClock(minutes, ctx.runtime.campaign.settings.calendar);
+}
+
+/**
+ * Weather hook for every clock advance: reroll when the advance crossed into a
+ * new day (or seeded the very first sky) and log it for everyone. Call after
+ * the clock has moved, with the reading from before it did.
+ */
+function logDailyWeather(ctx: Ctx, beforeMinutes: number): void {
+  const weather = rerollWeatherForNewDay(ctx.runtime, beforeMinutes, ctx.rng);
+  if (!weather) return;
+  const entry = ctx.runtime.appendLog('weather', weatherLogText(weather), 'all', {
+    text: weather.text,
+    icon: weather.icon,
+    minutes: weather.rolledAtMinutes,
+    forced: false,
+  });
+  notifyLog(ctx, entry);
+}
 
 /**
  * A human-readable label for a party-hex reference: the title of enabled
@@ -1238,10 +1284,13 @@ function advanceTravelClock(
   if (parked) {
     ctx.runtime.addHexTime(parked.mapId, parked.q, parked.r, time.minutes - parked.arrivedMinutes);
   }
+  const before = time.minutes;
   if (travelMinutes > 0) ctx.runtime.advanceTime(travelMinutes);
   const arrivedMinutes = ctx.runtime.campaign.time.minutes;
   ctx.runtime.recordHexArrival(map.id, to.q, to.r, arrivedMinutes);
   ctx.runtime.updateTime({ partyHex: { mapId: map.id, q: to.q, r: to.r, arrivedMinutes } });
+  // Travel that crosses midnight brings a new day's weather with it (#79).
+  logDailyWeather(ctx, before);
 }
 
 function capitalize(s: string): string {

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -128,6 +128,71 @@ export const INHERITABLE_MAP_FIELDS = [
 ] as const;
 export type InheritableMapField = (typeof INHERITABLE_MAP_FIELDS)[number];
 
+/**
+ * A fantasy calendar laid over the campaign clock (issue #79). The clock stays
+ * a plain minute count; this is naming only. Every month has the same length
+ * (`monthLength`), and festivals are intercalary days that sit *between*
+ * months and belong to no month — Harptos's Midwinter and friends. A year is
+ * `months.length * monthLength + festivals.length` days long.
+ */
+export const CalendarFestivalSchema = z.object({
+  name: z.string().min(1).max(60),
+  /** 0-based index of the month this festival follows. */
+  afterMonth: z.number().int().min(0).max(98),
+});
+export type CalendarFestival = z.infer<typeof CalendarFestivalSchema>;
+
+export const CalendarConfigSchema = z.object({
+  name: z.string().min(1).max(60),
+  monthLength: z.number().int().min(1).max(99),
+  months: z.array(z.string().min(1).max(60)).min(1).max(99),
+  /** Year number of campaign day 1. */
+  startYear: z.number().int().min(-99999).max(99999),
+  /** Rendered after the year: "1492 DR". */
+  yearSuffix: z.string().max(12).default(''),
+  festivals: z.array(CalendarFestivalSchema).max(99).default([]),
+  /** 0-based day-of-year the campaign starts on (0 = the first day). */
+  startDayOfYear: z.number().int().min(0).max(9998).default(0),
+});
+export type CalendarConfig = z.infer<typeof CalendarConfigSchema>;
+
+/** One row of a weather table: rolled value range → the day's weather. */
+export const WeatherEntrySchema = z.object({
+  min: z.number().int(),
+  max: z.number().int(),
+  text: z.string().min(1).max(120),
+  icon: z.string().max(8).default(''),
+});
+export type WeatherEntry = z.infer<typeof WeatherEntrySchema>;
+
+/** The weather now, rolled when the clock last crossed into a new day. */
+export const WeatherStateSchema = z.object({
+  text: z.string().max(120),
+  icon: z.string().max(8),
+  rolledAtMinutes: z.number().int().min(0),
+});
+export type WeatherState = z.infer<typeof WeatherStateSchema>;
+
+/** Die rolled against a weather table when the campaign has not set one. */
+export const WEATHER_DIE = '1d20';
+
+/**
+ * Built-in temperate weather table (1d20), used when a campaign has not
+ * configured `settings.weatherTable`. Deliberately fictional colour — nothing
+ * mechanical hangs off it yet (pace/encounter hooks are a follow-up).
+ */
+export const DEFAULT_WEATHER_TABLE: WeatherEntry[] = [
+  { min: 1, max: 5, text: 'Clear skies', icon: '☀️' },
+  { min: 6, max: 9, text: 'Scattered cloud', icon: '🌤️' },
+  { min: 10, max: 12, text: 'Overcast', icon: '☁️' },
+  { min: 13, max: 14, text: 'Drizzle', icon: '🌦️' },
+  { min: 15, max: 16, text: 'Steady rain', icon: '🌧️' },
+  { min: 17, max: 17, text: 'Thick fog', icon: '🌫️' },
+  { min: 18, max: 18, text: 'Hard wind', icon: '💨' },
+  { min: 19, max: 19, text: 'Thunderstorm', icon: '⛈️' },
+  { min: 20, max: 20, text: 'Violent storm', icon: '🌪️' },
+];
+
 export const CampaignSettingsSchema = z.object({
   /** Free text shown on the join screen. */
   description: z.string().max(2000).default(''),
@@ -148,6 +213,10 @@ export const CampaignSettingsSchema = z.object({
   pausePlayerMapSync: z.boolean().default(false),
   /** Campaign-wide map settings; maps opt in per field via inheritedFields. */
   mapDefaults: MapDefaultsSchema.default(() => MapDefaultsSchema.parse({})),
+  /** Fantasy calendar naming for the clock; null renders plain "Day N". */
+  calendar: CalendarConfigSchema.nullable().default(null),
+  /** Weather table rolled at dawn; null uses DEFAULT_WEATHER_TABLE. */
+  weatherTable: z.array(WeatherEntrySchema).max(100).nullable().default(null),
 });
 export type CampaignSettings = z.infer<typeof CampaignSettingsSchema>;
 
@@ -177,6 +246,12 @@ export const CampaignTimeSchema = z.object({
     })
     .nullable()
     .default(null),
+  /**
+   * The current weather, rerolled whenever the clock crosses into a new day
+   * (issue #79). Null until the first roll — brand-new campaigns and any
+   * campaign that predates the feature.
+   */
+  weather: WeatherStateSchema.nullable().default(null),
 });
 export type CampaignTime = z.infer<typeof CampaignTimeSchema>;
 

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 import {
+  CalendarConfigSchema,
   CharacterSchema,
   ContentTypeSchema,
   ClueSchema,
   CustomTravelModeSchema,
+  WeatherEntrySchema,
   TravelPaceSchema,
   EncounterTableSchema,
   FogStateSchema,
@@ -64,6 +66,14 @@ const CampaignSettingsPatchSchema = z
     sunriseHour: z.number().min(0).max(23),
     sunsetHour: z.number().min(0).max(24),
     mapDefaults: MapDefaultsPatchSchema,
+    /**
+     * Calendar and weather table are whole-value replacements (or null to go
+     * back to "Day N" / the built-in table), not nested patches — so unlike
+     * their siblings they keep their schema defaults, which is what completes
+     * the object the server stores verbatim.
+     */
+    calendar: CalendarConfigSchema.nullable(),
+    weatherTable: z.array(WeatherEntrySchema).max(100).nullable(),
   })
   .partial();
 
@@ -573,6 +583,15 @@ export const TimeConfigCommand = z.object({
   pace: TravelPaceSchema.optional(),
 });
 
+/**
+ * DM: force a weather reroll now (issue #79). Weather otherwise rerolls on its
+ * own whenever the clock crosses into a new day.
+ */
+export const WeatherRollCommand = z.object({
+  ...base,
+  kind: z.literal('weather.roll'),
+});
+
 /** DM: undo the most recent undoable change (fog, terrain, moves, edits). */
 export const UndoCommand = z.object({
   ...base,
@@ -643,6 +662,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   TimeAdvanceCommand,
   TimeSetCommand,
   TimeConfigCommand,
+  WeatherRollCommand,
   UndoCommand,
   NarrateCommand,
   SessionMarkCommand,

--- a/packages/shared/src/rules/calendar.test.ts
+++ b/packages/shared/src/rules/calendar.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CALENDAR_PRESETS,
+  HARPTOS_PRESET,
+  calendarDateForDay,
+  calendarDayOptions,
+  calendarYearLength,
+  formatCalendarClock,
+  formatCalendarDate,
+} from './calendar.js';
+import { CalendarConfigSchema } from '../domain.js';
+import { MINUTES_PER_DAY } from './time.js';
+
+/** Clock minutes at 8:00 AM on the given 1-based campaign day. */
+function atDay(day: number, hour = 8): number {
+  return (day - 1) * MINUTES_PER_DAY + hour * 60;
+}
+
+describe('calendar fallback', () => {
+  it('renders plain day numbers with no calendar configured', () => {
+    expect(formatCalendarDate(atDay(1), null)).toBe('Day 1');
+    expect(formatCalendarDate(atDay(3), undefined)).toBe('Day 3');
+    expect(formatCalendarClock(2 * MINUTES_PER_DAY + 18 * 60 + 40, null)).toBe('Day 3, 6:40 PM');
+  });
+});
+
+describe('Harptos', () => {
+  it('is a valid calendar config: 12 months, 5 festivals, 365 days', () => {
+    const parsed = CalendarConfigSchema.parse(HARPTOS_PRESET);
+    expect(parsed.months).toHaveLength(12);
+    expect(parsed.festivals).toHaveLength(5);
+    expect(calendarYearLength(parsed)).toBe(365);
+    expect(CALENDAR_PRESETS).toContain(HARPTOS_PRESET);
+  });
+
+  it('names the first day of the year and the first month', () => {
+    expect(formatCalendarDate(atDay(1), HARPTOS_PRESET)).toBe('Hammer 1, 1492 DR');
+    expect(formatCalendarDate(atDay(30), HARPTOS_PRESET)).toBe('Hammer 30, 1492 DR');
+  });
+
+  it('slots festivals between months, belonging to no month', () => {
+    // Midwinter follows Hammer (day 31), and Alturiak 1 is the day after.
+    const midwinter = calendarDateForDay(31, HARPTOS_PRESET);
+    expect(midwinter.festival).toBe('Midwinter');
+    expect(midwinter.month).toBeNull();
+    expect(midwinter.monthIndex).toBeNull();
+    expect(midwinter.day).toBeNull();
+    expect(formatCalendarDate(atDay(31), HARPTOS_PRESET)).toBe('Midwinter, 1492 DR');
+    expect(formatCalendarDate(atDay(32), HARPTOS_PRESET)).toBe('Alturiak 1, 1492 DR');
+  });
+
+  it('offsets every later month by the festivals already passed', () => {
+    // Marpenoth is month 10; nine months of 30 days plus the four festivals
+    // before it (Midwinter, Greengrass, Midsummer, Highharvestide) = 274 days.
+    expect(formatCalendarDate(atDay(274 + 12), HARPTOS_PRESET)).toBe('Marpenoth 12, 1492 DR');
+    const date = calendarDateForDay(274 + 12, HARPTOS_PRESET);
+    expect(date.month).toBe('Marpenoth');
+    expect(date.day).toBe(12);
+    expect(date.dayOfYear).toBe(274 + 11);
+  });
+
+  it('places all five festivals where the Realms puts them', () => {
+    const labels = calendarDayOptions(HARPTOS_PRESET);
+    expect(labels).toHaveLength(365);
+    // Month days render as "<Month> <n>"; anything else is a festival.
+    const festivalDays = labels
+      .map((o, i) => ({ ...o, day: i + 1 }))
+      .filter((o) => !/ \d+$/.test(o.label));
+    expect(festivalDays.map((f) => f.label)).toEqual([
+      'Midwinter',
+      'Greengrass',
+      'Midsummer',
+      'Highharvestide',
+      'Feast of the Moon',
+    ]);
+    // Feast of the Moon closes out Uktar, so Nightal 1 follows it.
+    const feastDay = festivalDays[4]!.day;
+    expect(formatCalendarDate(atDay(feastDay), HARPTOS_PRESET)).toBe('Feast of the Moon, 1492 DR');
+    expect(formatCalendarDate(atDay(feastDay + 1), HARPTOS_PRESET)).toBe('Nightal 1, 1492 DR');
+  });
+
+  it('rolls over to the next year after 365 days', () => {
+    expect(formatCalendarDate(atDay(365), HARPTOS_PRESET)).toBe('Nightal 30, 1492 DR');
+    expect(formatCalendarDate(atDay(366), HARPTOS_PRESET)).toBe('Hammer 1, 1493 DR');
+    expect(formatCalendarDate(atDay(365 * 3 + 1), HARPTOS_PRESET)).toBe('Hammer 1, 1495 DR');
+  });
+
+  it('starts the campaign wherever startDayOfYear points', () => {
+    // "The campaign opens on Marpenoth 12": day-of-year index 274 + 11.
+    const calendar = { ...HARPTOS_PRESET, startDayOfYear: 274 + 11 };
+    expect(formatCalendarDate(atDay(1), calendar)).toBe('Marpenoth 12, 1492 DR');
+    expect(formatCalendarDate(atDay(2), calendar)).toBe('Marpenoth 13, 1492 DR');
+    // 365 days after the year's day 285 comes New Year's Day of 1493.
+    expect(formatCalendarDate(atDay(81), calendar)).toBe('Hammer 1, 1493 DR');
+    expect(formatCalendarDate(atDay(82), calendar)).toBe('Hammer 2, 1493 DR');
+  });
+
+  it('keeps the time of day alongside the calendar date', () => {
+    expect(formatCalendarClock(atDay(1, 18) + 40, HARPTOS_PRESET)).toBe(
+      'Hammer 1, 1492 DR, 6:40 PM',
+    );
+  });
+});
+
+describe('custom calendars', () => {
+  const simple = CalendarConfigSchema.parse({
+    name: 'Twin Moons',
+    monthLength: 10,
+    months: ['First', 'Second'],
+    startYear: 1,
+  });
+
+  it('handles a festival-free calendar', () => {
+    expect(calendarYearLength(simple)).toBe(20);
+    expect(formatCalendarDate(atDay(11), simple)).toBe('Second 1, 1');
+    expect(formatCalendarDate(atDay(21), simple)).toBe('First 1, 2');
+  });
+
+  it('renders no year suffix when the calendar has none', () => {
+    expect(formatCalendarDate(atDay(1), simple)).toBe('First 1, 1');
+  });
+
+  it('appends an out-of-range festival at year end rather than losing a day', () => {
+    const odd = CalendarConfigSchema.parse({
+      ...simple,
+      festivals: [{ name: 'Longnight', afterMonth: 9 }],
+    });
+    expect(calendarYearLength(odd)).toBe(21);
+    expect(formatCalendarDate(atDay(21), odd)).toBe('Longnight, 1');
+    expect(formatCalendarDate(atDay(22), odd)).toBe('First 1, 2');
+  });
+});

--- a/packages/shared/src/rules/calendar.ts
+++ b/packages/shared/src/rules/calendar.ts
@@ -1,0 +1,158 @@
+import type { CalendarConfig } from '../domain.js';
+import { formatTimeOfDay, timeOfDay } from './time.js';
+
+/**
+ * Fantasy calendars over the campaign clock (issue #79).
+ *
+ * The clock stays what it always was — minutes since campaign start — and this
+ * module is pure naming on top of it. Nothing here mutates state, and with no
+ * calendar configured every function falls back to the original "Day N".
+ *
+ * Model: months all share one length (`monthLength`); festivals are
+ * intercalary days that sit *between* months and belong to no month, so
+ * "Midwinter" is a date in its own right rather than "Hammer 31". A year is
+ * `months.length * monthLength + festivals.length` days.
+ *
+ * Import direction is one-way — this file imports `time.ts`, never the other
+ * way round — so `formatDay`/`formatClock` stay calendar-free and callers that
+ * *have* a calendar reach for `formatCalendarDate`/`formatCalendarClock`.
+ */
+
+export interface CalendarDate {
+  /** Year number. */
+  year: number;
+  /** 0-based day of year. */
+  dayOfYear: number;
+  /** 0-based month index, or null on a festival day. */
+  monthIndex: number | null;
+  /** Month name, or null on a festival day. */
+  month: string | null;
+  /** 1-based day within the month, or null on a festival day. */
+  day: number | null;
+  /** Festival name when this day is a festival, else null. */
+  festival: string | null;
+}
+
+/** Days in one year of this calendar (months plus intercalary festivals). */
+export function calendarYearLength(calendar: CalendarConfig): number {
+  return calendar.months.length * calendar.monthLength + (calendar.festivals?.length ?? 0);
+}
+
+/**
+ * The ordered day slots of one year: each month's days in turn, with a
+ * festival slotted in after the month it follows (`afterMonth`, 0-based).
+ * Festivals whose `afterMonth` is out of range are appended at year's end so a
+ * misconfigured calendar still renders every day.
+ */
+function yearSlots(calendar: CalendarConfig): CalendarDate[] {
+  const festivals = calendar.festivals ?? [];
+  const slots: CalendarDate[] = [];
+  const push = (partial: Omit<CalendarDate, 'year' | 'dayOfYear'>) =>
+    slots.push({ year: 0, dayOfYear: slots.length, ...partial });
+
+  calendar.months.forEach((month, monthIndex) => {
+    for (let day = 1; day <= calendar.monthLength; day++) {
+      push({ monthIndex, month, day, festival: null });
+    }
+    for (const f of festivals.filter((x) => x.afterMonth === monthIndex)) {
+      push({ monthIndex: null, month: null, day: null, festival: f.name });
+    }
+  });
+  for (const f of festivals.filter((x) => x.afterMonth >= calendar.months.length)) {
+    push({ monthIndex: null, month: null, day: null, festival: f.name });
+  }
+  return slots;
+}
+
+/**
+ * Resolve a campaign day number (1-based, as `timeOfDay().day` reports it) to
+ * a calendar date. `calendar.startDayOfYear` says where in the year day 1
+ * falls, so a campaign can open on Marpenoth 12 rather than New Year's Day.
+ */
+export function calendarDateForDay(day: number, calendar: CalendarConfig): CalendarDate {
+  const yearLength = calendarYearLength(calendar);
+  const slots = yearSlots(calendar);
+  const absolute = Math.max(0, Math.floor(day) - 1) + (calendar.startDayOfYear ?? 0);
+  const yearOffset = Math.floor(absolute / yearLength);
+  const dayOfYear = ((absolute % yearLength) + yearLength) % yearLength;
+  const slot = slots[dayOfYear]!;
+  return { ...slot, year: calendar.startYear + yearOffset, dayOfYear };
+}
+
+/** "Marpenoth 12, 1492 DR" / "Midwinter, 1492 DR". */
+export function formatCalendarDay(date: CalendarDate, calendar: CalendarConfig): string {
+  const suffix = calendar.yearSuffix ? ` ${calendar.yearSuffix}` : '';
+  const head = date.festival ?? `${date.month} ${date.day}`;
+  return `${head}, ${date.year}${suffix}`;
+}
+
+/**
+ * The campaign date for a clock reading: a calendar date when the campaign has
+ * one configured, and the plain "Day 3" otherwise.
+ */
+export function formatCalendarDate(
+  minutes: number,
+  calendar?: CalendarConfig | null,
+): string {
+  const { day } = timeOfDay(minutes);
+  if (!calendar) return `Day ${day}`;
+  return formatCalendarDay(calendarDateForDay(day, calendar), calendar);
+}
+
+/** "Marpenoth 12, 1492 DR, 6:40 PM" — the calendar-aware `formatClock`. */
+export function formatCalendarClock(minutes: number, calendar?: CalendarConfig | null): string {
+  return `${formatCalendarDate(minutes, calendar)}, ${formatTimeOfDay(minutes)}`;
+}
+
+/**
+ * The Calendar of Harptos (Forgotten Realms): twelve 30-day months with five
+ * intercalary festivals, 365 days a year.
+ *
+ * Shieldmeet — the leap day after Midsummer every fourth year — is deliberately
+ * NOT modelled: the calendar model has no leap rule, and adding one for a
+ * single setting would complicate every date computation. A Harptos campaign
+ * that plays through a Shieldmeet year drifts one day; the DM can nudge the
+ * clock with `time.set` if it matters.
+ */
+export const HARPTOS_PRESET: CalendarConfig = {
+  name: 'Harptos',
+  monthLength: 30,
+  months: [
+    'Hammer',
+    'Alturiak',
+    'Ches',
+    'Tarsakh',
+    'Mirtul',
+    'Kythorn',
+    'Flamerule',
+    'Eleasis',
+    'Eleint',
+    'Marpenoth',
+    'Uktar',
+    'Nightal',
+  ],
+  startYear: 1492,
+  yearSuffix: 'DR',
+  festivals: [
+    { name: 'Midwinter', afterMonth: 0 },
+    { name: 'Greengrass', afterMonth: 3 },
+    { name: 'Midsummer', afterMonth: 6 },
+    { name: 'Highharvestide', afterMonth: 8 },
+    { name: 'Feast of the Moon', afterMonth: 10 },
+  ],
+  startDayOfYear: 0,
+};
+
+/** Calendar presets offered in the UI (plus "none", which stores null). */
+export const CALENDAR_PRESETS: CalendarConfig[] = [HARPTOS_PRESET];
+
+/**
+ * Every day of a calendar year as a pickable label, in order — the "campaign
+ * starts on …" selector in settings. The index is the `startDayOfYear` value.
+ */
+export function calendarDayOptions(calendar: CalendarConfig): { value: number; label: string }[] {
+  return yearSlots(calendar).map((slot, value) => ({
+    value,
+    label: slot.festival ?? `${slot.month} ${slot.day}`,
+  }));
+}

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -2,4 +2,5 @@ export * from './dice.js';
 export * from './gates.js';
 export * from './filter.js';
 export * from './time.js';
+export * from './calendar.js';
 export * from './recap.js';

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -97,8 +97,10 @@ function fullState(): CampaignState {
         sunriseHour: 6,
         sunsetHour: 20,
         mapDefaults: MapDefaultsSchema.parse({}),
+        calendar: null,
+        weatherTable: null,
       },
-      time: { minutes: 8 * 60, travelMode: 'foot', pace: 'normal', partyHex: null },
+      time: { minutes: 8 * 60, travelMode: 'foot', pace: 'normal', partyHex: null, weather: null },
     },
     seats: [
       { id: 'dm', role: 'dm', name: 'DM', characterId: null, online: true },

--- a/packages/shared/src/rules/time.ts
+++ b/packages/shared/src/rules/time.ts
@@ -116,7 +116,12 @@ export function minutesUntilSunrise(minutes: number, settings: DaylightSettings 
   return sunriseToday + MINUTES_PER_DAY - total;
 }
 
-/** "Day 3" — deliberately calendar-free; #79 can rename this layer. */
+/**
+ * "Day 3" — deliberately calendar-free. A campaign with
+ * `settings.calendar` configured renders dates through
+ * `formatCalendarDate`/`formatCalendarClock` in `calendar.ts` instead, which
+ * falls back to exactly this string when there is no calendar.
+ */
 export function formatDay(minutes: number): string {
   return `Day ${timeOfDay(minutes).day}`;
 }
@@ -129,7 +134,7 @@ export function formatTimeOfDay(minutes: number): string {
   return `${h12}:${String(minute).padStart(2, '0')} ${suffix}`;
 }
 
-/** "Day 3, 6:40 PM" */
+/** "Day 3, 6:40 PM" — see `formatCalendarClock` for the calendar-aware form. */
 export function formatClock(minutes: number): string {
   return `${formatDay(minutes)}, ${formatTimeOfDay(minutes)}`;
 }


### PR DESCRIPTION
Closes #79

Weather and a fantasy calendar layered on the campaign clock. The clock itself is untouched — it is still one integer, in-game minutes since campaign start.

## Calendar

- `settings.calendar` (nullable, default null → the original "Day N"): equal-length months plus **intercalary festivals that belong to no month**, a start year, a year suffix, and a `startDayOfYear` so a campaign can open on Marpenoth 12 rather than New Year's Day.
- `shared/src/rules/calendar.ts` (new): `formatCalendarDate` / `formatCalendarClock` / `calendarDateForDay` / `calendarDayOptions`. It imports `time.ts` one-way and nothing imports it back, so `formatDay` / `formatClock` stay calendar-free and every calendar function falls back to "Day N" when there is no calendar.
- **Harptos preset**: twelve 30-day months (Hammer…Nightal) with Midwinter, Greengrass, Midsummer, Highharvestide and the Feast of the Moon slotted between them; 365 days. **Shieldmeet is not modelled** — the calendar model has no leap rule, and a Harptos campaign that plays through a leap year drifts one day (nudgeable with `time.set`).
- Clock readouts in the `time` and `session` log lines route through the calendar; the top-bar readout does too.
- UI in Setup: preset select (none / Harptos), start year, and a "the campaign starts on <day>" select listing every day of the year.

## Weather

- `settings.weatherTable: [{min,max,text,icon}] | null` — null uses a built-in temperate 1d20 table (clear → scattered cloud → overcast → drizzle → rain → fog → wind → thunderstorm → violent storm), each with an emoji.
- Current sky lives on the campaign `time` blob (`weather: {text, icon, rolledAtMinutes} | null`), so players see it too and it survives restarts with no migration (zod defaults on a JSON column).
- **Auto-reroll**: any clock advance that crosses into a new day rerolls and logs `weather` at visibility `all` ("The weather turns: Steady rain"). Both advance paths are covered — `time.advance` and `advanceTravelClock`, so walking past midnight brings a new sky. A campaign with no weather yet also seeds one on its first advance rather than showing a blank top bar until midnight.
- **Multi-day advances roll once per crossed day but keep and log only the final day's weather** (capped at 30 rolls so a year-long advance is not 365 wasted rolls). The intervening days are already history.
- `time.set` deliberately does **not** reroll: it is bookkeeping and can move the clock backwards. `weather.roll` (DM-only) forces a fresh sky any time.

## UI

- Top bar: weather icon + text next to the clock for all roles, tooltip with the full text (additive — a separate `WeatherReadout` next to `TimeControl`, no header restructuring).
- DM clock popover: current weather + "Reroll".
- `weather` kind in `LogTab` `KIND_META` + `FILTERS`.

## Tests

- `packages/shared/src/rules/calendar.test.ts` (new, 12 tests): fallback with no calendar, Harptos month/festival math, festival days belonging to no month, month offsets after passed festivals, year rollover, `startDayOfYear`, a festival-free custom calendar, and an out-of-range festival landing at year's end instead of losing a day.
- `packages/server/src/weather.test.ts` (new, 12 tests): seeding, exactly one reroll per crossed dawn, one-roll-per-day on a multi-day advance (pinned by replaying the seeded RNG), travel across midnight, `time.set` leaving the sky alone, `weather.roll` DM-only, table fallback and custom tables, player visibility through `filterStateForViewer`, persistence through a reload, and calendar-named log lines.
- `pnpm typecheck && pnpm test` green: shared 60, server 134.

## Follow-ups (deliberately not in this PR)

- **Weather effects**: pace multipliers and encounter-threshold nudges. The weather is fiction only this round.
- **Weather table editor**: `settings.weatherTable` is accepted over the wire and persisted, but there is no UI for editing it yet (the built-in table covers the default case).
- Moon phases and DM-scheduled calendar events ("the caravan leaves Elturel on Marpenoth 12") from the issue — the calendar model now gives them a date to fire on.
- `LocationDialog` visit timestamps and `LogTab` session ranges still print "Day N"; routing them through the calendar needs the campaign settings in scope at those call sites.

## Docs notes

- `docs/DESIGN.md` gains a "Clock, calendar & weather" subsection: the clock stays an integer, the calendar is naming over it, weather is one roll per in-game day and fiction only for now.
- `docs/AI-DEVELOPMENT.md` gains a gotcha: the one-way `calendar.ts` → `time.ts` import direction, and that weather rerolls in exactly one place (`logDailyWeather` in `handlers.ts`, called after every clock advance with the pre-advance reading) — a new path that moves the clock must call it too, and `time.set` intentionally does not.
