### PR TITLE
Map manager from the top bar + Link all on campaign defaults

### DIFF
--- a/packages/client/src/components/MapManagerDialog.tsx
+++ b/packages/client/src/components/MapManagerDialog.tsx
@@ -476,6 +476,19 @@ function CampaignDefaults() {
     send({ kind: 'campaign.update', settings: { mapDefaults: p } });
   const linked = (field: InheritableMapField) =>
     maps.filter((m) => m.inheritedFields.includes(field)).length;
+  /** Point every map at the campaign default for one field. */
+  const linkAll = (field: InheritableMapField) => {
+    for (const m of maps) {
+      if (!m.inheritedFields.includes(field)) {
+        send({ kind: 'map.setInherit', mapId: m.id, field, inherit: true });
+      }
+    }
+  };
+  const row = (field: InheritableMapField) => ({
+    count: linked(field),
+    total: maps.length,
+    onLinkAll: () => linkAll(field),
+  });
 
   return (
     <div className="mb-4 rounded-lg border border-brass-500/40 bg-brass-500/5 p-3">
@@ -487,7 +500,7 @@ function CampaignDefaults() {
         {maps.length === 1 ? '' : 's'} total).
       </p>
       <div className="space-y-1">
-        <DefaultRow label="Miles per hex" count={linked('milesPerHex')}>
+        <DefaultRow label="Miles per hex" {...row('milesPerHex')}>
           <Input
             type="number"
             key={`d-mph-${defaults.milesPerHex}`}
@@ -495,7 +508,7 @@ function CampaignDefaults() {
             onBlur={(e) => set({ milesPerHex: Math.max(0, num(e.target.value, defaults.milesPerHex)) })}
           />
         </DefaultRow>
-        <DefaultRow label="Sight radius" count={linked('sightRadius')}>
+        <DefaultRow label="Sight radius" {...row('sightRadius')}>
           <Input
             type="number"
             min={0}
@@ -507,13 +520,13 @@ function CampaignDefaults() {
             }
           />
         </DefaultRow>
-        <DefaultRow label="Fog mode" count={linked('fogMode')}>
+        <DefaultRow label="Fog mode" {...row('fogMode')}>
           <Select value={defaults.fogMode} onChange={(e) => set({ fogMode: e.target.value })}>
             <option value="auto">Auto-reveal</option>
             <option value="manual">Manual only</option>
           </Select>
         </DefaultRow>
-        <DefaultRow label="Fog decay" count={linked('fogDecay')}>
+        <DefaultRow label="Fog decay" {...row('fogDecay')}>
           <CheckLine
             disabled={false}
             checked={defaults.fogDecay}
@@ -521,13 +534,13 @@ function CampaignDefaults() {
             onChange={(v) => set({ fogDecay: v })}
           />
         </DefaultRow>
-        <DefaultRow label="Movement" count={linked('moveMode')}>
+        <DefaultRow label="Movement" {...row('moveMode')}>
           <Select value={defaults.moveMode} onChange={(e) => set({ moveMode: e.target.value })}>
             <option value="free">Free drag</option>
             <option value="step">One hex/step</option>
           </Select>
         </DefaultRow>
-        <DefaultRow label="Move approval" count={linked('moveApproval')}>
+        <DefaultRow label="Move approval" {...row('moveApproval')}>
           <CheckLine
             disabled={false}
             checked={defaults.moveApproval}
@@ -535,7 +548,7 @@ function CampaignDefaults() {
             onChange={(v) => set({ moveApproval: v })}
           />
         </DefaultRow>
-        <DefaultRow label="Encounter check" count={linked('encounterCheck')}>
+        <DefaultRow label="Encounter check" {...row('encounterCheck')}>
           <EncounterFields
             disabled={false}
             value={defaults.encounterCheck}
@@ -550,19 +563,38 @@ function CampaignDefaults() {
 function DefaultRow({
   label,
   count,
+  total,
+  onLinkAll,
   children,
 }: {
   label: string;
   count: number;
+  total: number;
+  onLinkAll: () => void;
   children: React.ReactNode;
 }) {
+  const allLinked = total > 0 && count === total;
   return (
     <div className="flex items-center gap-2 py-1">
       <span className="w-40 shrink-0 text-[11px] uppercase tracking-wider text-ink-400">{label}</span>
       <div className="flex-1 min-w-0">{children}</div>
       <span className="w-16 shrink-0 text-right text-[10px] text-ink-500" title="Maps following this default">
-        🔗 {count}
+        🔗 {count}/{total}
       </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="!px-1.5 !py-0.5 shrink-0 text-[10px] border border-ink-600 disabled:opacity-30"
+        disabled={allLinked}
+        onClick={onLinkAll}
+        title={
+          allLinked
+            ? 'Every map already follows this default'
+            : 'Point every map at this campaign default (overwrites their map-specific values)'
+        }
+      >
+        Link all
+      </Button>
     </div>
   );
 }

--- a/packages/client/src/components/TopBar.tsx
+++ b/packages/client/src/components/TopBar.tsx
@@ -398,22 +398,35 @@ export function TopBar({
   // the map picker moves into the ⋯ menu rather than squeezing the title to
   // two letters. Same element either way — just a different home.
   const mapPicker = state && state.maps.length > 0 && (
-    <Select
-      className="!w-auto max-w-28 md:max-w-44 shrink"
-      value={state.campaign.activeMapId ?? ''}
-      onChange={(e) =>
-        role === 'dm'
-          ? send({ kind: 'map.setActive', mapId: e.target.value })
-          : send({ kind: 'view.map', mapId: e.target.value })
-      }
-      title={role === 'dm' ? 'Active map (the party default)' : 'Browse another map'}
-    >
-      {state.maps.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.name}
-        </option>
-      ))}
-    </Select>
+    <span className="flex items-center gap-0.5 min-w-0">
+      <Select
+        className="!w-auto max-w-28 md:max-w-44 shrink"
+        value={state.campaign.activeMapId ?? ''}
+        onChange={(e) =>
+          role === 'dm'
+            ? send({ kind: 'map.setActive', mapId: e.target.value })
+            : send({ kind: 'view.map', mapId: e.target.value })
+        }
+        title={role === 'dm' ? 'Active map (the party default)' : 'Browse another map'}
+      >
+        {state.maps.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.name}
+          </option>
+        ))}
+      </Select>
+      {role === 'dm' && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="!px-1.5 shrink-0"
+          onClick={() => useUi.getState().set('mapManagerOpen', true)}
+          title="Manage maps — thumbnails, per-map settings, campaign defaults"
+        >
+          🗺️
+        </Button>
+      )}
+    </span>
   );
 
   return (

--- a/packages/client/src/components/panels/MapsTab.tsx
+++ b/packages/client/src/components/panels/MapsTab.tsx
@@ -4,13 +4,13 @@ import { activeMap, useSession } from '../../stores/session.js';
 import { send } from '../../ws.js';
 import { uploadMapImage } from '../../api.js';
 import { Button, EmptyNote, Field, Input, Section, cx } from '../../ui/kit.js';
-import { MapManagerDialog } from '../MapManagerDialog.js';
+import { useUi } from '../../stores/ui.js';
 
 export function MapsTab({ campaignId }: { campaignId: string }) {
   const state = useSession((s) => s.state);
   const map = activeMap(state);
   const [newName, setNewName] = useState('');
-  const [managing, setManaging] = useState(false);
+  const setUi = useUi((s) => s.set);
 
   if (!state) return null;
 
@@ -22,16 +22,13 @@ export function MapsTab({ campaignId }: { campaignId: string }) {
 
   return (
     <div>
-      {managing && (
-        <MapManagerDialog campaignId={campaignId} onClose={() => setManaging(false)} />
-      )}
       <Section
         title="Maps"
         actions={
           <Button
             size="sm"
             variant="ghost"
-            onClick={() => setManaging(true)}
+            onClick={() => setUi('mapManagerOpen', true)}
             title="Thumbnails, per-map settings, and campaign defaults in one place"
           >
             Manage maps

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -36,6 +36,8 @@ interface UiStore {
   editingContentId: string | null;
   /** Content whose full detail dialog (app data + wiki) is open (#66). */
   locationDialogContentId: string | null;
+  /** DM map manager dialog (opened from the top bar or Build → Maps). */
+  mapManagerOpen: boolean;
   /** Which side pop-out panel is open (null = none). */
   openPanel: PanelId | null;
   /** Pop-out panel width in px (drag the left edge to resize). */
@@ -125,6 +127,7 @@ export const useUi = create<UiStore>((set) => ({
   contentDialogHex: null,
   editingContentId: null,
   locationDialogContentId: null,
+  mapManagerOpen: false,
   openPanel: 'information',
   panelWidth: initialPanelWidth(),
   measureStart: null,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -13,6 +13,7 @@ import { PendingMoves } from '../components/PendingMoves.js';
 import { SelectionBar } from '../components/SelectionBar.js';
 import { PinActions } from '../components/PinActions.js';
 import { LocationDialog } from '../components/LocationDialog.js';
+import { MapManagerDialog } from '../components/MapManagerDialog.js';
 
 export function TableView({ campaignId }: { campaignId: string }) {
   const hostRef = useRef<HTMLDivElement>(null);
@@ -22,6 +23,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
   const role = useSession((s) => s.role);
   const contentDialogHex = useUi((s) => s.contentDialogHex);
   const locationDialogContentId = useUi((s) => s.locationDialogContentId);
+  const mapManagerOpen = useUi((s) => s.mapManagerOpen);
 
   useEffect(() => {
     connectWs(campaignId);
@@ -139,6 +141,12 @@ export function TableView({ campaignId }: { campaignId: string }) {
       </div>
       {contentDialogHex && <ContentDialog />}
       {locationDialogContentId && <LocationDialog campaignId={campaignId} />}
+      {mapManagerOpen && role === 'dm' && (
+        <MapManagerDialog
+          campaignId={campaignId}
+          onClose={() => useUi.getState().set('mapManagerOpen', false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #60 per Wes's request: the map manager is now one click from the map dropdown (DM-only 🗺️ button; lives in the ⋯ overflow on mobile), and each campaign-default row has a Link all button that points every map at that default with a n/total linked counter. Verified live in both desktop and mobile layouts (click flips 0/1→1/1 and the button disables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)