### PR TITLE
Region painting: drag brush + Region tool

### DIFF
--- a/docs/AI-DEVELOPMENT.md
+++ b/docs/AI-DEVELOPMENT.md
@@ -138,6 +138,20 @@ player-facing data).
   `contentCoversHex`, `distanceToContent`) in shared `domain.ts` are the
   single source of area truth — never compare `c.q === hex.q` directly for
   content-on-hex checks.
+- **Region painting is a stroke, not a click** (#108): the engine's brush
+  machinery (`beginStroke`/`strokeApply`/`flushStroke`) has a third mode,
+  `region`, driven by the same `ui.brushRadius` as terrain. Two flavours:
+  with `ui.areaPaint` set (the content dialog's collapsed paint bar) the
+  stroke only edits that local draft — the dialog commits it with
+  `content.upsert` on save, because a brand-new item has no id yet; with the
+  Region tool (`ui.tool === 'region'` + `ui.regionTargetId`) each flush sends
+  a `content.area {contentId, add?, remove?}` delta, so a 200-hex forest never
+  resends its payload. `ui.regionErase` is the polarity, latched at stroke
+  start. The server merges by hex key, never stores the anchor (it's an
+  implicit member), re-runs `evaluateKnowledge` (a region grown over a
+  standing party opens its entering gate), and merges consecutive deltas on
+  one content within 3s into a single undo entry — the same trick
+  `recordCellUndo` plays for terrain, so one drag is one undo.
 - **Seat cookies are per-hostname.** To run a DM and a player session against
   one dev server, open one on `localhost` and one on `127.0.0.1` — separate
   cookie jars.

--- a/packages/client/src/components/ContentDialog.tsx
+++ b/packages/client/src/components/ContentDialog.tsx
@@ -13,6 +13,7 @@ import { activeMap, useSession } from '../stores/session.js';
 import { useUi } from '../stores/ui.js';
 import { send } from '../ws.js';
 import { Button, Dialog, Field, Input, Select, TextArea, cx } from '../ui/kit.js';
+import { RegionBrushControls } from './Toolbar.js';
 
 interface ClueDraft {
   id: string | null;
@@ -87,14 +88,15 @@ export function ContentDialog() {
 
   if (areaPaint) {
     return (
-      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-ink-850/95 border border-brass-500/60 rounded-xl shadow-2xl px-4 py-2.5 backdrop-blur">
+      <div className="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 flex-wrap justify-center max-w-[calc(100vw-1.5rem)] bg-ink-850/95 border border-brass-500/60 rounded-xl shadow-2xl px-4 py-2.5 backdrop-blur">
         <span className="text-sm text-ink-100">
           Painting the area of <span className="font-medium">{title.trim() || 'this content'}</span>
         </span>
         <span className="text-xs text-ink-400">
-          {areaPaint.cells.length} extra hex{areaPaint.cells.length === 1 ? '' : 'es'} · click to
-          toggle
+          {areaPaint.cells.length} extra hex{areaPaint.cells.length === 1 ? '' : 'es'} · drag to
+          paint
         </span>
+        <RegionBrushControls compact />
         <Button size="sm" variant="ghost" onClick={() => setUi('areaPaint', { cells: [] })}>
           Clear
         </Button>

--- a/packages/client/src/components/Toolbar.tsx
+++ b/packages/client/src/components/Toolbar.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react';
 import {
+  CONTENT_TYPE_GLYPHS,
   TERRAINS,
   TERRAIN_IDS,
+  contentCells,
   hexKey,
   hexesInPixelRect,
+  isFullContent,
+  type Content,
   type FogState,
   type HexCoord,
 } from '@hexcrawl/shared';
@@ -20,6 +24,7 @@ const TOOLS: { tool: Tool; icon: string; name: string; hint: string }[] = [
   { tool: 'marker', icon: '📍', name: 'Marker (M)', hint: 'Place effect markers' },
   { tool: 'content', icon: '📖', name: 'Content (C)', hint: 'Add hex content' },
   { tool: 'trail', icon: '👣', name: 'Trail (T)', hint: 'Draw a footstep trail cell by cell' },
+  { tool: 'region', icon: '🗺️', name: 'Region (G)', hint: 'Paint area footprints' },
   { tool: 'measure', icon: '📏', name: 'Measure (R)', hint: 'Measure distances' },
 ];
 
@@ -139,11 +144,148 @@ export function Toolbar() {
 
       {ui.tool === 'trail' && <TrailOptions />}
 
+      {ui.tool === 'region' && <RegionOptions />}
+
       {ui.tool === 'measure' && (
         <div className="bg-ink-900/95 border border-ink-700 rounded-lg p-2 shadow-xl backdrop-blur w-44 text-xs text-ink-300">
           Click a hex to set the start point, then hover. Click again to clear.
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Brush size (1/7/19 hexes) and add/erase polarity for region painting
+ * (issue #108). Shared by the Region tool's panel and the content dialog's
+ * floating paint bar so the two modes feel like one brush — `brushRadius` is
+ * literally the terrain painter's, so a size chosen there carries over.
+ */
+export function RegionBrushControls({ compact = false }: { compact?: boolean }) {
+  const brushRadius = useUi((s) => s.brushRadius);
+  const regionErase = useUi((s) => s.regionErase);
+  const set = useUi((s) => s.set);
+
+  return (
+    <div
+      className={cx(
+        'gap-1',
+        // In the toolbar panel the two rows stack (it's only 13rem wide); in
+        // the dialog's floating bar they sit inline with the other controls.
+        compact ? 'flex items-center' : 'flex flex-col w-full',
+      )}
+    >
+      <div className="flex items-center gap-1">
+        {([0, 1, 2] as const).map((r) => (
+          <button
+            key={r}
+            onClick={() => set('brushRadius', r)}
+            title={`Brush: ${r === 0 ? '1 hex' : r === 1 ? '7 hexes' : '19 hexes'}`}
+            className={cx(
+              'py-1 rounded text-xs cursor-pointer border',
+              compact ? 'px-2' : 'flex-1',
+              brushRadius === r
+                ? 'border-brass-500 bg-brass-500/15 text-brass-300'
+                : 'border-ink-700 hover:bg-ink-700 text-ink-200',
+            )}
+          >
+            {r === 0 ? '1' : r === 1 ? '7' : '19'}
+          </button>
+        ))}
+      </div>
+      <div className={cx('flex items-center gap-1', compact && 'ml-1')}>
+        {([false, true] as const).map((erase) => (
+          <button
+            key={String(erase)}
+            onClick={() => set('regionErase', erase)}
+            title={
+              erase
+                ? 'Erase: drag to take hexes out of the footprint'
+                : 'Add: drag to bring hexes into the footprint'
+            }
+            className={cx(
+              'px-2 py-1 rounded text-xs cursor-pointer border',
+              !compact && 'flex-1',
+              regionErase === erase
+                ? erase
+                  ? 'border-ember-500 bg-ember-500/15 text-ember-500'
+                  : 'border-brass-500 bg-brass-500/15 text-brass-300'
+                : 'border-ink-700 hover:bg-ink-700 text-ink-200',
+            )}
+          >
+            {erase ? '⌫ Remove' : '+ Add'}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Region tool panel (issue #108): pick an existing content item and paint its
+ * multi-hex footprint straight onto the map — no dialog round trip. Regions
+ * (and anything that already has an area) sort to the top of the target list,
+ * because those are what a DM paints; every item is still reachable, since any
+ * content type can carry an area.
+ */
+function RegionOptions() {
+  const targetId = useUi((s) => s.regionTargetId);
+  const state = useSession((s) => s.state);
+  const map = activeMap(state);
+  const contents = (state?.mapState?.contents ?? []).filter(isFullContent) as Content[];
+
+  const options = [...contents].sort((a, b) => {
+    const rank = (c: Content) => (c.type === 'region' ? 0 : c.area.length > 0 ? 1 : 2);
+    return rank(a) - rank(b) || a.title.localeCompare(b.title);
+  });
+  const target = options.find((c) => c.id === targetId) ?? null;
+  const targetCells = target ? contentCells(target).length : 0;
+
+  if (!map) return null;
+
+  return (
+    <div className="bg-ink-900/95 border border-ink-700 rounded-lg p-2 shadow-xl backdrop-blur w-52 overflow-y-auto space-y-2">
+      <p className="text-[10px] uppercase tracking-wider text-ink-400 font-semibold">
+        Paint the area of
+      </p>
+      {options.length === 0 ? (
+        <p className="text-[11px] text-ink-400">
+          No content on this map yet. Create a region with the Content tool (C), then come back here
+          to paint its footprint.
+        </p>
+      ) : (
+        <select
+          className="w-full bg-ink-950 border border-ink-600 rounded px-1 py-1 text-xs text-ink-100 cursor-pointer"
+          value={targetId ?? ''}
+          onChange={(e) => useUi.getState().set('regionTargetId', e.target.value || null)}
+          title="Which content item this brush paints into"
+        >
+          <option value="">Choose a region…</option>
+          {options.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.glyph || CONTENT_TYPE_GLYPHS[c.type]} {c.title} ({contentCells(c).length} hex
+              {contentCells(c).length === 1 ? '' : 'es'})
+            </option>
+          ))}
+        </select>
+      )}
+      {target ? (
+        <p className="text-[11px] text-ink-300">
+          <span className="text-brass-300 font-medium">{targetCells}</span> hex
+          {targetCells === 1 ? '' : 'es'} — drag on the map to paint. The anchor hex always belongs
+          to the region.
+        </p>
+      ) : (
+        options.length > 0 && (
+          <p className="text-[11px] text-ink-400">Pick a target before painting.</p>
+        )
+      )}
+      <div>
+        <p className="text-[10px] uppercase tracking-wider text-ink-400 font-semibold mb-1">
+          Brush
+        </p>
+        <RegionBrushControls />
+      </div>
     </div>
   );
 }

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -148,8 +148,21 @@ export class CanvasEngine {
   private resizeObserver: ResizeObserver | null = null;
   private unsubs: (() => void)[] = [];
 
-  private stroke: { mode: 'paint' | 'fog'; pending: Map<string, HexCoord>; timer: number } | null =
-    null;
+  /**
+   * A brush stroke in progress. Terrain and fog paint cells; `region` paints
+   * membership of a content footprint (issue #108) — either into the content
+   * dialog's local draft (`contentId: null`, committed on save) or straight to
+   * the server as `content.area` deltas.
+   */
+  private stroke: {
+    mode: 'paint' | 'fog' | 'region';
+    pending: Map<string, HexCoord>;
+    timer: number;
+    /** Region mode: the content being painted, or null for the dialog draft. */
+    contentId?: string | null;
+    /** Region mode: polarity, latched at stroke start so it can't flip mid-drag. */
+    erase?: boolean;
+  } | null = null;
   /**
    * A token grab in progress. It starts *armed* (`active: false`): the token
    * only follows the pointer once it has travelled past DRAG_THRESHOLD, so a
@@ -290,6 +303,13 @@ export class CanvasEngine {
         this.drawAreaHighlight();
         if ((u.areaPaint !== null) !== (prev.areaPaint !== null)) {
           this.viewport.cursor = u.areaPaint ? 'crosshair' : 'default';
+          this.drawHighlight(); // the brush ring follows the pointer in paint mode
+        }
+      }
+      if (u.tool !== prev.tool || u.regionTargetId !== prev.regionTargetId) {
+        this.syncRegionHighlight();
+        if ((u.tool === 'region') !== (prev.tool === 'region')) {
+          this.viewport.cursor = u.tool === 'region' ? 'crosshair' : 'default';
         }
       }
       if (u.selectedHex !== prev.selectedHex) {
@@ -404,6 +424,9 @@ export class CanvasEngine {
       this.lastTrails = ms.trails;
       this.lastTrailSigns = ms.trailSigns;
       this.drawPins();
+      // The brush target may have grown/shrunk (this snapshot, another DM, an
+      // undo) — refresh its preview unless a stroke is mid-flight.
+      if (useUi.getState().tool === 'region') this.syncRegionHighlight();
     }
 
     this.drawHighlight();
@@ -813,7 +836,9 @@ export class CanvasEngine {
     g.clear();
     if (!this.layout) return;
     const ui = useUi.getState();
-    const painting = ui.areaPaint !== null;
+    // "Painting" (a warmer wash) covers both authoring modes: the dialog's
+    // draft and the Region tool's live target.
+    const painting = ui.areaPaint !== null || (ui.tool === 'region' && this.role === 'dm');
     const cells = ui.areaPaint?.cells ?? ui.areaHighlight?.cells ?? [];
     if (cells.length === 0) return;
     const color = painting ? 0x6fae6a : 0x59a5c4;
@@ -828,6 +853,34 @@ export class CanvasEngine {
       g.poly(this.polyPoints(center, corners));
     }
     g.stroke({ width: 1.5 / this.viewport.scale.x, color, alpha: 0.6 });
+  }
+
+  /** The content item on this map with that id, if it's still there. */
+  private findContent(contentId: string): Content | ContentPlayerView | null {
+    return this.lastContents.find((c) => c.id === contentId) ?? null;
+  }
+
+  /**
+   * Point the footprint highlight at the region tool's target (issue #108):
+   * picking a tool or a target shows what the brush will paint into. A stroke
+   * in progress owns the highlight — a snapshot landing mid-drag must not
+   * yank the optimistic cells back.
+   */
+  private syncRegionHighlight(): void {
+    if (this.stroke?.mode === 'region') return;
+    const ui = useUi.getState();
+    if (ui.tool !== 'region' || this.role !== 'dm') {
+      // Leaving the tool takes its own preview with it; a highlight the DM
+      // opened from a panel (a different item) stays put.
+      if (ui.areaHighlight && ui.areaHighlight.contentId === ui.regionTargetId) {
+        ui.set('areaHighlight', null);
+        this.drawAreaHighlight();
+      }
+      return;
+    }
+    const target = ui.regionTargetId ? this.findContent(ui.regionTargetId) : null;
+    ui.set('areaHighlight', target ? { contentId: target.id, cells: contentCells(target) } : null);
+    this.drawAreaHighlight();
   }
 
   /** Keep the DM pin-action popup glued above the selected hex. */
@@ -862,7 +915,9 @@ export class CanvasEngine {
       g.stroke({ width: lineW * 1.5, color: 0xc9a24b, alpha: 1 });
     }
     if (ui.hoverHex) {
-      const isBrush = (ui.tool === 'paint' || ui.tool === 'fog') && this.role === 'dm';
+      const isBrush =
+        (ui.tool === 'paint' || ui.tool === 'fog' || ui.tool === 'region' || ui.areaPaint !== null) &&
+        this.role === 'dm';
       let centers: { x: number; y: number }[];
       if (lvl === 0) {
         const cells = isBrush ? hexRange(ui.hoverHex, ui.brushRadius) : [ui.hoverHex];
@@ -1562,13 +1617,11 @@ export class CanvasEngine {
         return;
       }
 
-      // Armed "paint area" mode: clicks toggle footprint membership until
-      // the dialog's Done (or Escape) ends it. Nothing is sent until save.
+      // Armed "paint area" mode: drag the brush over footprint membership
+      // until the dialog's Done (or Escape) ends it. Nothing is sent until
+      // save — the dialog owns this draft (a new item has no id yet).
       if (ui.areaPaint && isDm) {
-        const cells = ui.areaPaint.cells;
-        const idx = cells.findIndex((c) => c.q === hex.q && c.r === hex.r);
-        const next = idx >= 0 ? cells.filter((_, i) => i !== idx) : [...cells, hex];
-        useUi.getState().set('areaPaint', { cells: next });
+        this.beginStroke('region', hex, null);
         return;
       }
 
@@ -1668,6 +1721,15 @@ export class CanvasEngine {
           this.drawHighlight();
           break;
         }
+        case 'region': {
+          // Region brush (issue #108): drag over the map to grow (or erase)
+          // the chosen region's footprint. Without a target there's nothing
+          // to paint into — the toolbar panel says so.
+          if (!isDm || !ui.regionTargetId) return;
+          if (!this.findContent(ui.regionTargetId)) return;
+          this.beginStroke('region', hex, ui.regionTargetId);
+          break;
+        }
         case 'measure':
           if (ui.measureStart && hexDistance(ui.measureStart, hex) > 0) {
             useUi.getState().set('measureStart', null);
@@ -1740,9 +1802,21 @@ export class CanvasEngine {
     useUi.getState().set('contentSelection', ids.length ? ids : null);
   }
 
-  private beginStroke(mode: 'paint' | 'fog', hex: HexCoord): void {
+  private beginStroke(mode: 'paint' | 'fog', hex: HexCoord): void;
+  private beginStroke(mode: 'region', hex: HexCoord, contentId: string | null): void;
+  private beginStroke(
+    mode: 'paint' | 'fog' | 'region',
+    hex: HexCoord,
+    contentId: string | null = null,
+  ): void {
     this.viewport.plugins.pause('drag');
-    this.stroke = { mode, pending: new Map(), timer: 0 };
+    this.stroke = {
+      mode,
+      pending: new Map(),
+      timer: 0,
+      contentId,
+      erase: useUi.getState().regionErase,
+    };
     this.strokeApply(hex);
   }
 
@@ -1768,13 +1842,46 @@ export class CanvasEngine {
     const session = useSession.getState();
     if (this.stroke.mode === 'paint') {
       session.optimisticPaint(this.lastMap.id, fresh, ui.paintTerrain);
-    } else {
+    } else if (this.stroke.mode === 'fog') {
       session.optimisticFog(this.lastMap.id, fresh, ui.fogTarget);
+    } else {
+      this.regionStrokePreview(fresh);
     }
     const now = performance.now();
     if (now - this.stroke.timer > STROKE_FLUSH_MS) {
       this.flushStroke(false);
       this.stroke.timer = now;
+    }
+  }
+
+  /**
+   * Show a region stroke the moment the brush passes: the dialog's draft and
+   * the tool's footprint highlight are the same wash on screen, so both get
+   * the cells before any server round trip.
+   */
+  private regionStrokePreview(fresh: HexCoord[]): void {
+    const stroke = this.stroke;
+    if (!stroke) return;
+    const ui = useUi.getState();
+    const target = stroke.contentId ? this.findContent(stroke.contentId) : null;
+    const source = stroke.contentId ? ui.areaHighlight?.cells : ui.areaPaint?.cells;
+    const cells = new Map<string, HexCoord>();
+    for (const cell of source ?? []) cells.set(hexKey(cell.q, cell.r), cell);
+    // The anchor hex is a member no matter what the brush does to it.
+    const anchorKey = target ? hexKey(target.q, target.r) : null;
+    for (const cell of fresh) {
+      const key = hexKey(cell.q, cell.r);
+      if (stroke.erase) {
+        if (key !== anchorKey) cells.delete(key);
+      } else {
+        cells.set(key, cell);
+      }
+    }
+    const next = [...cells.values()];
+    if (stroke.contentId) {
+      ui.set('areaHighlight', { contentId: stroke.contentId, cells: next });
+    } else {
+      ui.set('areaPaint', { cells: next });
     }
   }
 
@@ -1785,8 +1892,16 @@ export class CanvasEngine {
       const ui = useUi.getState();
       if (this.stroke.mode === 'paint') {
         send({ kind: 'terrain.paint', mapId: this.lastMap.id, cells, terrain: ui.paintTerrain });
-      } else {
+      } else if (this.stroke.mode === 'fog') {
         send({ kind: 'fog.set', mapId: this.lastMap.id, cells, state: ui.fogTarget });
+      } else if (this.stroke.contentId) {
+        // The dialog's draft (contentId === null) is committed by its save;
+        // the region tool paints an existing item, one delta per flush.
+        send(
+          this.stroke.erase
+            ? { kind: 'content.area', contentId: this.stroke.contentId, remove: cells }
+            : { kind: 'content.area', contentId: this.stroke.contentId, add: cells },
+        );
       }
     }
     if (final) this.stroke = null;

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -1,7 +1,15 @@
 import { create } from 'zustand';
 import type { FogState, HexCoord, TerrainId } from '@hexcrawl/shared';
 
-export type Tool = 'select' | 'paint' | 'fog' | 'marker' | 'content' | 'trail' | 'measure';
+export type Tool =
+  | 'select'
+  | 'paint'
+  | 'fog'
+  | 'marker'
+  | 'content'
+  | 'trail'
+  | 'region'
+  | 'measure';
 
 /**
  * Side pop-out panels (issue #61). Three player-facing headings plus two
@@ -60,12 +68,20 @@ interface UiStore {
   /** Region footprint highlight: the hexes of a clicked multi-hex content (issue #69). */
   areaHighlight: { contentId: string; cells: HexCoord[] } | null;
   /**
-   * DM "paint area" mode (armed from the content dialog): while set, a map
-   * click toggles the hex in `cells` instead of running the active tool. The
-   * dialog owns the draft until it's saved, so this holds live cells, not an
-   * id — a brand-new content item has no id yet.
+   * DM "paint area" mode (armed from the content dialog): while set, dragging
+   * the map brushes hexes into (or out of) `cells` instead of running the
+   * active tool. The dialog owns the draft until it's saved, so this holds
+   * live cells, not an id — a brand-new content item has no id yet.
    */
   areaPaint: { cells: HexCoord[] } | null;
+  /**
+   * Region tool (issue #108): which existing content the brush paints into.
+   * Unlike `areaPaint`, strokes here go straight to the server as
+   * `content.area` deltas — no dialog, no save step.
+   */
+  regionTargetId: string | null;
+  /** Region brush polarity: true removes hexes from the footprint. */
+  regionErase: boolean;
   /** DM trail tool: cells of the trail being drawn, in click order. */
   trailDraft: HexCoord[];
   /** DM trail tool: id of the trail whose nodes are being edited (null = new). */
@@ -140,6 +156,8 @@ export const useUi = create<UiStore>((set) => ({
   trailHighlight: null,
   areaHighlight: null,
   areaPaint: null,
+  regionTargetId: null,
+  regionErase: false,
   trailDraft: [],
   editingTrailId: null,
   contentSelection: null,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -65,6 +65,9 @@ export function TableView({ campaignId }: { campaignId: string }) {
         ui.set('trailHighlight', null);
         ui.set('trailDraft', []);
         ui.set('editingTrailId', null);
+        // The region brush's target owns the footprint preview cleared above;
+        // dropping both together keeps the tool and the map in step.
+        ui.set('regionTargetId', null);
         ui.set('contentSelection', null);
         return;
       }
@@ -74,7 +77,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
         send({ kind: 'undo' });
         return;
       }
-      const tools = { v: 'select', b: 'paint', f: 'fog', m: 'marker', c: 'content', t: 'trail', r: 'measure' } as const;
+      const tools = { v: 'select', b: 'paint', f: 'fog', m: 'marker', c: 'content', t: 'trail', g: 'region', r: 'measure' } as const;
       const tool = tools[e.key.toLowerCase() as keyof typeof tools];
       if (tool && !e.metaKey && !e.ctrlKey && !e.altKey) ui.setTool(tool);
     };

--- a/packages/server/src/content-area.test.ts
+++ b/packages/server/src/content-area.test.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ClientCommandSchema, seededRng } from '@hexcrawl/shared';
+import type { ClientCommand, Content } from '@hexcrawl/shared';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { CampaignRuntime, type SeatRecord } from './state/runtime.js';
+import { Hub } from './ws/hub.js';
+import { dispatchCommand } from './ws/handlers.js';
+
+/**
+ * `content.area` (issue #108): the region brush's wire format. A stroke sends
+ * only the hexes it touched, so painting a 200-hex forest never resends the
+ * content payload and two strokes can't clobber each other's cells.
+ */
+
+let store: Store;
+let runtime: CampaignRuntime;
+let dmSeat: SeatRecord;
+let hub: Hub;
+let cmdCounter = 0;
+
+function asSeat(seat: SeatRecord, cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `a${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+function dm(cmd: Omit<ClientCommand, 'id'>): void {
+  asSeat(dmSeat, cmd);
+}
+
+beforeEach(() => {
+  store = new Store(createTestDb());
+  const created = store.createCampaign('Areas', 'The DM');
+  runtime = created.runtime;
+  dmSeat = created.dmSeat;
+  hub = new Hub();
+  cmdCounter = 0;
+});
+
+/** A region anchored at (5,0) with an initial footprint of (6,0). */
+function region(title: string, clues: unknown[] = []): Content {
+  const mapId = runtime.campaign.activeMapId!;
+  dm({
+    kind: 'content.upsert',
+    content: {
+      id: null,
+      mapId,
+      q: 5,
+      r: 0,
+      area: [{ q: 6, r: 0 }],
+      type: 'region',
+      title,
+      dmNotes: '',
+      glyph: '',
+      clues,
+    },
+  } as never);
+  return [...runtime.requireMap(mapId).contents.values()].find((c) => c.title === title)!;
+}
+
+function areaOf(contentId: string): { q: number; r: number }[] {
+  const mapId = runtime.campaign.activeMapId!;
+  return runtime.requireMap(mapId).contents.get(contentId)!.area;
+}
+
+/** A PC token at the origin, with a claimed seat, so gates can fire. */
+function party(): { mapId: string; charId: string; tokenId: string; seat: SeatRecord } {
+  const mapId = runtime.campaign.activeMapId!;
+  dm({
+    kind: 'character.create',
+    character: {
+      name: 'Scout',
+      color: '#00aa00',
+      glyph: '🏹',
+      speed: 30,
+      skills: { perception: 4, survival: 2 },
+      extra: { bio: '', appearance: '', goals: '', inventory: '', notes: '' },
+    },
+  } as never);
+  const charId = [...runtime.characters.keys()][0]!;
+  const seat = runtime.createSeat('player', 'Alice');
+  asSeat(seat, { kind: 'seat.claimCharacter', characterId: charId } as never);
+  seat.characterId = runtime.seats.get(seat.id)!.characterId;
+  dm({
+    kind: 'token.create',
+    mapId,
+    q: 0,
+    r: 0,
+    tokenKind: 'pc',
+    characterId: charId,
+    label: '',
+    color: '#00aa00',
+    glyph: '',
+    playerVisible: true,
+  } as never);
+  const tokenId = [...runtime.requireMap(mapId).tokens.keys()][0]!;
+  return { mapId, charId, tokenId, seat };
+}
+
+describe('content.area: the command schema', () => {
+  it('accepts add-only, remove-only and both; rejects neither', () => {
+    const base = { id: 'x1', kind: 'content.area' as const, contentId: 'c1' };
+    expect(ClientCommandSchema.safeParse({ ...base, add: [{ q: 1, r: 1 }] }).success).toBe(true);
+    expect(ClientCommandSchema.safeParse({ ...base, remove: [{ q: 1, r: 1 }] }).success).toBe(true);
+    expect(
+      ClientCommandSchema.safeParse({ ...base, add: [{ q: 1, r: 1 }], remove: [] }).success,
+    ).toBe(true);
+    expect(ClientCommandSchema.safeParse(base).success).toBe(false);
+  });
+
+  it('caps each list at 5000 cells', () => {
+    const cells = Array.from({ length: 5001 }, (_, i) => ({ q: i, r: 0 }));
+    const parsed = ClientCommandSchema.safeParse({
+      id: 'x2',
+      kind: 'content.area',
+      contentId: 'c1',
+      add: cells,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('content.area: merging', () => {
+  it('adds hexes to the stored footprint', () => {
+    const content = region('Forest of Wyrms');
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 7, r: 0 },
+        { q: 8, r: 0 },
+      ],
+    } as never);
+    expect(areaOf(content.id)).toEqual([
+      { q: 6, r: 0 },
+      { q: 7, r: 0 },
+      { q: 8, r: 0 },
+    ]);
+  });
+
+  it('dedupes by hex key — repainting the same cells is a no-op', () => {
+    const content = region('Forest of Wyrms');
+    dm({ kind: 'content.area', contentId: content.id, add: [{ q: 7, r: 0 }] } as never);
+    const undoDepth = runtime.undoStack.length;
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 6, r: 0 },
+        { q: 7, r: 0 },
+        { q: 7, r: 0 },
+      ],
+    } as never);
+    expect(areaOf(content.id)).toEqual([
+      { q: 6, r: 0 },
+      { q: 7, r: 0 },
+    ]);
+    // Nothing changed, so the stroke did not stack another undo entry.
+    expect(runtime.undoStack.length).toBe(undoDepth);
+  });
+
+  it('never stores the anchor, and ignores a request to remove it', () => {
+    const content = region('Forest of Wyrms');
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 5, r: 0 }, // the anchor — an implicit member
+        { q: 7, r: 0 },
+      ],
+    } as never);
+    expect(areaOf(content.id)).toEqual([
+      { q: 6, r: 0 },
+      { q: 7, r: 0 },
+    ]);
+
+    dm({ kind: 'content.area', contentId: content.id, remove: [{ q: 5, r: 0 }] } as never);
+    const after = runtime.requireMap(runtime.campaign.activeMapId!).contents.get(content.id)!;
+    expect(after.q).toBe(5);
+    expect(after.r).toBe(0);
+    expect(after.area).toEqual([
+      { q: 6, r: 0 },
+      { q: 7, r: 0 },
+    ]);
+  });
+
+  it('removes hexes, ignoring ones that were never members', () => {
+    const content = region('Forest of Wyrms');
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 7, r: 0 },
+        { q: 8, r: 0 },
+      ],
+    } as never);
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      remove: [
+        { q: 7, r: 0 },
+        { q: 40, r: 40 },
+      ],
+    } as never);
+    expect(areaOf(content.id)).toEqual([
+      { q: 6, r: 0 },
+      { q: 8, r: 0 },
+    ]);
+  });
+
+  it('applies add and remove in one stroke (remove wins on a collision)', () => {
+    const content = region('Forest of Wyrms');
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [{ q: 7, r: 0 }],
+      remove: [{ q: 6, r: 0 }],
+    } as never);
+    expect(areaOf(content.id)).toEqual([{ q: 7, r: 0 }]);
+  });
+
+  it('survives a round trip through the database', () => {
+    const mapId = runtime.campaign.activeMapId!;
+    const content = region('Serpent Hills');
+    dm({ kind: 'content.area', contentId: content.id, add: [{ q: 7, r: 0 }] } as never);
+    store.forget(runtime.id);
+    const reloaded = store.getCampaign(runtime.id)!;
+    expect(reloaded.requireMap(mapId).contents.get(content.id)!.area).toEqual([
+      { q: 6, r: 0 },
+      { q: 7, r: 0 },
+    ]);
+  });
+
+  it('rejects an unknown content id', () => {
+    expect(() =>
+      dm({ kind: 'content.area', contentId: 'nope', add: [{ q: 1, r: 1 }] } as never),
+    ).toThrow(/not found/i);
+  });
+});
+
+describe('content.area: knowledge re-evaluation', () => {
+  it('growing a region over a standing party opens its entering gate', () => {
+    const { tokenId, seat } = party();
+    const content = region('Forest of Wyrms', [
+      { id: null, text: 'You are among the wyrm-trees', gate: { kind: 'auto' }, sortOrder: 0 },
+    ]);
+    // Two hexes clear of the footprint (anchor 5,0 plus 6,0).
+    asSeat(seat, { kind: 'token.move', tokenId, q: 9, r: 0 } as never);
+    expect(runtime.discoveries.size).toBe(0);
+
+    // The brush spreads the forest out to where the party is standing: no one
+    // moved, but they are inside the region now.
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 7, r: 0 },
+        { q: 8, r: 0 },
+        { q: 9, r: 0 },
+      ],
+    } as never);
+    expect(runtime.discoveries.size).toBe(1);
+    expect([...runtime.discoveries.values()][0]!.locates).toBe(true);
+  });
+
+  it('shrinking a region leaves existing discoveries alone', () => {
+    const { tokenId, seat } = party();
+    const content = region('Forest of Wyrms', [
+      { id: null, text: 'You are among the wyrm-trees', gate: { kind: 'auto' }, sortOrder: 0 },
+    ]);
+    asSeat(seat, { kind: 'token.move', tokenId, q: 6, r: 0 } as never);
+    expect(runtime.discoveries.size).toBe(1);
+    dm({ kind: 'content.area', contentId: content.id, remove: [{ q: 6, r: 0 }] } as never);
+    expect(areaOf(content.id)).toEqual([]);
+    expect(runtime.discoveries.size).toBe(1); // learned is learned
+  });
+});
+
+describe('content.area: undo and authority', () => {
+  it('undo restores the footprint the stroke started from', () => {
+    const content = region('Forest of Wyrms');
+    dm({
+      kind: 'content.area',
+      contentId: content.id,
+      add: [
+        { q: 7, r: 0 },
+        { q: 8, r: 0 },
+      ],
+    } as never);
+    expect(areaOf(content.id)).toHaveLength(3);
+    dm({ kind: 'undo' } as never);
+    expect(areaOf(content.id)).toEqual([{ q: 6, r: 0 }]);
+  });
+
+  it('undo of a removal puts the hexes back', () => {
+    const content = region('Forest of Wyrms');
+    dm({ kind: 'content.area', contentId: content.id, remove: [{ q: 6, r: 0 }] } as never);
+    expect(areaOf(content.id)).toEqual([]);
+    dm({ kind: 'undo' } as never);
+    expect(areaOf(content.id)).toEqual([{ q: 6, r: 0 }]);
+  });
+
+  it('merges the flushes of one drag into a single undo step', () => {
+    const content = region('Forest of Wyrms');
+    const depth = runtime.undoStack.length;
+    // A drag flushes every ~180ms; each flush is its own command.
+    dm({ kind: 'content.area', contentId: content.id, add: [{ q: 7, r: 0 }] } as never);
+    dm({ kind: 'content.area', contentId: content.id, add: [{ q: 8, r: 0 }] } as never);
+    dm({ kind: 'content.area', contentId: content.id, add: [{ q: 9, r: 0 }] } as never);
+    expect(runtime.undoStack.length).toBe(depth + 1);
+    dm({ kind: 'undo' } as never);
+    expect(areaOf(content.id)).toEqual([{ q: 6, r: 0 }]);
+  });
+
+  it('keeps a different region on its own undo step', () => {
+    const a = region('Forest of Wyrms');
+    const b = region('Serpent Hills');
+    dm({ kind: 'content.area', contentId: a.id, add: [{ q: 7, r: 0 }] } as never);
+    dm({ kind: 'content.area', contentId: b.id, add: [{ q: 8, r: 0 }] } as never);
+    dm({ kind: 'undo' } as never);
+    expect(areaOf(b.id)).toEqual([{ q: 6, r: 0 }]);
+    expect(areaOf(a.id)).toHaveLength(2);
+  });
+
+  it('is DM-only', () => {
+    const content = region('Forest of Wyrms');
+    const player = runtime.createSeat('player', 'Bob');
+    expect(() =>
+      asSeat(player, {
+        kind: 'content.area',
+        contentId: content.id,
+        add: [{ q: 7, r: 0 }],
+      } as never),
+    ).toThrow(/DM/);
+    expect(areaOf(content.id)).toEqual([{ q: 6, r: 0 }]);
+  });
+});

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -624,6 +624,77 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, found.mapId));
   }) as Handler,
 
+  /**
+   * Region brush strokes (issue #108): a delta on one content item's
+   * footprint. Add/remove merge into the stored area by hex key, the anchor
+   * is never stored (it's an implicit member, and removing it is a no-op),
+   * and growing a footprint re-runs the knowledge engine — a party standing
+   * where the region just spread has now "entered" it.
+   */
+  'content.area': ((cmd: Extract<ClientCommand, { kind: 'content.area' }>, ctx: Ctx) => {
+    requireDm(ctx);
+    let found: Content | null = null;
+    for (const rt of ctx.runtime.mapStates.values()) {
+      const c = rt.contents.get(cmd.contentId);
+      if (c) { found = c; break; }
+    }
+    if (!found) throw new Error('Content not found');
+    const anchorKey = hexKey(found.q, found.r);
+    const cells = new Map<string, { q: number; r: number }>();
+    for (const cell of found.area) cells.set(hexKey(cell.q, cell.r), { q: cell.q, r: cell.r });
+    for (const cell of cmd.add ?? []) {
+      const key = hexKey(cell.q, cell.r);
+      if (key === anchorKey) continue; // the anchor is always a member
+      cells.set(key, { q: cell.q, r: cell.r });
+    }
+    for (const cell of cmd.remove ?? []) cells.delete(hexKey(cell.q, cell.r));
+    const area = [...cells.values()];
+    const priorArea = found.area;
+    if (area.length === priorArea.length && area.every((c, i) => {
+      const p = priorArea[i];
+      return p && p.q === c.q && p.r === c.r;
+    })) {
+      return; // stroke changed nothing (repainting hexes already in the area)
+    }
+    const mapId = found.mapId;
+    const title = found.title;
+    ctx.runtime.upsertContent({ ...found, area });
+    // One drag is one undo. A stroke flushes several times on its way across
+    // the map, so consecutive deltas on the same region within a short window
+    // merge — keeping the EARLIEST area, the one the drag started from.
+    const now = Date.now();
+    const top = ctx.runtime.undoStack[ctx.runtime.undoStack.length - 1];
+    if (
+      top &&
+      top.kind === 'content.area' &&
+      top.mapId === mapId &&
+      now - top.at < 3000 &&
+      top.restore?.has(cmd.contentId)
+    ) {
+      top.at = now;
+    } else {
+      const restore = new Map<string, unknown>([[cmd.contentId, priorArea]]);
+      ctx.runtime.pushUndo({
+        at: now,
+        kind: 'content.area',
+        mapId,
+        description: `restore the area of "${title}"`,
+        restore,
+        run: (runtime) => {
+          for (const [contentId, priorCells] of restore) {
+            const current = runtime.mapStates.get(mapId)?.contents.get(contentId);
+            if (current) {
+              runtime.upsertContent({ ...current, area: priorCells as { q: number; r: number }[] });
+            }
+          }
+        },
+      });
+    }
+    // A grown footprint can open entering-the-region gates for whoever is
+    // already standing there; a shrunk one costs nothing to re-evaluate.
+    deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, found.mapId));
+  }) as Handler,
+
   'view.map': ((_cmd: Extract<ClientCommand, { kind: 'view.map' }>, _ctx: Ctx) => {
     // Handled at the connection layer (per-connection state); never dispatched.
     throw new Error('view.map is connection-scoped');

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -9,6 +9,7 @@ import {
   TravelPaceSchema,
   EncounterTableSchema,
   FogStateSchema,
+  HexRefSchema,
   INHERITABLE_MAP_FIELDS,
   MarkerSchema,
   TerrainIdSchema,
@@ -448,6 +449,25 @@ export const ContentMoveCommand = z.object({
   r: z.number().int(),
 });
 
+/**
+ * DM: grow or shrink a region footprint by whole brush strokes (issue #108).
+ * A delta, not a replacement: painting sends only the hexes the stroke
+ * touched, so a 200-hex forest never resends its whole payload — and two
+ * strokes in flight can't clobber each other. The anchor hex is an implicit
+ * member and is silently ignored in both lists.
+ */
+export const ContentAreaCommand = z
+  .object({
+    ...base,
+    kind: z.literal('content.area'),
+    contentId: z.string(),
+    add: z.array(HexRefSchema).max(5000).optional(),
+    remove: z.array(HexRefSchema).max(5000).optional(),
+  })
+  .refine((c) => c.add !== undefined || c.remove !== undefined, {
+    message: 'content.area needs add or remove',
+  });
+
 /** Any seat: view a different map on this connection (handled per-connection). */
 export const ViewMapCommand = z.object({
   ...base,
@@ -647,6 +667,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   ContentSetEnabledCommand,
   ContentSetQuestCommand,
   ContentMoveCommand,
+  ContentAreaCommand,
   ViewMapCommand,
   TrailUpsertCommand,
   TrailDeleteCommand,


### PR DESCRIPTION
Closes #108

Region footprints (#69) were click-per-hex. They are now painted with the same brush as terrain, from the content dialog or from a dedicated tool.

## What changed

**Server / protocol**
- New `content.area { contentId, add?, remove? }` (DM-only, each list capped at 5000, at least one required). It merges into the content's `area` by hex key, never stores the anchor hex (it is an implicit member, and removing it is a no-op), persists through the existing `upsertContent`, and re-runs `evaluateKnowledge` + `deliverDiscoveries` for the map — growing a region over a party that is already standing there opens its entering gate.
- Undo merges consecutive deltas on the same content within 3s into one entry (the trick `recordCellUndo` plays for terrain), so one drag is one undo rather than one per mid-stroke flush.

**Engine**
- `beginStroke`/`strokeApply`/`flushStroke` gain a `region` mode, reusing the terrain painter's brush-radius cell expansion and `ui.brushRadius`. With `ui.areaPaint` set (the dialog) a stroke only edits the local draft — nothing is sent, and the dialog's save still commits it as `content.upsert`, because a brand-new item has no id yet. With the Region tool it sends one `content.area` per flush. `ui.regionErase` is the add/remove polarity, latched at stroke start so it cannot flip mid-drag.
- The #69 `areaHighlight` layer doubles as the live preview: optimistic during a stroke, resynced from the snapshot afterwards (never mid-stroke).

**Client UI**
- Region tool in the DM toolbar after Trail, hotkey `g`. Its panel has a target dropdown of the current map's content (region-type and has-area items first, formatted "glyph title (N hexes)"), a hint to create one with the Content tool when the map is empty, the brush trio, an Add/Remove toggle, and the target's live hex count.
- The content dialog's collapsed paint bar drags instead of click-toggling, and gains the same brush trio and Add/Remove toggle. Escape/Done semantics are unchanged (commit on exit).
- Player rendering and the knowledge/filter path are untouched.

## Tests

New `packages/server/src/content-area.test.ts` (16 tests): schema shape (add-only / remove-only / both / neither, the 5000 cap), add + remove merging, dedupe, anchor exclusion in both directions, database round trip, knowledge re-evaluation on grow, undo restore and stroke merging, and DM-only.

`pnpm typecheck && pnpm test && pnpm build` green.

## Manual smoke

Against the built client on a scratch campaign: a drag on the Region tool produced `content.area` frames of 1 then 7 cells (one send per flush, the first-cell flush plus the batched rest), erase produced `remove:` frames, Cmd+Z reverted the whole stroke in one step, and a drag in the dialog's paint mode sent **zero** frames and committed as a single `content.upsert` with the full area on save.

## Docs notes

`docs/AI-DEVELOPMENT.md` gains a gotcha entry for #108: the two flavours of the region stroke (dialog draft vs. tool delta), that `ui.brushRadius` is deliberately shared with terrain, that `ui.regionErase` latches at stroke start, and that the server never stores the anchor and merges undo entries per drag. `DESIGN.md` needed no change — content areas are not described there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)