### PR TITLE
Hex search: single attempts, DM approval, investigation view

### DIFF
--- a/docs/AI-DEVELOPMENT.md
+++ b/docs/AI-DEVELOPMENT.md
@@ -221,6 +221,23 @@ player-facing data).
   the app cannot hide a wiki section from a player who opens the page in a
   browser, so DM secrets belong in `dmNotes` or on unlinked pages. Page layout
   conventions: `docs/WIKI-TEMPLATE.md`.
+- **Hex search is DM-adjudicated** (#107): a player's `check.roll` against a
+  hex writes a `search_attempt` (unique per map/hex/character/skill — the row
+  IS the once-per-skill limit, and the handler checks it *before* rolling) and
+  turns each beaten clue into a `pending_reveal` instead of a discovery. The
+  DM's `search.resolve` turns approved pendings into discoveries through
+  `runtime.addDiscovery` + `deliverDiscoveries`, so an approved find is
+  indistinguishable from an instant one. DM-initiated hex rolls keep the old
+  instant behaviour and skip the limit; `addDiscovery` consumes any pending
+  for that clue+character, which is how instant reveals dedupe against a
+  queued one. Trails still reveal instantly on a search — follow-up.
+  Two consequences worth remembering: **a log entry's outcome is baked into
+  its `text`**, so a hex search writes *two* entries (a `'dm'` one with the
+  full accounting, an `'all'` one saying only that the DM will describe it) —
+  one row cannot say different things to different readers, and counts of
+  found/not-found are themselves information about the hex. And
+  `pendingReveals` is DM-only in `filterStateForViewer` while
+  `mapState.searchAttempts` is filtered to the viewer's own character.
 - CI (`.github/workflows/ci.yml`) runs typecheck + test on PRs; pnpm is
   pinned there and in the Dockerfile — keep the versions in sync.
 

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -12,6 +12,7 @@ import {
   type Content,
   type ContentPlayerView,
   type FogState,
+  type SearchAttempt,
 } from '@hexcrawl/shared';
 import { activeMap, useSession } from '../../stores/session.js';
 import { useUi } from '../../stores/ui.js';
@@ -186,7 +187,11 @@ export function InspectTab() {
 
       <TrailInfo hex={hex} isDm={isDm} />
 
-      {(isDm || myCharacterId) && <SearchHex mapId={map.id} hex={hex} isDm={isDm} />}
+      {isDm && <InvestigationSection hex={hex} />}
+
+      {(isDm || myCharacterId) && (
+        <SearchHex mapId={map.id} hex={hex} isDm={isDm} characterId={myCharacterId} />
+      )}
 
       {!isDm && !myCharacterId && (
         <p className="text-xs text-ink-400 mt-4">
@@ -312,14 +317,36 @@ function TrailInfo({ hex, isDm }: { hex: { q: number; r: number }; isDm: boolean
  * reveals anything the roll beats — including active-only gates that never
  * open passively.
  */
-function SearchHex({ mapId, hex, isDm }: { mapId: string; hex: { q: number; r: number }; isDm: boolean }) {
+function SearchHex({
+  mapId,
+  hex,
+  isDm,
+  characterId,
+}: {
+  mapId: string;
+  hex: { q: number; r: number };
+  isDm: boolean;
+  characterId: string | null;
+}) {
   const [skill, setSkill] = React.useState('perception');
+  const attempts = useSession((s) => s.state?.mapState?.searchAttempts) ?? EMPTY_ATTEMPTS;
+  // A player gets one roll per skill on a hex (issue #107). The snapshot only
+  // carries their own character's attempts, so this is all they can know.
+  const spent = React.useMemo(() => {
+    if (isDm || !characterId) return new Set<string>();
+    return new Set(
+      attempts
+        .filter((a) => a.q === hex.q && a.r === hex.r && a.characterId === characterId)
+        .map((a) => a.skill),
+    );
+  }, [attempts, hex.q, hex.r, characterId, isDm]);
+  const used = spent.has(skill);
   return (
     <Section title="Search this hex">
       <p className="text-xs text-ink-400 mb-2">
         {isDm
           ? 'Rolls for every character with a token on the map; reveals clues the rolls beat.'
-          : 'Roll a check against this hex — you might notice something others missed.'}
+          : 'Roll a check against this hex — one attempt per skill. The DM describes what you turn up.'}
       </p>
       <div className="flex gap-1.5">
         <select
@@ -328,19 +355,198 @@ function SearchHex({ mapId, hex, isDm }: { mapId: string; hex: { q: number; r: n
           onChange={(e) => setSkill(e.target.value)}
         >
           {CORE_SKILLS.map((s) => (
-            <option key={s} value={s}>
+            <option key={s} value={s} disabled={spent.has(s)}>
               {s}
+              {spent.has(s) ? ' — already tried' : ''}
             </option>
           ))}
         </select>
         <Button
           size="sm"
           variant="primary"
+          disabled={used}
+          title={used ? 'One attempt per skill — ask the DM for another chance' : undefined}
           onClick={() => send({ kind: 'check.roll', skill, dc: null, characterIds: [], mapId, hex })}
         >
           🎲 Roll
         </Button>
       </div>
+      {!isDm && spent.size > 0 && (
+        <p className="text-[11px] text-ink-400 mt-1">
+          One attempt per skill. Already tried here: {[...spent].join(', ')}.
+        </p>
+      )}
+    </Section>
+  );
+}
+
+const EMPTY_ATTEMPTS: SearchAttempt[] = [];
+
+function timeAgo(at: number, now: number): string {
+  const secs = Math.max(0, Math.round((now - at) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+/**
+ * The DM's investigation view for the inspected hex (issue #107): what the
+ * party has already tried here, what their rolls turned up that still needs a
+ * ruling, and what the players have passed on to each other.
+ */
+function InvestigationSection({ hex }: { hex: { q: number; r: number } }) {
+  const state = useSession((s) => s.state);
+  const now = Date.now();
+  if (!state?.mapState) return null;
+  const characters = state.characters;
+  const nameOf = (id: string) => characters.find((c) => c.id === id)?.name ?? 'Unknown';
+
+  const attempts = state.mapState.searchAttempts
+    .filter((a) => a.q === hex.q && a.r === hex.r)
+    .sort((a, b) => b.at - a.at);
+  const attemptById = new Map(state.mapState.searchAttempts.map((a) => [a.id, a]));
+
+  // Pendings are campaign-wide; this hex's are the ones whose attempt is here.
+  const pendings = state.pendingReveals.filter((p) => {
+    const a = attemptById.get(p.attemptId);
+    return a?.q === hex.q && a?.r === hex.r;
+  });
+
+  // Clue text lives on the content, which the DM always has in full.
+  const clueText = new Map<string, string>();
+  for (const c of state.mapState.contents) {
+    if (!isFullContent(c)) continue;
+    for (const clue of c.clues) clueText.set(clue.id, `${c.title} — ${clue.text}`);
+  }
+
+  // Player-to-player sharing on this hex's content (how.kind === 'shared').
+  const hexClueIds = new Set<string>();
+  for (const c of state.mapState.contents) {
+    if (!isFullContent(c) || !contentCoversHex(c, hex)) continue;
+    for (const clue of c.clues) hexClueIds.add(clue.id);
+  }
+  const shared = state.discoveries.filter(
+    (d) => d.how.kind === 'shared' && hexClueIds.has(d.clueId),
+  );
+
+  if (attempts.length === 0 && pendings.length === 0 && shared.length === 0) return null;
+
+  const byCharacter = new Map<string, typeof pendings>();
+  for (const p of pendings) {
+    const list = byCharacter.get(p.characterId) ?? [];
+    list.push(p);
+    byCharacter.set(p.characterId, list);
+  }
+  const resolve = (pendingIds: string[], approve: boolean) => {
+    if (pendingIds.length) send({ kind: 'search.resolve', pendingIds, approve });
+  };
+
+  return (
+    <Section title="Investigation">
+      {pendings.length > 0 && (
+        <div className="mb-3">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs font-medium text-brass-300">
+              Awaiting your call ({pendings.length})
+            </p>
+            <div className="flex gap-1.5">
+              <button
+                className="text-[11px] text-brass-400 hover:text-brass-300 cursor-pointer"
+                onClick={() => resolve(pendings.map((p) => p.id), true)}
+              >
+                Share all
+              </button>
+              <button
+                className="text-[11px] text-ink-400 hover:text-ember-500 cursor-pointer"
+                onClick={() => resolve(pendings.map((p) => p.id), false)}
+              >
+                Withhold all
+              </button>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {[...byCharacter.entries()].map(([characterId, list]) => (
+              <div
+                key={characterId}
+                className="bg-ink-850 border border-brass-500/40 rounded-lg p-2"
+              >
+                <p className="text-xs font-medium text-ink-100">{nameOf(characterId)}</p>
+                <ul className="mt-1 space-y-1.5">
+                  {list.map((p) => {
+                    const attempt = attemptById.get(p.attemptId);
+                    return (
+                      <li
+                        key={p.id}
+                        className="text-xs border-t border-ink-700 pt-1.5 first:border-0 first:pt-0"
+                      >
+                        <p className="text-ink-200">{clueText.get(p.clueId) ?? '(clue removed)'}</p>
+                        <p className="text-ink-400 mt-0.5">
+                          {attempt?.skill ?? 'search'} {p.total} (d20 {p.roll}
+                          {p.modifier >= 0 ? '+' : ''}
+                          {p.modifier})
+                          {p.direction ? ` · bearing ${p.direction}` : ''}
+                          {p.locates ? ' · pins the location' : ''}
+                        </p>
+                        <div className="flex gap-1.5 mt-1">
+                          <Button size="sm" variant="primary" onClick={() => resolve([p.id], true)}>
+                            Share
+                          </Button>
+                          <Button size="sm" onClick={() => resolve([p.id], false)}>
+                            Withhold
+                          </Button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {attempts.length > 0 && (
+        <div className="mb-3">
+          <p className="text-xs font-medium text-ink-300 mb-1">Attempts here</p>
+          <ul className="space-y-1">
+            {attempts.map((a) => (
+              <li key={a.id} className="flex items-center gap-2 text-xs text-ink-200">
+                <span className="truncate">{nameOf(a.characterId)}</span>
+                <span className="text-ink-400 capitalize">{a.skill}</span>
+                <span className="text-ink-100 font-medium">{a.total}</span>
+                <span className="text-ink-400">{timeAgo(a.at, now)}</span>
+                <button
+                  className="ml-auto text-ink-400 hover:text-ember-500 cursor-pointer"
+                  title={`Let ${nameOf(a.characterId)} try ${a.skill} here again`}
+                  onClick={() => send({ kind: 'search.clearAttempt', attemptId: a.id })}
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {shared.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-ink-300 mb-1">Shared with the party</p>
+          <ul className="space-y-1">
+            {shared.map((d) => (
+              <li key={d.id} className="text-xs text-ink-300">
+                {clueText.get(d.clueId) ?? '(clue removed)'}
+                <span className="text-ink-400">
+                  {' '}
+                  — shared by {d.how.kind === 'shared' ? nameOf(d.how.fromCharacterId) : 'someone'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </Section>
   );
 }

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -113,6 +113,13 @@ function handleMessage(msg: ServerMessage): void {
           title: mine ? 'You pick up a trail…' : `${msg.characterName} picks up a trail`,
           text: dirs ? `Signs of passage — ${dirs}.` : 'Signs of passage here.',
         });
+      } else if (msg.kind === 'search.pending') {
+        // DM-only (the server targets it): results are waiting on a ruling.
+        session.pushToast({
+          kind: 'info',
+          title: `🔎 Search — ${msg.characterName}`,
+          text: `${msg.skill} ${msg.total} at ${msg.q},${msg.r} — review in Inspect`,
+        });
       } else if (msg.kind === 'move.requested') {
         session.pushToast({
           kind: 'info',

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -245,6 +245,38 @@ export function migrate(d: DB): void {
     );
     CREATE INDEX IF NOT EXISTS trail_discovery_campaign ON trail_discovery(campaign_id);
     CREATE UNIQUE INDEX IF NOT EXISTS trail_discovery_unique ON trail_discovery(trail_id, cell_index, character_id);
+
+    CREATE TABLE IF NOT EXISTS search_attempt (
+      id TEXT PRIMARY KEY,
+      campaign_id TEXT NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
+      map_id TEXT NOT NULL REFERENCES map(id) ON DELETE CASCADE,
+      q INTEGER NOT NULL,
+      r INTEGER NOT NULL,
+      character_id TEXT NOT NULL,
+      skill TEXT NOT NULL,
+      roll INTEGER NOT NULL,
+      modifier INTEGER NOT NULL,
+      total INTEGER NOT NULL,
+      at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS search_attempt_map ON search_attempt(map_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS search_attempt_unique ON search_attempt(map_id, q, r, character_id, skill);
+
+    CREATE TABLE IF NOT EXISTS pending_reveal (
+      id TEXT PRIMARY KEY,
+      campaign_id TEXT NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
+      clue_id TEXT NOT NULL REFERENCES clue(id) ON DELETE CASCADE,
+      character_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL REFERENCES search_attempt(id) ON DELETE CASCADE,
+      direction TEXT,
+      locates INTEGER NOT NULL DEFAULT 0,
+      roll INTEGER NOT NULL,
+      modifier INTEGER NOT NULL,
+      total INTEGER NOT NULL,
+      at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS pending_reveal_campaign ON pending_reveal(campaign_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS pending_reveal_unique ON pending_reveal(clue_id, character_id);
   `,
   );
   // Additive migrations for columns introduced after first release.

--- a/packages/server/src/db/schema.pg.ts
+++ b/packages/server/src/db/schema.pg.ts
@@ -209,6 +209,38 @@ export const POSTGRES_SCHEMA = `
     );
     CREATE INDEX IF NOT EXISTS trail_discovery_campaign ON trail_discovery(campaign_id);
     CREATE UNIQUE INDEX IF NOT EXISTS trail_discovery_unique ON trail_discovery(trail_id, cell_index, character_id);
+
+    CREATE TABLE IF NOT EXISTS search_attempt (
+      id TEXT PRIMARY KEY,
+      campaign_id TEXT NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
+      map_id TEXT NOT NULL REFERENCES map(id) ON DELETE CASCADE,
+      q BIGINT NOT NULL,
+      r BIGINT NOT NULL,
+      character_id TEXT NOT NULL,
+      skill TEXT NOT NULL,
+      roll BIGINT NOT NULL,
+      modifier BIGINT NOT NULL,
+      total BIGINT NOT NULL,
+      at BIGINT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS search_attempt_map ON search_attempt(map_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS search_attempt_unique ON search_attempt(map_id, q, r, character_id, skill);
+
+    CREATE TABLE IF NOT EXISTS pending_reveal (
+      id TEXT PRIMARY KEY,
+      campaign_id TEXT NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
+      clue_id TEXT NOT NULL REFERENCES clue(id) ON DELETE CASCADE,
+      character_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL REFERENCES search_attempt(id) ON DELETE CASCADE,
+      direction TEXT,
+      locates BIGINT NOT NULL DEFAULT 0,
+      roll BIGINT NOT NULL,
+      modifier BIGINT NOT NULL,
+      total BIGINT NOT NULL,
+      at BIGINT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS pending_reveal_campaign ON pending_reveal(campaign_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS pending_reveal_unique ON pending_reveal(clue_id, character_id);
 `;
 
 /**

--- a/packages/server/src/http/portability.ts
+++ b/packages/server/src/http/portability.ts
@@ -13,8 +13,9 @@
  *   `ensureColumn` migration still imports: missing columns take their SQL
  *   defaults, unknown columns are dropped.
  * - Import remaps every id (campaign, character, map, image layer, token,
- *   marker, content, clue, discovery, trail, trail discovery, encounter table,
- *   log) so an archive can be restored into the instance it came from.
+ *   marker, content, clue, discovery, trail, trail discovery, search attempt,
+ *   pending reveal, encounter table, log) so an archive can be restored into
+ *   the instance it came from.
  * - Secrets are never exported: no dm/player key, no seat auth tokens. Seats
  *   are exported for reference (names/roles) but not restored — the importer
  *   gets a fresh DM seat and fresh invite keys.
@@ -52,6 +53,9 @@ export interface CampaignExport {
   discoveries: Row[];
   trails: Row[];
   trailDiscoveries: Row[];
+  /** Hex-search history and un-adjudicated results (issue #107). */
+  searchAttempts: Row[];
+  pendingReveals: Row[];
   encTables: Row[];
   log: Row[];
   /** image_layer rows, each with the uploaded file inlined as base64. */
@@ -124,6 +128,12 @@ function collectExport(db: DB, campaignId: string): Omit<CampaignExport, 'images
     trails: childRows(db, 'trail', 'map_id', mapIds),
     trailDiscoveries: db
       .prepare('SELECT * FROM trail_discovery WHERE campaign_id = ?')
+      .all(campaignId) as Row[],
+    searchAttempts: db
+      .prepare('SELECT * FROM search_attempt WHERE campaign_id = ?')
+      .all(campaignId) as Row[],
+    pendingReveals: db
+      .prepare('SELECT * FROM pending_reveal WHERE campaign_id = ?')
       .all(campaignId) as Row[],
     encTables: db.prepare('SELECT * FROM enc_table WHERE campaign_id = ?').all(campaignId) as Row[],
     log: db
@@ -221,6 +231,9 @@ export const CampaignImportSchema = z.object({
   discoveries: RowsSchema,
   trails: RowsSchema,
   trailDiscoveries: RowsSchema,
+  // Absent in archives exported before hex-search approval (issue #107).
+  searchAttempts: RowsSchema.default([]),
+  pendingReveals: RowsSchema.default([]),
   encTables: RowsSchema,
   log: RowsSchema,
   images: RowsSchema,
@@ -316,6 +329,8 @@ export function importCampaign(
   const imageMap = remapIds(data.images);
   const discoveryMap = remapIds(data.discoveries);
   const trailDiscMap = remapIds(data.trailDiscoveries);
+  const attemptMap = remapIds(data.searchAttempts, 12);
+  const pendingMap = remapIds(data.pendingReveals, 12);
   const logMap = remapIds(data.log, 12);
 
   const name = (opts.name ?? str(data.campaign.name) ?? 'Restored campaign').slice(0, 120);
@@ -476,6 +491,38 @@ export function importCampaign(
         const charId = charMap.get(str(row.character_id) ?? '');
         return id && trailId && charId
           ? { ...row, id, campaign_id: campaignId, trail_id: trailId, character_id: charId }
+          : null;
+      }),
+    );
+    counts.search_attempt = insertRows(
+      db,
+      'search_attempt',
+      keep(data.searchAttempts, (row) => {
+        const id = attemptMap.get(str(row.id) ?? '');
+        const mapId = mapMap.get(str(row.map_id) ?? '');
+        const charId = charMap.get(str(row.character_id) ?? '');
+        return id && mapId && charId
+          ? { ...row, id, campaign_id: campaignId, map_id: mapId, character_id: charId }
+          : null;
+      }),
+    );
+    counts.pending_reveal = insertRows(
+      db,
+      'pending_reveal',
+      keep(data.pendingReveals, (row) => {
+        const id = pendingMap.get(str(row.id) ?? '');
+        const clueId = clueMap.get(str(row.clue_id) ?? '');
+        const charId = charMap.get(str(row.character_id) ?? '');
+        const attemptId = attemptMap.get(str(row.attempt_id) ?? '');
+        return id && clueId && charId && attemptId
+          ? {
+              ...row,
+              id,
+              campaign_id: campaignId,
+              clue_id: clueId,
+              character_id: charId,
+              attempt_id: attemptId,
+            }
           : null;
       }),
     );

--- a/packages/server/src/regions.test.ts
+++ b/packages/server/src/regions.test.ts
@@ -262,6 +262,9 @@ describe('region footprints: knowledge', () => {
       mapId,
       hex: { q: 6, r: 0 },
     } as never);
+    // The DM's call gates the reveal now (issue #107).
+    expect(runtime.pendingReveals.size).toBe(1);
+    dm({ kind: 'search.resolve', pendingIds: [...runtime.pendingReveals.keys()], approve: true } as never);
     expect(runtime.discoveries.size).toBe(1);
     const discovery = [...runtime.discoveries.values()][0]!;
     expect(discovery.clueId).toBe(content.clues[0]!.id);

--- a/packages/server/src/search-approval.test.ts
+++ b/packages/server/src/search-approval.test.ts
@@ -1,0 +1,463 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { filterStateForViewer, seededRng } from '@hexcrawl/shared';
+import type { CampaignState, ClientCommand } from '@hexcrawl/shared';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { CampaignRuntime, type SeatRecord } from './state/runtime.js';
+import { Hub } from './ws/hub.js';
+import { dispatchCommand } from './ws/handlers.js';
+import { exportCampaign, importCampaign } from './http/portability.js';
+
+/**
+ * Hex search: one roll per skill per hex per character, and the DM's call on
+ * what a successful roll actually reveals (issue #107).
+ *
+ * The two invariants worth defending here are (a) a player cannot spend the
+ * same skill on the same hex twice, and (b) nothing a player's roll turned up
+ * reaches them — not the clue, not even the *number* of clues — until the DM
+ * shares it.
+ */
+
+let store: Store;
+let runtime: CampaignRuntime;
+let dmSeat: SeatRecord;
+let hub: Hub;
+let cmdCounter = 0;
+
+function dm(cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `s${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat: dmSeat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+function asSeat(seat: SeatRecord, cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `s${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+beforeEach(() => {
+  store = new Store(createTestDb());
+  const created = store.createCampaign('Search', 'The DM');
+  runtime = created.runtime;
+  dmSeat = created.dmSeat;
+  hub = new Hub();
+  cmdCounter = 0;
+});
+
+interface Party {
+  mapId: string;
+  charId: string;
+  tokenId: string;
+  seat: SeatRecord;
+}
+
+/** A scout (perception +4 / survival +2) with a token at the origin. */
+function party(name = 'Scout', q = 0, r = 0): Party {
+  const mapId = runtime.campaign.activeMapId!;
+  dm({
+    kind: 'character.create',
+    character: {
+      name,
+      color: '#00aa00',
+      glyph: '🏹',
+      speed: 30,
+      skills: { perception: 4, survival: 2 },
+      extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' },
+    },
+  } as never);
+  const charId = [...runtime.characters.values()].find((c) => c.name === name)!.id;
+  const seat = runtime.createSeat('player', `${name}'s player`);
+  asSeat(seat, { kind: 'seat.claimCharacter', characterId: charId } as never);
+  seat.characterId = runtime.seats.get(seat.id)!.characterId;
+  dm({
+    kind: 'token.create',
+    mapId,
+    q,
+    r,
+    tokenKind: 'pc',
+    characterId: charId,
+    label: name,
+    color: '#00aa00',
+    glyph: '',
+    playerVisible: true,
+  } as never);
+  const tokenId = [...runtime.requireMap(mapId).tokens.values()].find(
+    (t) => t.characterId === charId,
+  )!.id;
+  return { mapId, charId, tokenId, seat };
+}
+
+/** Content on `hex` whose single clue only an active search can open. */
+function searchable(
+  mapId: string,
+  hex: { q: number; r: number },
+  title: string,
+  clue: Record<string, unknown> = {},
+): { contentId: string; clueId: string } {
+  dm({
+    kind: 'content.upsert',
+    content: {
+      id: null,
+      mapId,
+      q: hex.q,
+      r: hex.r,
+      type: 'cache',
+      title,
+      dmNotes: '',
+      glyph: '',
+      clues: [
+        {
+          id: null,
+          text: `${title}: a scuffed flagstone`,
+          gate: { kind: 'skill', skill: 'survival', dc: 2, maxDistance: 2, mode: 'active' },
+          sortOrder: 0,
+          ...clue,
+        },
+      ],
+    },
+  } as never);
+  const content = [...runtime.requireMap(mapId).contents.values()].find((c) => c.title === title)!;
+  return { contentId: content.id, clueId: content.clues[0]!.id };
+}
+
+function viewFor(seat: SeatRecord): CampaignState {
+  return filterStateForViewer(runtime.buildFullState(), {
+    seatId: seat.id,
+    role: seat.role,
+    characterId: seat.characterId,
+  });
+}
+
+function search(seat: SeatRecord, mapId: string, hex: { q: number; r: number }, skill: string) {
+  asSeat(seat, { kind: 'check.roll', skill, dc: null, characterIds: [], mapId, hex } as never);
+}
+
+describe('one attempt per skill per hex per character', () => {
+  it('rejects a second roll of the same skill on the same hex, before rolling', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const attempts = [...runtime.requireMap(mapId).searchAttempts.values()];
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]!.skill).toBe('survival');
+
+    expect(() => search(seat, mapId, { q: 0, r: 0 }, 'survival')).toThrow(
+      /Scout already searched this hex with survival/,
+    );
+    // Rejected before the dice: still exactly one attempt on record.
+    expect(runtime.requireMap(mapId).searchAttempts.size).toBe(1);
+  });
+
+  it('scopes the limit to the skill, the hex and the character', () => {
+    const { mapId, seat } = party();
+    const other = party('Bard', 1, 0);
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    // A different skill, a different hex and a different character all pass.
+    search(seat, mapId, { q: 0, r: 0 }, 'perception');
+    search(seat, mapId, { q: 1, r: 0 }, 'survival');
+    search(other.seat, mapId, { q: 0, r: 0 }, 'survival');
+    expect(runtime.requireMap(mapId).searchAttempts.size).toBe(4);
+  });
+
+  it('does not limit the DM, but still records the attempt', () => {
+    const { mapId, charId } = party();
+    dm({
+      kind: 'check.roll',
+      skill: 'survival',
+      dc: null,
+      characterIds: [charId],
+      mapId,
+      hex: { q: 0, r: 0 },
+    } as never);
+    dm({
+      kind: 'check.roll',
+      skill: 'survival',
+      dc: null,
+      characterIds: [charId],
+      mapId,
+      hex: { q: 0, r: 0 },
+    } as never);
+    // The unique tuple means the re-roll updates the row rather than adding one.
+    expect(runtime.requireMap(mapId).searchAttempts.size).toBe(1);
+  });
+});
+
+describe('pending reveals', () => {
+  it("a player's successful search queues the clue instead of revealing it", () => {
+    const { mapId, charId, seat } = party();
+    const { clueId } = searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+
+    expect(runtime.discoveries.size).toBe(0);
+    expect(runtime.pendingReveals.size).toBe(1);
+    const pending = [...runtime.pendingReveals.values()][0]!;
+    expect(pending.clueId).toBe(clueId);
+    expect(pending.characterId).toBe(charId);
+    // Searched from on top of the content: the find pins the location.
+    expect(pending.locates).toBe(true);
+    expect(runtime.getSearchAttempt(pending.attemptId)?.skill).toBe('survival');
+    // The player learns nothing of it.
+    expect(viewFor(seat).mapState!.contents).toHaveLength(0);
+  });
+
+  it('freezes the bearing at roll time for a directional clue found from afar', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 2, r: 0 }, 'Distant cache', { indicatesDirection: true });
+    search(seat, mapId, { q: 2, r: 0 }, 'survival');
+    const pending = [...runtime.pendingReveals.values()][0]!;
+    expect(pending.direction).not.toBeNull();
+    // Two hexes away — knowing about it doesn't pin it on the map.
+    expect(pending.locates).toBe(false);
+  });
+
+  it('a DM-initiated hex roll reveals instantly and queues nothing', () => {
+    const { mapId, charId } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    dm({
+      kind: 'check.roll',
+      skill: 'survival',
+      dc: null,
+      characterIds: [charId],
+      mapId,
+      hex: { q: 0, r: 0 },
+    } as never);
+    expect(runtime.pendingReveals.size).toBe(0);
+    expect(runtime.discoveries.size).toBe(1);
+  });
+
+  it('an instant reveal consumes a row already pending for that clue', () => {
+    const { mapId, charId, seat } = party();
+    const { clueId } = searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    expect(runtime.pendingReveals.size).toBe(1);
+
+    dm({ kind: 'clue.reveal', clueId, characterIds: [charId] } as never);
+    expect(runtime.discoveries.size).toBe(1);
+    expect(runtime.pendingReveals.size).toBe(0);
+  });
+});
+
+describe('search.resolve', () => {
+  it('approving creates the discovery with the roll that earned it', () => {
+    const { mapId, charId, seat } = party();
+    const { clueId } = searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const pending = [...runtime.pendingReveals.values()][0]!;
+
+    dm({ kind: 'search.resolve', pendingIds: [pending.id], approve: true } as never);
+
+    expect(runtime.pendingReveals.size).toBe(0);
+    const disc = [...runtime.discoveries.values()][0]!;
+    expect(disc.clueId).toBe(clueId);
+    expect(disc.characterId).toBe(charId);
+    expect(disc.locates).toBe(pending.locates);
+    expect(disc.direction).toBe(pending.direction);
+    expect(disc.how).toEqual({
+      kind: 'roll',
+      skill: 'survival',
+      roll: pending.roll,
+      modifier: pending.modifier,
+      total: pending.total,
+      dc: 2,
+    });
+    // It reaches the player through the normal delivery path.
+    const view = viewFor(seat);
+    expect(view.mapState!.contents.map((c) => c.title)).toEqual(['Cache']);
+    expect(view.log.some((e) => e.text.includes('scuffed flagstone'))).toBe(true);
+  });
+
+  it('denying drops the rows, tells nobody but the DM, and reveals nothing', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const pending = [...runtime.pendingReveals.values()][0]!;
+
+    dm({ kind: 'search.resolve', pendingIds: [pending.id], approve: false } as never);
+
+    expect(runtime.pendingReveals.size).toBe(0);
+    expect(runtime.discoveries.size).toBe(0);
+    const withheld = runtime.log.find((e) => e.text.startsWith('Withheld'));
+    expect(withheld?.text).toBe('Withheld 1 result(s) at hex 0,0');
+    expect(withheld?.visibility).toBe('dm');
+    expect(viewFor(seat).log.some((e) => e.text.includes('Withheld'))).toBe(false);
+    // The attempt stays spent: denial is a ruling, not a do-over.
+    expect(runtime.requireMap(mapId).searchAttempts.size).toBe(1);
+  });
+
+  it('shares some and withholds others from the same roll', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache A');
+    searchable(mapId, { q: 0, r: 0 }, 'Cache B');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    expect(runtime.pendingReveals.size).toBe(2);
+    const [first, second] = [...runtime.pendingReveals.values()];
+
+    dm({ kind: 'search.resolve', pendingIds: [first!.id], approve: true } as never);
+    dm({ kind: 'search.resolve', pendingIds: [second!.id], approve: false } as never);
+
+    expect(runtime.discoveries.size).toBe(1);
+    expect(runtime.pendingReveals.size).toBe(0);
+    expect(viewFor(seat).mapState!.contents).toHaveLength(1);
+  });
+
+  it('is DM-only', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const pending = [...runtime.pendingReveals.values()][0]!;
+    expect(() =>
+      asSeat(seat, { kind: 'search.resolve', pendingIds: [pending.id], approve: true } as never),
+    ).toThrow(/DM/);
+    expect(() =>
+      asSeat(seat, { kind: 'search.clearAttempt', attemptId: pending.attemptId } as never),
+    ).toThrow(/DM/);
+  });
+});
+
+describe('search.clearAttempt', () => {
+  it('lets the character roll that skill here again and drops its pendings', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const attemptId = [...runtime.requireMap(mapId).searchAttempts.keys()][0]!;
+    expect(runtime.pendingReveals.size).toBe(1);
+
+    dm({ kind: 'search.clearAttempt', attemptId } as never);
+    expect(runtime.requireMap(mapId).searchAttempts.size).toBe(0);
+    expect(runtime.pendingReveals.size).toBe(0);
+
+    // The retry rolls afresh and queues the clue again.
+    expect(() => search(seat, mapId, { q: 0, r: 0 }, 'survival')).not.toThrow();
+    expect(runtime.pendingReveals.size).toBe(1);
+  });
+
+  it('rejects an attempt id that is already gone', () => {
+    party();
+    expect(() => dm({ kind: 'search.clearAttempt', attemptId: 'nope' } as never)).toThrow(
+      /already gone/,
+    );
+  });
+});
+
+describe('what the roll tells each side', () => {
+  it("the player's log entry names no outcome; the DM's carries the accounting", () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+
+    const playerLog = viewFor(seat).log.filter((e) => e.kind === 'check');
+    expect(playerLog).toHaveLength(1);
+    expect(playerLog[0]!.text).toContain('the DM will describe what you find');
+    expect(playerLog[0]!.text).not.toMatch(/clue\(s\)|nothing|awaiting/);
+
+    const dmLog = runtime.log.filter((e) => e.kind === 'check' && e.visibility === 'dm');
+    expect(dmLog).toHaveLength(1);
+    expect(dmLog[0]!.text).toContain('1 awaiting your approval');
+    expect(dmLog[0]!.data.pending).toBe(1);
+  });
+
+  it('a fruitless search reads identically to a fruitful one for the player', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache', {
+      gate: { kind: 'skill', skill: 'survival', dc: 39, maxDistance: 2, mode: 'active' },
+    });
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    expect(runtime.pendingReveals.size).toBe(0);
+    const playerLog = viewFor(seat).log.filter((e) => e.kind === 'check');
+    expect(playerLog[0]!.text).toContain('the DM will describe what you find');
+    expect(playerLog[0]!.text).not.toContain('nothing');
+  });
+
+  it('a non-hex check keeps its plain summary', () => {
+    const { mapId, seat } = party();
+    void mapId;
+    asSeat(seat, {
+      kind: 'check.roll',
+      skill: 'survival',
+      dc: 10,
+      characterIds: [],
+      mapId: null,
+      hex: null,
+    } as never);
+    const playerLog = viewFor(seat).log.filter((e) => e.kind === 'check');
+    expect(playerLog).toHaveLength(1);
+    expect(playerLog[0]!.text).not.toContain('the DM will describe');
+  });
+});
+
+describe('filterStateForViewer (issue #107)', () => {
+  it('gives a player their own attempts only, and never a pending reveal', () => {
+    const { mapId, seat } = party();
+    const other = party('Bard', 1, 0);
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    search(other.seat, mapId, { q: 0, r: 0 }, 'perception');
+
+    const mine = viewFor(seat);
+    expect(mine.mapState!.searchAttempts).toHaveLength(1);
+    expect(mine.mapState!.searchAttempts[0]!.characterId).toBe(seat.characterId);
+    expect(mine.pendingReveals).toEqual([]);
+
+    const theirs = viewFor(other.seat);
+    expect(theirs.mapState!.searchAttempts.map((a) => a.skill)).toEqual(['perception']);
+    expect(theirs.pendingReveals).toEqual([]);
+
+    // The DM sees the lot.
+    const dmView = viewFor(dmSeat);
+    expect(dmView.mapState!.searchAttempts).toHaveLength(2);
+    expect(dmView.pendingReveals).toHaveLength(1);
+  });
+
+  it('gives an unclaimed player seat no attempts at all', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const bare = runtime.createSeat('player', 'Lurker');
+    expect(viewFor(bare).mapState!.searchAttempts).toEqual([]);
+  });
+});
+
+describe('portability', () => {
+  it('carries attempts and pending reveals through an export/import roundtrip', () => {
+    const { mapId, seat } = party();
+    searchable(mapId, { q: 0, r: 0 }, 'Cache');
+    search(seat, mapId, { q: 0, r: 0 }, 'survival');
+    const attempt = [...runtime.requireMap(mapId).searchAttempts.values()][0]!;
+    const pending = [...runtime.pendingReveals.values()][0]!;
+
+    const uploads = fs.mkdtempSync(path.join(os.tmpdir(), 'hexcrawl-search-'));
+    const archive = exportCampaign(store.db, runtime.id, uploads);
+    expect(archive.searchAttempts).toHaveLength(1);
+    expect(archive.pendingReveals).toHaveLength(1);
+
+    const result = importCampaign(store.db, archive, { uploadsDir: uploads });
+    expect(result.counts.search_attempt).toBe(1);
+    expect(result.counts.pending_reveal).toBe(1);
+
+    const restored = store.getCampaign(result.campaignId)!;
+    const restoredMap = [...restored.mapStates.values()].find((m) => m.searchAttempts.size > 0)!;
+    const restoredAttempt = [...restoredMap.searchAttempts.values()][0]!;
+    expect(restoredAttempt.id).not.toBe(attempt.id);
+    expect(restoredAttempt.skill).toBe('survival');
+    expect(restoredAttempt.total).toBe(attempt.total);
+    expect(restoredAttempt.characterId).not.toBe(attempt.characterId);
+
+    const restoredPending = [...restored.pendingReveals.values()][0]!;
+    expect(restoredPending.attemptId).toBe(restoredAttempt.id);
+    expect(restoredPending.characterId).toBe(restoredAttempt.characterId);
+    expect(restoredPending.clueId).not.toBe(pending.clueId);
+    expect(restoredPending.locates).toBe(pending.locates);
+    // The restored pending still points at a live clue.
+    expect(restored.findContentByClue(restoredPending.clueId)?.title).toBe('Cache');
+  });
+});

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -593,14 +593,21 @@ describe('hex-targeted skill checks', () => {
     // Active gates never open passively.
     expect(runtime.discoveries.size).toBe(0);
 
+    // A player's success is a proposal now (issue #107): nothing is revealed
+    // until the DM shares it.
     asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 1, r: 0 } } as never);
+    expect(runtime.discoveries.size).toBe(0);
+    expect(runtime.pendingReveals.size).toBe(1);
+    dm({ kind: 'search.resolve', pendingIds: [...runtime.pendingReveals.keys()], approve: true } as never);
     expect(runtime.discoveries.size).toBe(1);
     const disc = [...runtime.discoveries.values()][0]!;
     expect(disc.how.kind).toBe('roll');
     expect(disc.locates).toBe(false); // searched from one hex away
 
-    // Re-rolling doesn't duplicate the discovery.
-    asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 1, r: 0 } } as never);
+    // One attempt per skill per hex: the same skill is spent here.
+    expect(() =>
+      asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 1, r: 0 } } as never),
+    ).toThrow(/already searched/);
     expect(runtime.discoveries.size).toBe(1);
   });
 });
@@ -718,8 +725,10 @@ describe('skill-gated items (issue #41)', () => {
     asSeat(playerSeat, { kind: 'token.move', tokenId, q: 3, r: 0 } as never);
     expect(playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave')).toBeUndefined();
 
-    // A Survival search on the hex finds the cave and reveals the item.
+    // A Survival search on the hex finds the cave — once the DM shares it.
     asSeat(playerSeat, { kind: 'check.roll', skill: 'survival', dc: null, characterIds: [], mapId, hex: { q: 3, r: 0 } } as never);
+    expect(playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave')).toBeUndefined();
+    dm({ kind: 'search.resolve', pendingIds: [...runtime.pendingReveals.keys()], approve: true } as never);
     const cave = playerView().mapState!.contents.find((c) => c.title === 'Goblin Cave');
     expect(cave).toBeDefined();
   });

--- a/packages/server/src/state/runtime.ts
+++ b/packages/server/src/state/runtime.ts
@@ -21,6 +21,8 @@ import type {
   MapInfo,
   MapState,
   Marker,
+  PendingReveal,
+  SearchAttempt,
   SeatPublic,
   SeatRole,
   TerrainId,
@@ -73,6 +75,8 @@ export interface MapRuntime {
   trails: Map<string, Trail>;
   /** Party visit accounting per hex, keyed by hexKey. */
   visits: Map<string, HexVisit>;
+  /** Search rolls made on this map (issue #107), keyed by attempt id. */
+  searchAttempts: Map<string, SearchAttempt>;
 }
 
 const LOG_MEMORY_LIMIT = 500;
@@ -118,6 +122,8 @@ export class CampaignRuntime {
   discoveredByClueChar = new Set<string>();
   trailDiscoveries = new Map<string, TrailDiscovery>();
   private trailDiscoveryKeys = new Set<string>();
+  /** Search results awaiting the DM's share/withhold call (issue #107). */
+  pendingReveals = new Map<string, PendingReveal>();
   encounterTables = new Map<string, EncounterTable>();
   log: LogEntry[] = [];
   /** Seat ids currently connected (managed by the hub). */
@@ -260,6 +266,22 @@ export class CampaignRuntime {
       this.trailDiscoveries.set(disc.id, disc);
       this.trailDiscoveryKeys.add(`${disc.trailId}|${disc.cellIndex}|${disc.characterId}`);
     }
+    for (const pr of d
+      .prepare('SELECT * FROM pending_reveal WHERE campaign_id = ?')
+      .all(this.id) as Array<Record<string, unknown>>) {
+      this.pendingReveals.set(pr.id as string, {
+        id: pr.id as string,
+        clueId: pr.clue_id as string,
+        characterId: pr.character_id as string,
+        attemptId: pr.attempt_id as string,
+        direction: (pr.direction as string | null) ?? null,
+        locates: Boolean(pr.locates),
+        roll: pr.roll as number,
+        modifier: pr.modifier as number,
+        total: pr.total as number,
+        at: pr.at as number,
+      });
+    }
     this.log = (
       d
         .prepare('SELECT * FROM log WHERE campaign_id = ? ORDER BY at DESC, id DESC LIMIT ?')
@@ -290,7 +312,13 @@ export class CampaignRuntime {
       pendingMoves: new Map(),
       trails: new Map(),
       visits: new Map(),
+      searchAttempts: new Map(),
     };
+    for (const a of d.prepare('SELECT * FROM search_attempt WHERE map_id = ?').all(mapId) as Array<
+      Record<string, unknown>
+    >) {
+      rt.searchAttempts.set(a.id as string, searchAttemptFromRow(mapId, a));
+    }
     for (const l of d
       .prepare('SELECT * FROM image_layer WHERE map_id = ? ORDER BY z')
       .all(mapId) as Array<Record<string, unknown>>) {
@@ -431,6 +459,7 @@ export class CampaignRuntime {
       trails: [...rt.trails.values()],
       trailSigns: [],
       visits: [...rt.visits.values()],
+      searchAttempts: [...rt.searchAttempts.values()],
     };
   }
 
@@ -457,6 +486,7 @@ export class CampaignRuntime {
       discoveries: [...this.discoveries.values()],
       trailDiscoveries: [...this.trailDiscoveries.values()],
       senses: [],
+      pendingReveals: [...this.pendingReveals.values()],
       encounterTables: [...this.encounterTables.values()],
       log: this.log,
     };
@@ -724,6 +754,7 @@ export class CampaignRuntime {
       pendingMoves: new Map(),
       trails: new Map(),
       visits: new Map(),
+      searchAttempts: new Map(),
     });
     this.db
       .prepare(
@@ -854,6 +885,14 @@ export class CampaignRuntime {
   }
 
   deleteMap(mapId: string): void {
+    // Pendings hang off attempts, which hang off the map: mirror the SQL
+    // cascade in memory before the map runtime (and its attempts) goes.
+    const attempts = this.mapStates.get(mapId)?.searchAttempts;
+    if (attempts) {
+      for (const [id, p] of this.pendingReveals) {
+        if (attempts.has(p.attemptId)) this.pendingReveals.delete(id);
+      }
+    }
     this.maps.delete(mapId);
     this.mapStates.delete(mapId);
     this.db.prepare('DELETE FROM map WHERE id = ?').run(mapId);
@@ -1149,8 +1188,10 @@ export class CampaignRuntime {
     // Deleted clues cascade their discoveries in SQL; mirror in memory.
     if (existing) {
       const keep = new Set(content.clues.map((c) => c.id));
+      const dropped = new Set<string>();
       for (const old of existing.clues) {
         if (!keep.has(old.id)) {
+          dropped.add(old.id);
           for (const [id, disc] of this.discoveries) {
             if (disc.clueId === old.id) {
               this.discoveries.delete(id);
@@ -1159,6 +1200,7 @@ export class CampaignRuntime {
           }
         }
       }
+      this.dropPendingRevealsForClues(dropped);
     }
   }
 
@@ -1174,6 +1216,7 @@ export class CampaignRuntime {
             this.discoveredByClueChar.delete(`${disc.clueId}|${disc.characterId}`);
           }
         }
+        this.dropPendingRevealsForClues(new Set(c.clues.map((cl) => cl.id)));
         return c;
       }
     }
@@ -1195,6 +1238,10 @@ export class CampaignRuntime {
 
   addDiscovery(discovery: Discovery): boolean {
     if (this.hasDiscovery(discovery.clueId, discovery.characterId)) return false;
+    // Knowing it settles the question: an instant reveal (DM roll, reveal
+    // pill, share) consumes anything queued for the DM's call on that clue.
+    const queued = this.findPendingReveal(discovery.clueId, discovery.characterId);
+    if (queued) this.deletePendingReveal(queued.id);
     this.discoveries.set(discovery.id, discovery);
     this.discoveredByClueChar.add(`${discovery.clueId}|${discovery.characterId}`);
     this.db
@@ -1212,6 +1259,146 @@ export class CampaignRuntime {
         discovery.locates ? 1 : 0,
       );
     return true;
+  }
+
+  // -- hex searches (issue #107) ---------------------------------------------
+
+  /** The attempt this character has already spent on (hex, skill), if any. */
+  findSearchAttempt(
+    mapId: string,
+    q: number,
+    r: number,
+    characterId: string,
+    skill: string,
+  ): SearchAttempt | null {
+    const rt = this.mapStates.get(mapId);
+    if (!rt) return null;
+    for (const a of rt.searchAttempts.values()) {
+      if (a.q === q && a.r === r && a.characterId === characterId && a.skill === skill) return a;
+    }
+    return null;
+  }
+
+  getSearchAttempt(attemptId: string): SearchAttempt | null {
+    for (const rt of this.mapStates.values()) {
+      const a = rt.searchAttempts.get(attemptId);
+      if (a) return a;
+    }
+    return null;
+  }
+
+  /**
+   * Write down a search roll. The (map, hex, character, skill) tuple is
+   * unique, so a DM group re-roll updates the existing attempt in place
+   * rather than inserting a second one — keeping the id stable is what lets
+   * pending reveals keep pointing at it.
+   */
+  recordSearchAttempt(attempt: SearchAttempt): SearchAttempt {
+    const rt = this.requireMap(attempt.mapId);
+    const existing = this.findSearchAttempt(
+      attempt.mapId,
+      attempt.q,
+      attempt.r,
+      attempt.characterId,
+      attempt.skill,
+    );
+    if (existing) {
+      const next: SearchAttempt = {
+        ...existing,
+        roll: attempt.roll,
+        modifier: attempt.modifier,
+        total: attempt.total,
+        at: attempt.at,
+      };
+      rt.searchAttempts.set(next.id, next);
+      this.db
+        .prepare('UPDATE search_attempt SET roll = ?, modifier = ?, total = ?, at = ? WHERE id = ?')
+        .run(next.roll, next.modifier, next.total, next.at, next.id);
+      return next;
+    }
+    rt.searchAttempts.set(attempt.id, attempt);
+    this.db
+      .prepare(
+        'INSERT INTO search_attempt (id, campaign_id, map_id, q, r, character_id, skill, roll, modifier, total, at) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      )
+      .run(
+        attempt.id,
+        this.id,
+        attempt.mapId,
+        attempt.q,
+        attempt.r,
+        attempt.characterId,
+        attempt.skill,
+        attempt.roll,
+        attempt.modifier,
+        attempt.total,
+        attempt.at,
+      );
+    return attempt;
+  }
+
+  /**
+   * Clear one attempt (the DM letting a character try again). Anything still
+   * pending from that roll goes with it — SQL cascades on `attempt_id`;
+   * memory is mirrored here.
+   */
+  deleteSearchAttempt(attemptId: string): SearchAttempt | null {
+    const attempt = this.getSearchAttempt(attemptId);
+    if (!attempt) return null;
+    this.mapStates.get(attempt.mapId)?.searchAttempts.delete(attemptId);
+    for (const [id, p] of this.pendingReveals) {
+      if (p.attemptId === attemptId) this.pendingReveals.delete(id);
+    }
+    this.db.prepare('DELETE FROM pending_reveal WHERE attempt_id = ?').run(attemptId);
+    this.db.prepare('DELETE FROM search_attempt WHERE id = ?').run(attemptId);
+    return attempt;
+  }
+
+  findPendingReveal(clueId: string, characterId: string): PendingReveal | null {
+    for (const p of this.pendingReveals.values()) {
+      if (p.clueId === clueId && p.characterId === characterId) return p;
+    }
+    return null;
+  }
+
+  /** Queue a clue for the DM's call. False when it is already known or queued. */
+  addPendingReveal(pending: PendingReveal): boolean {
+    if (this.hasDiscovery(pending.clueId, pending.characterId)) return false;
+    if (this.findPendingReveal(pending.clueId, pending.characterId)) return false;
+    this.pendingReveals.set(pending.id, pending);
+    this.db
+      .prepare(
+        'INSERT INTO pending_reveal (id, campaign_id, clue_id, character_id, attempt_id, direction, locates, roll, modifier, total, at) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+      )
+      .run(
+        pending.id,
+        this.id,
+        pending.clueId,
+        pending.characterId,
+        pending.attemptId,
+        pending.direction,
+        pending.locates ? 1 : 0,
+        pending.roll,
+        pending.modifier,
+        pending.total,
+        pending.at,
+      );
+    return true;
+  }
+
+  deletePendingReveal(pendingId: string): PendingReveal | null {
+    const pending = this.pendingReveals.get(pendingId);
+    if (!pending) return null;
+    this.pendingReveals.delete(pendingId);
+    this.db.prepare('DELETE FROM pending_reveal WHERE id = ?').run(pendingId);
+    return pending;
+  }
+
+  /** Drop every pending row for these clues (clue/content deletion). */
+  private dropPendingRevealsForClues(clueIds: Set<string>): void {
+    for (const [id, p] of this.pendingReveals) {
+      if (clueIds.has(p.clueId)) this.deletePendingReveal(id);
+    }
   }
 
   /** Upgrade an at-a-distance discovery: the character reached the source. */
@@ -1354,6 +1541,21 @@ function imageLayerFromRow(mapId: string, row: Record<string, unknown>): ImageLa
     z: row.z as number,
     dmOnly: Boolean(row.dm_only),
     visible: Boolean(row.visible),
+  };
+}
+
+function searchAttemptFromRow(mapId: string, row: Record<string, unknown>): SearchAttempt {
+  return {
+    id: row.id as string,
+    mapId,
+    q: row.q as number,
+    r: row.r as number,
+    characterId: row.character_id as string,
+    skill: row.skill as string,
+    roll: row.roll as number,
+    modifier: row.modifier as number,
+    total: row.total as number,
+    at: row.at as number,
   };
 }
 

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -776,6 +776,26 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
             .map((t) => t.characterId!)
         : [];
     }
+    // One attempt per skill per hex per character (issue #107) — checked
+    // BEFORE the dice come out, so a rejected search costs nothing. The DM is
+    // exempt: they re-run group checks, and their rolls reveal instantly
+    // anyway.
+    const dmRoll = ctx.seat.role === 'dm';
+    if (cmd.hex && cmd.mapId && !dmRoll) {
+      for (const characterId of targets) {
+        const prior = ctx.runtime.findSearchAttempt(
+          cmd.mapId,
+          cmd.hex.q,
+          cmd.hex.r,
+          characterId,
+          cmd.skill,
+        );
+        if (prior) {
+          const name = ctx.runtime.characters.get(characterId)?.name ?? 'That character';
+          throw new Error(`${name} already searched this hex with ${cmd.skill}`);
+        }
+      }
+    }
     const results = targets
       .map((characterId) => {
         const character = ctx.runtime.characters.get(characterId);
@@ -798,11 +818,33 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     // and passive gates alike — a deliberate search can find what passive
     // senses missed).
     let found = 0;
+    let pending = 0;
     if (cmd.hex && cmd.mapId) {
       const rt = ctx.runtime.mapStates.get(cmd.mapId);
       const map = ctx.runtime.maps.get(cmd.mapId);
       if (rt && map) {
         const created: NewDiscovery[] = [];
+        // Every roll is written down, DM- or player-initiated: the DM's
+        // investigation view is a history of who tried what, not just of
+        // what is still outstanding.
+        const attempts = new Map<string, string>();
+        for (const r of results) {
+          attempts.set(
+            r.characterId,
+            ctx.runtime.recordSearchAttempt({
+              id: nanoid(12),
+              mapId: cmd.mapId,
+              q: cmd.hex.q,
+              r: cmd.hex.r,
+              characterId: r.characterId,
+              skill: cmd.skill,
+              roll: r.roll,
+              modifier: r.modifier,
+              total: r.total,
+              at: Date.now(),
+            }).id,
+          );
+        }
         for (const r of results) {
           const token = [...rt.tokens.values()].find(
             (t) => t.kind === 'pc' && t.characterId === r.characterId,
@@ -823,6 +865,30 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
                 clue.indicatesDirection && distance > 0
                   ? compassDirection({ q: token.q, r: token.r }, cmd.hex, map.orientation)
                   : null;
+              const locates = distance === 0 && clue.revealsLocation;
+              // A player's success is a proposal, not a reveal (issue #107):
+              // the DM decides whether the character actually finds it. The
+              // bearing and locates flag are frozen here, at roll time, so the
+              // approval describes what they saw from where they stood.
+              if (!dmRoll) {
+                if (
+                  ctx.runtime.addPendingReveal({
+                    id: nanoid(12),
+                    clueId: clue.id,
+                    characterId: r.characterId,
+                    attemptId: attempts.get(r.characterId) ?? '',
+                    direction,
+                    locates,
+                    roll: r.roll,
+                    modifier: r.modifier,
+                    total: r.total,
+                    at: Date.now(),
+                  })
+                ) {
+                  pending++;
+                }
+                continue;
+              }
               const discovery = {
                 id: nanoid(12),
                 clueId: clue.id,
@@ -837,7 +903,7 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
                   dc: clue.gate.dc,
                 },
                 direction,
-                locates: distance === 0 && clue.revealsLocation,
+                locates,
               };
               if (ctx.runtime.addDiscovery(discovery)) {
                 created.push({
@@ -892,6 +958,23 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
         deliverTrailFinds(ctx, trailFinds);
         found = created.length + trailFinds.length;
         deliverDiscoveries(ctx, created);
+        if (pending > 0) {
+          // Nudge the DM: results are sitting in Inspect waiting on them.
+          ctx.hub.sendTo(
+            ctx.runtime,
+            {
+              type: 'event',
+              kind: 'search.pending',
+              characterName: results.map((r) => r.name).join(', '),
+              skill: cmd.skill,
+              total: Math.max(...results.map((r) => r.total)),
+              q: cmd.hex.q,
+              r: cmd.hex.r,
+              count: pending,
+            },
+            { dm: true },
+          );
+        }
       }
     }
     const summary = results
@@ -903,20 +986,57 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
       )
       .join(' · ');
     const where = cmd.hex ? ` on hex ${cmd.hex.q},${cmd.hex.r}` : '';
+    const headline = `${capitalize(cmd.skill)}${cmd.dc !== null ? ` DC ${cmd.dc}` : ''}${where}: ${summary || 'no targets'}`;
+    const rolled = new Set(results.map((r) => r.characterId));
+    const ownerSeats = [...ctx.runtime.seats.values()]
+      .filter((s) => s.characterId && rolled.has(s.characterId))
+      .map((s) => s.id);
+
+    // A player's hex search gets TWO entries (issue #107). The outcome string
+    // is baked into `text`, and one row cannot say different things to
+    // different readers — so the DM's row carries the full accounting (what
+    // opened, what is waiting on them) and the player's row says only that
+    // the DM will narrate. Counts of found/not-found never reach a player:
+    // "nothing new found" is itself information about the hex.
+    if (ctx.seat.role !== 'dm' && cmd.hex) {
+      const dmOutcome = [
+        found ? `${found} clue(s) uncovered` : null,
+        pending ? `${pending} awaiting your approval` : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      const dmEntry = ctx.runtime.appendLog('check', `${headline} — ${dmOutcome || 'nothing found'}`, 'dm', {
+        skill: cmd.skill,
+        dc: cmd.dc,
+        results,
+        hex: { q: cmd.hex.q, r: cmd.hex.r },
+        pending,
+      });
+      ctx.hub.sendTo(ctx.runtime, { type: 'event', kind: 'log.appended', entry: dmEntry }, { dm: true });
+      const playerEntry = ctx.runtime.appendLog(
+        'check',
+        `${headline} — the DM will describe what you find`,
+        'all',
+        { skill: cmd.skill, dc: cmd.dc, results },
+      );
+      ctx.hub.sendTo(
+        ctx.runtime,
+        { type: 'event', kind: 'log.appended', entry: playerEntry },
+        { seatIds: ownerSeats },
+      );
+      return;
+    }
+
     const outcome = cmd.hex ? (found ? ` — ${found} clue(s) uncovered` : ' — nothing new found') : '';
     const entry = ctx.runtime.appendLog(
       'check',
-      `${capitalize(cmd.skill)}${cmd.dc !== null ? ` DC ${cmd.dc}` : ''}${where}: ${summary || 'no targets'}${outcome}`,
+      `${headline}${outcome}`,
       ctx.seat.role === 'dm' ? 'dm' : 'all',
       { skill: cmd.skill, dc: cmd.dc, results },
     );
     if (entry.visibility === 'all') {
       // A character's rolls are theirs alone: notify only the seats owning a
       // character that rolled (the snapshot filter applies the same rule).
-      const rolled = new Set(results.map((r) => r.characterId));
-      const ownerSeats = [...ctx.runtime.seats.values()]
-        .filter((s) => s.characterId && rolled.has(s.characterId))
-        .map((s) => s.id);
       ctx.hub.sendTo(
         ctx.runtime,
         { type: 'event', kind: 'log.appended', entry },
@@ -925,6 +1045,90 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     } else {
       notifyLog(ctx, entry);
     }
+  }) as Handler,
+
+  /**
+   * The DM's call on pending search results (issue #107). Approving runs them
+   * through the normal discovery path — same toast, same log lines, same
+   * senses — so an approved find is indistinguishable from an instant one.
+   */
+  'search.resolve': ((cmd: Extract<ClientCommand, { kind: 'search.resolve' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    const created: NewDiscovery[] = [];
+    let withheld = 0;
+    let hex: { q: number; r: number } | null = null;
+    for (const pendingId of cmd.pendingIds) {
+      const pending = ctx.runtime.pendingReveals.get(pendingId);
+      if (!pending) continue;
+      const attempt = ctx.runtime.getSearchAttempt(pending.attemptId);
+      if (attempt) hex = { q: attempt.q, r: attempt.r };
+      if (!cmd.approve) {
+        ctx.runtime.deletePendingReveal(pendingId);
+        withheld++;
+        continue;
+      }
+      const content = ctx.runtime.findContentByClue(pending.clueId);
+      const clue = content?.clues.find((c) => c.id === pending.clueId);
+      // The clue went away under the DM's feet: drop the stale row.
+      if (!content || !clue) {
+        ctx.runtime.deletePendingReveal(pendingId);
+        continue;
+      }
+      const character = ctx.runtime.characters.get(pending.characterId);
+      const discovery = {
+        id: nanoid(12),
+        clueId: pending.clueId,
+        characterId: pending.characterId,
+        at: Date.now(),
+        how: {
+          kind: 'roll' as const,
+          skill: attempt?.skill ?? 'search',
+          roll: pending.roll,
+          modifier: pending.modifier,
+          total: pending.total,
+          dc: clue.gate.kind === 'skill' ? clue.gate.dc : 0,
+        },
+        direction: pending.direction,
+        locates: pending.locates,
+      };
+      // addDiscovery consumes the pending row itself; the explicit delete
+      // covers the already-known case, where it returns false.
+      if (ctx.runtime.addDiscovery(discovery)) {
+        created.push({
+          discovery,
+          contentId: content.id,
+          contentTitle: content.title,
+          clueText: clue.text,
+          characterName: character?.name ?? 'Someone',
+        });
+      }
+      ctx.runtime.deletePendingReveal(pendingId);
+    }
+    deliverDiscoveries(ctx, created);
+    if (withheld > 0) {
+      const where = hex ? ` at hex ${hex.q},${hex.r}` : '';
+      notifyLog(ctx, ctx.runtime.appendLog('check', `Withheld ${withheld} result(s)${where}`, 'dm', {}));
+    }
+  }) as Handler,
+
+  /** Let a character search this hex with this skill again (issue #107). */
+  'search.clearAttempt': ((
+    cmd: Extract<ClientCommand, { kind: 'search.clearAttempt' }>,
+    ctx: Ctx,
+  ) => {
+    requireDm(ctx);
+    const attempt = ctx.runtime.deleteSearchAttempt(cmd.attemptId);
+    if (!attempt) throw new Error('That search attempt is already gone');
+    const name = ctx.runtime.characters.get(attempt.characterId)?.name ?? 'Someone';
+    notifyLog(
+      ctx,
+      ctx.runtime.appendLog(
+        'check',
+        `${name} may search hex ${attempt.q},${attempt.r} with ${attempt.skill} again`,
+        'dm',
+        {},
+      ),
+    );
   }) as Handler,
 
   // -- encounters ------------------------------------------------------------

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -793,6 +793,49 @@ export const HexVisitSchema = z.object({
 });
 export type HexVisit = z.infer<typeof HexVisitSchema>;
 
+/**
+ * One character's one shot at searching one hex with one skill (issue #107).
+ * The row IS the limit: a player may not roll the same skill on the same hex
+ * twice until the DM clears the attempt. DM-initiated group rolls record
+ * attempts too (so the investigation view shows the history) but ignore the
+ * limit.
+ */
+export const SearchAttemptSchema = z.object({
+  id: z.string(),
+  mapId: z.string(),
+  q: z.number().int(),
+  r: z.number().int(),
+  characterId: z.string(),
+  skill: z.string(),
+  roll: z.number().int(),
+  modifier: z.number().int(),
+  total: z.number().int(),
+  at: z.number(),
+});
+export type SearchAttempt = z.infer<typeof SearchAttemptSchema>;
+
+/**
+ * A clue a player's search roll beat, waiting on the DM's call (issue #107).
+ * Everything the discovery will need is frozen here at roll time — the
+ * bearing and whether the find locates the source are computed against where
+ * the character stood when they rolled, not where they stand when the DM
+ * gets round to it. DM-only: `filterStateForViewer` sends players none.
+ */
+export const PendingRevealSchema = z.object({
+  id: z.string(),
+  clueId: z.string(),
+  characterId: z.string(),
+  /** The search_attempt this came out of (carries the skill and the hex). */
+  attemptId: z.string(),
+  direction: z.string().nullable().default(null),
+  locates: z.boolean().default(false),
+  roll: z.number().int(),
+  modifier: z.number().int(),
+  total: z.number().int(),
+  at: z.number(),
+});
+export type PendingReveal = z.infer<typeof PendingRevealSchema>;
+
 export const MapStateSchema = z.object({
   imageLayers: z.array(ImageLayerSchema),
   hexes: z.array(HexCellSchema),
@@ -808,6 +851,12 @@ export const MapStateSchema = z.object({
   trailSigns: z.array(TrailSignSchema).default([]),
   /** Party visit records; players see them for hexes that aren't fogged out. */
   visits: z.array(HexVisitSchema).default([]),
+  /**
+   * Search rolls made on this map (issue #107). DM: every character's;
+   * players: their own character's only, so the Search UI can grey out the
+   * skills they have already spent on a hex.
+   */
+  searchAttempts: z.array(SearchAttemptSchema).default([]),
 });
 export type MapState = z.infer<typeof MapStateSchema>;
 
@@ -848,6 +897,8 @@ export const CampaignStateSchema = z.object({
   trailDiscoveries: z.array(TrailDiscoverySchema).default([]),
   /** Player only: sensed clues on the viewed map; empty for the DM. */
   senses: z.array(SenseSchema).default([]),
+  /** DM only: search results awaiting the DM's share/withhold call. */
+  pendingReveals: z.array(PendingRevealSchema).default([]),
   /** DM only; empty for players. */
   encounterTables: z.array(EncounterTableSchema),
   log: z.array(LogEntrySchema),

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -527,6 +527,25 @@ export const CheckRollCommand = z.object({
   hex: z.object({ q: z.number().int(), r: z.number().int() }).nullable().default(null),
 });
 
+/**
+ * The DM's call on search results a player's roll turned up (issue #107):
+ * share them (they become normal discoveries and reach the player through
+ * the usual toast/log/senses path) or withhold them.
+ */
+export const SearchResolveCommand = z.object({
+  ...base,
+  kind: z.literal('search.resolve'),
+  pendingIds: z.array(z.string()).min(1).max(100),
+  approve: z.boolean(),
+});
+
+/** Clear one search attempt so its character may roll that skill here again. */
+export const SearchClearAttemptCommand = z.object({
+  ...base,
+  kind: z.literal('search.clearAttempt'),
+  attemptId: z.string(),
+});
+
 export const EncounterRollCommand = z.object({
   ...base,
   kind: z.literal('encounter.roll'),
@@ -656,6 +675,8 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   DiscoveryRevokeCommand,
   ClueShareCommand,
   CheckRollCommand,
+  SearchResolveCommand,
+  SearchClearAttemptCommand,
   EncounterRollCommand,
   EncounterTableUpsertCommand,
   EncounterTableDeleteCommand,

--- a/packages/shared/src/protocol/events.ts
+++ b/packages/shared/src/protocol/events.ts
@@ -113,6 +113,18 @@ export const ServerEventSchema = z.discriminatedUnion('kind', [
     forward: z.string().nullable(),
     backward: z.string().nullable(),
   }),
+  /**
+   * DM-only nudge (issue #107): a player's hex search turned up clues that
+   * are waiting on the DM's share/withhold call in Inspect.
+   */
+  ev('search.pending', {
+    characterName: z.string(),
+    skill: z.string(),
+    total: z.number().int(),
+    q: z.number().int(),
+    r: z.number().int(),
+    count: z.number().int(),
+  }),
   ev('encounterTable.upserted', { table: EncounterTableSchema }),
   ev('encounterTable.deleted', { tableId: z.string() }),
   ev('log.appended', { entry: LogEntrySchema }),

--- a/packages/shared/src/rules/filter.ts
+++ b/packages/shared/src/rules/filter.ts
@@ -61,6 +61,14 @@ export function filterStateForViewer(full: CampaignState, viewer: Viewer): Campa
           // rides along (q/r + clock minutes only). Gated on fog so a hex the
           // DM has re-hidden doesn't come back as a visit record.
           visits: mapState.visits.filter((v) => fogAt(v.q, v.r) !== 'hidden'),
+          // A player may see what THEIR character has already spent on a hex
+          // (issue #107) — that's what greys the used skills out in the
+          // Search UI. Another character's attempts are none of their
+          // business: knowing the ranger rolled 22 here and found nothing is
+          // information the table hasn't earned.
+          searchAttempts: viewer.characterId
+            ? mapState.searchAttempts.filter((a) => a.characterId === viewer.characterId)
+            : [],
         };
       })()
     : null;
@@ -78,6 +86,8 @@ export function filterStateForViewer(full: CampaignState, viewer: Viewer): Campa
       ? full.trailDiscoveries.filter((d) => d.characterId === viewer.characterId)
       : [],
     senses: computeSenses(full, viewer.characterId),
+    // Never: a pending reveal is a clue the DM has not decided to give yet.
+    pendingReveals: [],
     encounterTables: [],
     log: full.log.filter((e) => logEntryVisibleToPlayer(e, viewer)),
   };

--- a/packages/shared/src/rules/rules.test.ts
+++ b/packages/shared/src/rules/rules.test.ts
@@ -156,6 +156,11 @@ function fullState(): CampaignState {
         // Hex 2,0 has no fog record (hidden) — the visit must not leak it.
         { q: 2, r: 0, firstArrived: 60, lastArrived: 60, totalMinutes: 0 },
       ],
+      // Issue #107: one attempt from the viewer's character, one from another.
+      searchAttempts: [
+        { id: 'sa1', mapId: 'm1', q: 1, r: 0, characterId: 'char1', skill: 'perception', roll: 14, modifier: 4, total: 18, at: 2000 },
+        { id: 'sa2', mapId: 'm1', q: 1, r: 0, characterId: 'char2', skill: 'survival', roll: 9, modifier: 1, total: 10, at: 2001 },
+      ],
     },
     discoveries: [
       { id: 'd1', clueId: 'cl1', characterId: 'char1', at: 1000, how: { kind: 'auto' }, direction: null, locates: true },
@@ -163,6 +168,9 @@ function fullState(): CampaignState {
     ],
     trailDiscoveries: [],
     senses: [],
+    pendingReveals: [
+      { id: 'pr1', clueId: 'cl2', characterId: 'char1', attemptId: 'sa1', direction: null, locates: true, roll: 14, modifier: 4, total: 18, at: 2000 },
+    ],
     encounterTables: [{ id: 'et1', name: 'Forest', terrains: ['forest'], die: '1d12', entries: [], enabled: true }],
     log: [
       { id: 'l1', at: 1, kind: 'roll', text: 'dm secret roll', visibility: 'dm', data: {} },
@@ -193,6 +201,12 @@ describe('filterStateForViewer', () => {
   it('filters tokens: pc always; npc only playerVisible on visible hexes', () => {
     const s = filterStateForViewer(fullState(), viewer);
     expect(s.mapState!.tokens.map((t) => t.id).sort()).toEqual(['t1', 't2']);
+  });
+
+  it('shows a player only their own search attempts, and never a pending reveal', () => {
+    const s = filterStateForViewer(fullState(), viewer);
+    expect(s.mapState!.searchAttempts.map((a) => a.id)).toEqual(['sa1']);
+    expect(s.pendingReveals).toEqual([]);
   });
 
   it('filters markers by dmOnly and fog', () => {


### PR DESCRIPTION
Closes #107

## Design

**Server model.** Two new tables, both in the shared DDL path (SQLite + Postgres, `schema-parity.test.ts` green) and both loaded into `CampaignRuntime` at boot — the runtime stays the cache, nothing reads the DB at request time.

- `search_attempt(id, campaign_id, map_id, q, r, character_id, skill, roll, modifier, total, at)` with `UNIQUE(map_id, q, r, character_id, skill)`. Lives in `MapRuntime.searchAttempts`. The row *is* the limit.
- `pending_reveal(id, campaign_id, clue_id, character_id, attempt_id, direction, locates, roll, modifier, total, at)` with `UNIQUE(clue_id, character_id)`. Campaign-level (`CampaignRuntime.pendingReveals`).

**`check.roll`, hex branch.**
- The once-per-skill check runs *before* the dice, so a rejected search costs nothing: `'<Name> already searched this hex with <skill>'`.
- Every rolling character gets an attempt recorded, DM- or player-initiated, so the investigation view is a history and not just a queue. A DM re-roll updates the existing row in place (the unique tuple) rather than inserting a second — keeping the id stable is what lets pendings keep pointing at it.
- Player-initiated: clues the roll beats become pendings with `direction`/`locates` computed exactly as the instant path did, frozen at roll time. A `search.pending` event goes to the DM only.
- DM-initiated: instant reveal, no pendings, no limit. Dedupe lives in `runtime.addDiscovery`, which consumes any pending for that clue+character — so an instant reveal, a reveal pill or a share all silently clear a queued row.
- Trails keep their current instant behaviour on a search. **Follow-up:** they should probably go through the same gate.

**Log entries.** A log row's outcome is baked into its `text`, and one row cannot say different things to different readers, so a player's hex search writes two: a `'dm'` entry with the full accounting (`N clue(s) uncovered, N awaiting your approval`) and an `'all'` entry ending `— the DM will describe what you find`. Counts of found/not-found never reach a player: "nothing new found" is itself information about the hex. Non-hex checks and DM rolls are unchanged (single entry).

**New commands.** `search.resolve { pendingIds (1..100), approve }` and `search.clearAttempt { attemptId }`, both DM-only, both default-free so no `CommandInput` call sites break. Approval builds the discovery with `how: {kind:'roll', skill (from the attempt), roll, modifier, total, dc: clue.gate.dc}` and runs it through `deliverDiscoveries` — an approved find is indistinguishable from an instant one. Denial deletes the rows and logs `Withheld N result(s) at hex q,r` DM-only; the attempt stays spent (a ruling, not a do-over).

**Filter** (`shared/rules/filter.ts`). `MapState.searchAttempts` is filtered to the viewer's own character (that is what greys the used skills out); `CampaignState.pendingReveals` is `[]` for players, always.

**Portability.** Both tables export and import, remapping `map_id`/`character_id`/`clue_id`/`attempt_id` the way discoveries do; the archive fields default to `[]` so pre-#107 backups still restore.

**Client.** Players see used skills disabled in the Search select with a "One attempt per skill" hint and a disabled roll button. The DM gets an `InvestigationSection` above Search: pendings grouped by character with per-row Share/Withhold plus Share all / Withhold all, "Attempts here" rows (character · skill · total · time-ago, each with ✕ to allow a retry), and "Shared with the party" for `how.kind === 'shared'` discoveries on the hex. `ws.ts` toasts `search.pending` for the DM.

## Tests

`packages/server/src/search-approval.test.ts` — 19 new tests: attempt uniqueness and its scoping (skill/hex/character), the DM bypass, pending creation and the frozen bearing, instant-reveal dedupe, approve/deny/mixed resolution, DM-only authorization, `clearAttempt` re-roll, what each side's log says (including that a fruitless search reads identically to a fruitful one), the filter split, and an export/import roundtrip. Plus one filter case in `shared/rules/rules.test.ts`.

Three existing tests asserted the old instant-reveal behaviour for player searches and were updated to route through `search.resolve` — that behaviour change is the issue.

`pnpm typecheck && pnpm test` green (61 shared + 193 server).

## Docs notes

`docs/AI-DEVELOPMENT.md` gains a gotcha bullet for #107: where the once-per-skill limit lives and that it is checked before rolling, that `addDiscovery` is the dedupe point for queued reveals, the two-log-entry rule (an outcome baked into `text` cannot be per-viewer), and the filter split between `searchAttempts` and `pendingReveals`. Trails-still-instant is recorded there as the known follow-up.
