### PR TITLE
Region manager: auto-detect area and terrain fill

### DIFF
--- a/docs/AI-DEVELOPMENT.md
+++ b/docs/AI-DEVELOPMENT.md
@@ -152,6 +152,27 @@ player-facing data).
   standing party opens its entering gate), and merges consecutive deltas on
   one content within 3s into a single undo entry — the same trick
   `recordCellUndo` plays for terrain, so one drag is one undo.
+- **Region auto-detect is a proposal, not a write** (#113): the region manager
+  (`components/RegionManagerDialog.tsx`, opened from the Region tool panel)
+  runs detection client-side and parks the result in `ui.areaProposal` +
+  an `areaHighlight` carrying `proposal: true` (the engine tints those amber
+  and `syncRegionHighlight` refuses to touch the highlight while a proposal
+  stands). Accept sends the usual `content.area` delta — nothing new server
+  side. The traversal itself is `shared/rules/flood.ts` (`floodFill` with an
+  `accept` predicate, unit-tested); only pixel sampling lives in the client
+  (`engine/regionDetect.ts`), because there is no client test runner. Colour
+  mode reads the BOTTOM-most visible non-`dmOnly` image layer, samples a
+  5-point kernel per hex against a FIXED seed colour (a running mean drifts
+  across gradients) with weighted-RGB (2/4/3) distance on a 0–441 scale, and
+  is bounded by both a cell cap and a 60-hex radius. Its transform is the
+  sprite's: `image = (world − layer.xy) / layer.scale` — get that backwards
+  and the proposal lands on the wrong part of the map.
+- **`content.applyTerrain`** (#113) paints one terrain over a whole footprint
+  and, by default, skips hexes that any OTHER content's non-empty area also
+  covers — anchor-only pins never block, so a mill inside a wood gets painted
+  with the wood. It reuses `recordCellUndo('terrain', …)`, so a fill merges
+  with neighbouring brush strokes into one undo, and reports painted/skipped
+  counts as a DM-only `note` log entry rather than a command reply.
 - **Seat cookies are per-hostname.** To run a DM and a player session against
   one dev server, open one on `localhost` and one on `127.0.0.1` — separate
   cookie jars.

--- a/packages/client/src/components/RegionManagerDialog.tsx
+++ b/packages/client/src/components/RegionManagerDialog.tsx
@@ -1,0 +1,608 @@
+import React, { useMemo, useState } from 'react';
+import {
+  CONTENT_TYPE_GLYPHS,
+  TERRAINS,
+  TERRAIN_IDS,
+  contentCells,
+  hexKey,
+  isFullContent,
+  type Content,
+  type HexCoord,
+  type HexLayout,
+  type MapInfo,
+  type TerrainId,
+} from '@hexcrawl/shared';
+import { activeMap, useSession } from '../stores/session.js';
+import { useUi } from '../stores/ui.js';
+import { send } from '../ws.js';
+import { Button, EmptyNote, Input, Select, cx } from '../ui/kit.js';
+import { baseImageLayer, detectByImage, detectByTerrain } from '../engine/regionDetect.js';
+
+/**
+ * DM region manager (issue #113): every region on the map in one place, with
+ * the two bulk operations hand-painting can't do — recommend a footprint from
+ * the map itself, and paint one terrain across a footprint.
+ *
+ * The preview flow mirrors the content dialog's paint bar: running a
+ * detection collapses this dialog to a floating Accept/Cancel bar so the DM
+ * can actually see the proposal on the map, and the component stays mounted
+ * so the settings that produced it survive a Cancel.
+ */
+
+/** `content.area` accepts 5000 cells per message; a huge accept is chunked. */
+const AREA_CHUNK = 5000;
+
+/**
+ * The auto-detect settings. They live in the dialog root rather than in the
+ * detail pane because the detail pane unmounts while the proposal bar is up —
+ * a tolerance the DM tuned to 60 must still be 60 after a Cancel.
+ */
+interface DetectSettings {
+  mode: 'terrain' | 'color';
+  terrains: TerrainId[];
+  tolerance: number;
+  maxCells: number;
+}
+
+export function RegionManagerDialog() {
+  const state = useSession((s) => s.state);
+  const map = activeMap(state);
+  const setUi = useUi((s) => s.set);
+  const areaHighlight = useUi((s) => s.areaHighlight);
+  const areaProposal = useUi((s) => s.areaProposal);
+
+  // Regions are contents typed 'region' plus anything else that has grown an
+  // area — any content type can carry a footprint, and a 40-hex "landmark"
+  // is a region in every way that matters here.
+  const regions = (state?.mapState?.contents ?? [])
+    .filter(isFullContent)
+    .filter((c) => c.type === 'region' || c.area.length > 0)
+    .sort((a, b) => a.title.localeCompare(b.title)) as Content[];
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    useUi.getState().regionTargetId ?? regions[0]?.id ?? null,
+  );
+  const selected = regions.find((r) => r.id === selectedId) ?? regions[0] ?? null;
+
+  const terrainAt = useMemo(() => {
+    const m = new Map<string, TerrainId>();
+    for (const cell of state?.mapState?.hexes ?? []) m.set(hexKey(cell.q, cell.r), cell.terrain);
+    return m;
+  }, [state?.mapState?.hexes]);
+
+  const [detect, setDetect] = useState<DetectSettings>({
+    mode: 'terrain',
+    terrains: [],
+    tolerance: 25,
+    maxCells: 800,
+  });
+  // The terrain chips default to the selected region's own terrain; the rest
+  // of the settings deliberately carry across regions.
+  const [defaultsFor, setDefaultsFor] = useState<string | null>(null);
+  if (selected && defaultsFor !== selected.id) {
+    const anchorTerrain = terrainAt.get(hexKey(selected.q, selected.r)) ?? null;
+    setDefaultsFor(selected.id);
+    setDetect((d) => ({ ...d, terrains: anchorTerrain ? [anchorTerrain] : [] }));
+  }
+
+  const close = () => {
+    setUi('areaProposal', null);
+    setUi('areaHighlight', null);
+    setUi('regionManagerOpen', false);
+  };
+
+  if (!map) return null;
+
+  // Collapsed: a proposal is on the map and the dialog is in the way.
+  if (areaProposal) {
+    return <ProposalBar proposal={areaProposal} regions={regions} />;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-2 sm:p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div className="bg-ink-850 border border-ink-600 rounded-xl shadow-2xl w-full min-w-0 max-w-5xl h-[85dvh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-ink-700 shrink-0">
+          <h2 className="font-semibold text-ink-100">Regions</h2>
+          <Button variant="ghost" size="sm" onClick={close} aria-label="Close">
+            ✕
+          </Button>
+        </div>
+
+        <div className="flex-1 min-h-0 flex">
+          <div className="w-44 sm:w-64 shrink-0 border-r border-ink-700 overflow-y-auto p-2 space-y-1.5">
+            {regions.length === 0 && (
+              <EmptyNote>
+                No regions on this map yet. Create one with the Content tool (C) — anything with an
+                area shows up here.
+              </EmptyNote>
+            )}
+            {regions.map((r) => (
+              <RegionCard
+                key={r.id}
+                region={r}
+                terrainAt={terrainAt}
+                selected={r.id === selected?.id}
+                onSelect={() => setSelectedId(r.id)}
+              />
+            ))}
+          </div>
+
+          <div className="flex-1 min-w-0 overflow-y-auto p-4">
+            {selected ? (
+              <RegionDetail
+                key={selected.id}
+                region={selected}
+                map={map}
+                terrainAt={terrainAt}
+                regions={regions}
+                detect={detect}
+                setDetect={setDetect}
+                highlighted={
+                  areaHighlight?.contentId === selected.id && !areaHighlight.proposal
+                }
+                onClose={close}
+              />
+            ) : (
+              <EmptyNote>Pick a region on the left.</EmptyNote>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Terrain histogram over a footprint, most common first. */
+function terrainSummary(
+  region: Content,
+  terrainAt: Map<string, TerrainId>,
+): { terrain: TerrainId | null; count: number }[] {
+  const counts = new Map<TerrainId | null, number>();
+  for (const cell of contentCells(region)) {
+    const t = terrainAt.get(hexKey(cell.q, cell.r)) ?? null;
+    counts.set(t, (counts.get(t) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([terrain, count]) => ({ terrain, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function summaryText(rows: { terrain: TerrainId | null; count: number }[]): string {
+  return rows
+    .slice(0, 3)
+    .map((row) => `${row.terrain ? TERRAINS[row.terrain].label : 'unpainted'} ${row.count}`)
+    .join(' · ');
+}
+
+function RegionCard({
+  region,
+  terrainAt,
+  selected,
+  onSelect,
+}: {
+  region: Content;
+  terrainAt: Map<string, TerrainId>;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const size = contentCells(region).length;
+  const rows = terrainSummary(region, terrainAt);
+  return (
+    <button
+      onClick={onSelect}
+      className={cx(
+        'w-full text-left rounded-lg border px-2 py-1.5 cursor-pointer',
+        selected ? 'border-brass-500 bg-brass-500/10' : 'border-ink-700 hover:bg-ink-800',
+      )}
+    >
+      <div className={cx('text-sm truncate', selected ? 'text-brass-300' : 'text-ink-200')}>
+        {region.glyph || CONTENT_TYPE_GLYPHS[region.type]} {region.title}
+      </div>
+      <div className="text-[11px] text-ink-400">
+        {size} hex{size === 1 ? '' : 'es'}
+      </div>
+      <div className="text-[10px] text-ink-500 truncate" title={summaryText(rows)}>
+        {summaryText(rows)}
+      </div>
+    </button>
+  );
+}
+
+function layoutOf(map: MapInfo): HexLayout {
+  return {
+    orientation: map.orientation,
+    size: map.hexSize,
+    origin: { x: map.originX, y: map.originY },
+  };
+}
+
+function RegionDetail({
+  region,
+  map,
+  terrainAt,
+  regions,
+  detect,
+  setDetect,
+  highlighted,
+  onClose,
+}: {
+  region: Content;
+  map: MapInfo;
+  terrainAt: Map<string, TerrainId>;
+  regions: Content[];
+  detect: DetectSettings;
+  setDetect: React.Dispatch<React.SetStateAction<DetectSettings>>;
+  highlighted: boolean;
+  onClose: () => void;
+}) {
+  const setUi = useUi((s) => s.set);
+  const imageLayers = useSession((s) => s.state?.mapState?.imageLayers) ?? [];
+  const baseLayer = baseImageLayer(imageLayers);
+  const anchorTerrain = terrainAt.get(hexKey(region.q, region.r)) ?? null;
+  const rows = terrainSummary(region, terrainAt);
+  const size = contentCells(region).length;
+
+  const { mode, terrains, tolerance, maxCells } = detect;
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [fill, setFill] = useState<TerrainId | 'erase'>(
+    (rows[0]?.terrain ?? anchorTerrain ?? 'plains') as TerrainId,
+  );
+  const [skipOtherRegions, setSkipOtherRegions] = useState(true);
+
+  const toggleTerrain = (id: TerrainId) =>
+    setDetect((d) => ({
+      ...d,
+      terrains: d.terrains.includes(id)
+        ? d.terrains.filter((t) => t !== id)
+        : [...d.terrains, id],
+    }));
+
+  const preview = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const anchor: HexCoord = { q: region.q, r: region.r };
+      const detected =
+        mode === 'terrain'
+          ? detectByTerrain({
+              hexes: useSession.getState().state?.mapState?.hexes ?? [],
+              anchor,
+              terrains: new Set(terrains),
+              limits: { maxCells },
+            })
+          : await detectByImage({
+              layer: baseLayer!,
+              layout: layoutOf(map),
+              anchor,
+              tolerance,
+              limits: { maxCells },
+            });
+      const cells = [anchor, ...detected];
+      setUi('areaProposal', { contentId: region.id, cells });
+      setUi('areaHighlight', { contentId: region.id, cells, proposal: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Detection failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const applyFill = () => {
+    const overlapping = countOverlap(region, regions);
+    if (!skipOtherRegions && overlapping > 0) {
+      const ok = confirm(
+        `Overwrite terrain on ${overlapping} hex${overlapping === 1 ? '' : 'es'} that belong to another region?`,
+      );
+      if (!ok) return;
+    }
+    send({
+      kind: 'content.applyTerrain',
+      contentId: region.id,
+      terrain: fill === 'erase' ? null : fill,
+      skipOtherRegions,
+    });
+  };
+
+  const rename = (title: string) => {
+    const next = title.trim();
+    if (!next || next === region.title) return;
+    // `content.upsert` sets exactly what it is sent (clues included), so a
+    // rename has to resend the whole item — dropping `clues` would wipe them.
+    send({
+      kind: 'content.upsert',
+      content: {
+        id: region.id,
+        mapId: region.mapId,
+        q: region.q,
+        r: region.r,
+        area: region.area,
+        type: region.type,
+        title: next,
+        dmNotes: region.dmNotes,
+        glyph: region.glyph,
+        showLabel: region.showLabel,
+        scaleVisibility: region.scaleVisibility,
+        wikiPage: region.wikiPage,
+        enabled: region.enabled,
+        knownLocation: region.knownLocation,
+        quest: region.quest,
+        clues: region.clues.map((c) => ({
+          id: c.id,
+          text: c.text,
+          gate: c.gate,
+          sortOrder: c.sortOrder,
+          indicatesDirection: c.indicatesDirection,
+          revealsLocation: c.revealsLocation,
+        })),
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Input
+          key={`name-${region.id}-${region.title}`}
+          defaultValue={region.title}
+          maxLength={120}
+          onBlur={(e) => rename(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+        />
+        <Button
+          size="sm"
+          variant={highlighted ? 'primary' : 'ghost'}
+          title="Wash this footprint over the map"
+          onClick={() =>
+            setUi(
+              'areaHighlight',
+              highlighted ? null : { contentId: region.id, cells: contentCells(region) },
+            )
+          }
+        >
+          {highlighted ? '◉ Highlighted' : '◎ Highlight'}
+        </Button>
+      </div>
+      <p className="text-xs text-ink-400">
+        Anchor {region.q}, {region.r} · {size} hex{size === 1 ? '' : 'es'} ·{' '}
+        {summaryText(rows) || 'unpainted'}
+      </p>
+
+      <section className="border border-ink-700 rounded-lg p-3 space-y-2">
+        <h3 className="text-[11px] uppercase tracking-wider text-ink-400 font-semibold">
+          Auto-detect the area
+        </h3>
+        <div className="flex items-center gap-2">
+          <Select
+            value={mode}
+            onChange={(e) =>
+              setDetect((d) => ({ ...d, mode: e.target.value as 'terrain' | 'color' }))
+            }
+            className="!w-44"
+          >
+            <option value="terrain">Terrain match</option>
+            <option value="color" disabled={!baseLayer}>
+              Map colours{baseLayer ? '' : ' (no map image)'}
+            </option>
+          </Select>
+          {!baseLayer && (
+            <span className="text-[11px] text-ink-500">
+              Add a map image layer to detect against the art.
+            </span>
+          )}
+        </div>
+
+        {mode === 'terrain' ? (
+          <div>
+            <p className="text-[11px] text-ink-400 mb-1">
+              Grow from the anchor across these terrains (unpainted hexes always stop the fill):
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {TERRAIN_IDS.map((id) => (
+                <button
+                  key={id}
+                  onClick={() => toggleTerrain(id)}
+                  className={cx(
+                    'px-2 py-0.5 rounded-full text-[11px] cursor-pointer border',
+                    terrains.includes(id)
+                      ? 'border-brass-500 bg-brass-500/15 text-brass-300'
+                      : 'border-ink-700 text-ink-300 hover:bg-ink-700',
+                  )}
+                >
+                  <span
+                    className="inline-block w-2 h-2 rounded-sm mr-1 align-middle"
+                    style={{ background: TERRAINS[id].color }}
+                  />
+                  {TERRAINS[id].label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div>
+            <label className="text-[11px] text-ink-400 flex items-center gap-2">
+              Colour tolerance
+              <input
+                type="range"
+                min={5}
+                max={80}
+                value={tolerance}
+                onChange={(e) => setDetect((d) => ({ ...d, tolerance: Number(e.target.value) }))}
+                className="flex-1"
+              />
+              <span className="w-8 text-right text-ink-200">{tolerance}</span>
+            </label>
+            <p className="text-[11px] text-ink-500 mt-1">
+              Every hex is compared against the anchor's colour on{' '}
+              {baseLayer ? baseLayer.name : 'the base image'} — low values hug one flat colour,
+              high values cross shading.
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <label className="text-[11px] text-ink-400 flex items-center gap-1.5">
+            Max hexes
+            <Input
+              type="number"
+              min={1}
+              max={3000}
+              className="!w-24"
+              value={maxCells}
+              onChange={(e) =>
+                setDetect((d) => ({
+                  ...d,
+                  maxCells: Math.min(3000, Math.max(1, Math.round(Number(e.target.value) || 1))),
+                }))
+              }
+            />
+          </label>
+          <Button
+            size="sm"
+            variant="primary"
+            disabled={busy || (mode === 'color' && !baseLayer)}
+            onClick={() => void preview()}
+          >
+            {busy ? 'Detecting…' : '🔍 Preview'}
+          </Button>
+          {error && <span className="text-[11px] text-ember-500">{error}</span>}
+        </div>
+      </section>
+
+      <section className="border border-ink-700 rounded-lg p-3 space-y-2">
+        <h3 className="text-[11px] uppercase tracking-wider text-ink-400 font-semibold">
+          Terrain fill
+        </h3>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Select
+            value={fill}
+            onChange={(e) => setFill(e.target.value as TerrainId | 'erase')}
+            className="!w-44"
+          >
+            {TERRAIN_IDS.map((id) => (
+              <option key={id} value={id}>
+                {TERRAINS[id].label}
+              </option>
+            ))}
+            <option value="erase">⌫ Erase terrain</option>
+          </Select>
+          <Button size="sm" variant="primary" onClick={applyFill}>
+            Apply to {size} hex{size === 1 ? '' : 'es'}
+          </Button>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-ink-200 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={skipOtherRegions}
+            onChange={(e) => setSkipOtherRegions(e.target.checked)}
+          />
+          Skip hexes in other regions
+          <span className="text-[11px] text-ink-400">
+            ({countOverlap(region, regions)} shared)
+          </span>
+        </label>
+      </section>
+
+      <div className="flex gap-2 flex-wrap">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setUi('contentDialogHex', { q: region.q, r: region.r });
+            setUi('editingContentId', region.id);
+            onClose();
+          }}
+        >
+          Open full editor
+        </Button>
+        <Button
+          size="sm"
+          variant="danger"
+          className="ml-auto"
+          disabled={region.area.length === 0}
+          onClick={() => {
+            if (confirm(`Clear the ${region.area.length}-hex area of "${region.title}"?`)) {
+              send({ kind: 'content.area', contentId: region.id, remove: region.area });
+            }
+          }}
+        >
+          Clear area
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** How many of this region's hexes another region also claims. */
+function countOverlap(region: Content, regions: Content[]): number {
+  const others = new Set<string>();
+  for (const other of regions) {
+    if (other.id === region.id || other.area.length === 0) continue;
+    for (const cell of contentCells(other)) others.add(hexKey(cell.q, cell.r));
+  }
+  return contentCells(region).filter((c) => others.has(hexKey(c.q, c.r))).length;
+}
+
+/**
+ * The collapsed state: the proposal is drawn on the map (amber, through the
+ * area-highlight layer) and this bar is all that's left of the dialog.
+ */
+function ProposalBar({
+  proposal,
+  regions,
+}: {
+  proposal: { contentId: string; cells: HexCoord[] };
+  regions: Content[];
+}) {
+  const setUi = useUi((s) => s.set);
+  const region = regions.find((r) => r.id === proposal.contentId) ?? null;
+
+  const cancel = () => {
+    setUi('areaProposal', null);
+    setUi('areaHighlight', null);
+  };
+
+  // What Accept would actually send: the proposal minus what the footprint
+  // already holds (the anchor included — the server ignores it either way).
+  const existing = new Set(region ? contentCells(region).map((c) => hexKey(c.q, c.r)) : []);
+  const add = proposal.cells.filter((c) => !existing.has(hexKey(c.q, c.r)));
+
+  const accept = () => {
+    if (region) {
+      for (let i = 0; i < add.length; i += AREA_CHUNK) {
+        send({
+          kind: 'content.area',
+          contentId: region.id,
+          add: add.slice(i, i + AREA_CHUNK),
+        });
+      }
+    }
+    cancel();
+  };
+
+  return (
+    <div className="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 flex-wrap justify-center max-w-[calc(100vw-1.5rem)] bg-ink-850/95 border border-brass-500/60 rounded-xl shadow-2xl px-4 py-2.5 backdrop-blur">
+      <span className="text-sm text-ink-100">
+        {proposal.cells.length} hex{proposal.cells.length === 1 ? '' : 'es'} proposed for{' '}
+        <span className="font-medium">{region?.title ?? 'this region'}</span>
+      </span>
+      <span className="text-xs text-ink-400">
+        {add.length} new hex{add.length === 1 ? '' : 'es'} would be added
+      </span>
+      <Button size="sm" variant="primary" onClick={accept} disabled={add.length === 0}>
+        Accept
+      </Button>
+      <Button size="sm" variant="ghost" onClick={cancel}>
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/packages/client/src/components/Toolbar.tsx
+++ b/packages/client/src/components/Toolbar.tsx
@@ -286,6 +286,13 @@ function RegionOptions() {
         </p>
         <RegionBrushControls />
       </div>
+      <button
+        className="w-full px-2 py-1 rounded text-xs cursor-pointer border border-ink-600 text-ink-200 hover:bg-ink-700"
+        title="Auto-detect footprints, fill terrain, rename (issue #113)"
+        onClick={() => useUi.getState().set('regionManagerOpen', true)}
+      >
+        ⚙ Manage regions…
+      </button>
     </div>
   );
 }

--- a/packages/client/src/engine/CanvasEngine.ts
+++ b/packages/client/src/engine/CanvasEngine.ts
@@ -306,6 +306,11 @@ export class CanvasEngine {
           this.drawHighlight(); // the brush ring follows the pointer in paint mode
         }
       }
+      // A cancelled/accepted proposal hands the highlight back to the region
+      // tool's own preview.
+      if (u.areaProposal !== prev.areaProposal && u.areaProposal === null) {
+        this.syncRegionHighlight();
+      }
       if (u.tool !== prev.tool || u.regionTargetId !== prev.regionTargetId) {
         this.syncRegionHighlight();
         if ((u.tool === 'region') !== (prev.tool === 'region')) {
@@ -850,23 +855,32 @@ export class CanvasEngine {
     g.clear();
     if (!this.layout) return;
     const ui = useUi.getState();
+    // An auto-detect recommendation (issue #113) is not the footprint yet, so
+    // it gets its own amber wash and a heavier outline — Pixi's Graphics has
+    // no dashed stroke, and weight reads at every zoom where dashes wouldn't.
+    const proposal = ui.areaPaint === null && ui.areaHighlight?.proposal === true;
     // "Painting" (a warmer wash) covers both authoring modes: the dialog's
     // draft and the Region tool's live target.
-    const painting = ui.areaPaint !== null || (ui.tool === 'region' && this.role === 'dm');
+    const painting =
+      !proposal && (ui.areaPaint !== null || (ui.tool === 'region' && this.role === 'dm'));
     const cells = ui.areaPaint?.cells ?? ui.areaHighlight?.cells ?? [];
     if (cells.length === 0) return;
-    const color = painting ? 0x6fae6a : 0x59a5c4;
+    const color = proposal ? 0xd9a441 : painting ? 0x6fae6a : 0x59a5c4;
     const corners = this.corners();
     for (const cell of cells) {
       const center = hexToPixel(this.layout, cell);
       g.poly(this.polyPoints(center, corners));
     }
-    g.fill({ color, alpha: painting ? 0.3 : 0.2 });
+    g.fill({ color, alpha: proposal ? 0.28 : painting ? 0.3 : 0.2 });
     for (const cell of cells) {
       const center = hexToPixel(this.layout, cell);
       g.poly(this.polyPoints(center, corners));
     }
-    g.stroke({ width: 1.5 / this.viewport.scale.x, color, alpha: 0.6 });
+    g.stroke({
+      width: (proposal ? 2.5 : 1.5) / this.viewport.scale.x,
+      color,
+      alpha: proposal ? 0.95 : 0.6,
+    });
   }
 
   /** The content item on this map with that id, if it's still there. */
@@ -883,6 +897,9 @@ export class CanvasEngine {
   private syncRegionHighlight(): void {
     if (this.stroke?.mode === 'region') return;
     const ui = useUi.getState();
+    // A pending auto-detect proposal owns the highlight until it's accepted
+    // or cancelled — a snapshot must not swap it back for the stored area.
+    if (ui.areaProposal) return;
     if (ui.tool !== 'region' || this.role !== 'dm') {
       // Leaving the tool takes its own preview with it; a highlight the DM
       // opened from a panel (a different item) stays put.

--- a/packages/client/src/engine/regionDetect.ts
+++ b/packages/client/src/engine/regionDetect.ts
@@ -1,0 +1,200 @@
+import {
+  FLOOD_MAX_CELLS,
+  FLOOD_MAX_RADIUS,
+  floodFill,
+  floodFillByTerrain,
+  hexKey,
+  hexToPixel,
+  type HexCell,
+  type HexCoord,
+  type HexLayout,
+  type ImageLayer,
+  type TerrainId,
+} from '@hexcrawl/shared';
+
+/**
+ * Region auto-detect (issue #113): recommend a footprint from a region's
+ * anchor hex. Two engines, one traversal — the flood fill itself lives in
+ * shared (`rules/flood.ts`, unit-tested); everything here is about deciding
+ * whether one hex belongs with the seed.
+ *
+ * Both return the recommended cells EXCLUDING the anchor (the anchor is an
+ * implicit member of every footprint, and `content.area` ignores it anyway).
+ */
+
+export interface DetectLimits {
+  maxCells?: number;
+  maxRadius?: number;
+}
+
+function withoutAnchor(cells: HexCoord[], anchor: HexCoord): HexCoord[] {
+  return cells.filter((c) => !(c.q === anchor.q && c.r === anchor.r));
+}
+
+/**
+ * Terrain match: contiguous hexes whose painted terrain is in `terrains`.
+ * Unpainted hexes stop the fill — an empty hex is the edge of the world, not
+ * a match for anything.
+ */
+export function detectByTerrain(opts: {
+  hexes: HexCell[];
+  anchor: HexCoord;
+  terrains: Set<TerrainId>;
+  limits?: DetectLimits;
+}): HexCoord[] {
+  const terrainAt = new Map<string, TerrainId>();
+  for (const cell of opts.hexes) terrainAt.set(hexKey(cell.q, cell.r), cell.terrain);
+  const cells = floodFillByTerrain(terrainAt, opts.anchor, opts.terrains, {
+    maxCells: opts.limits?.maxCells,
+    maxRadius: opts.limits?.maxRadius,
+  });
+  return withoutAnchor(cells, opts.anchor);
+}
+
+/**
+ * The base art for colour detection: the BOTTOM-most visible, player-visible
+ * image layer. A DM-only overlay (secret annotations, a grid tracing) is not
+ * what the region's colours live in, and the bottom layer is the sourcebook
+ * scan everything else is drawn over.
+ */
+export function baseImageLayer(layers: ImageLayer[]): ImageLayer | null {
+  const candidates = layers.filter((l) => l.visible && !l.dmOnly);
+  if (candidates.length === 0) return null;
+  return [...candidates].sort((a, b) => a.z - b.z)[0]!;
+}
+
+/** RGB triple, 0–255. */
+type Rgb = [number, number, number];
+
+/**
+ * Perceptually weighted RGB distance (the "low-cost approximation" weights
+ * 2/4/3). Plain Euclidean RGB over-weights blue, which on parchment-toned
+ * sourcebook art puts sea and sky closer together than the eye does. Range is
+ * 0 (identical) to ~441 (black vs white), which is the scale the tolerance
+ * slider (5–80) is calibrated against.
+ */
+function colorDistance(a: Rgb, b: Rgb): number {
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  return Math.sqrt(2 * dr * dr + 4 * dg * dg + 3 * db * db);
+}
+
+/** Above this, the source image is drawn down before it is read back. */
+const MAX_SAMPLE_DIMENSION = 4096;
+
+interface SampledImage {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+  /** Canvas pixels per source-image pixel (≤ 1 when the art was drawn down). */
+  drawScale: number;
+}
+
+/**
+ * Load an image layer's art and read it back ONCE. Uploads are served from
+ * the app's own origin (`/uploads`), so the canvas stays untainted and
+ * `getImageData` is allowed. Very large scans are drawn down first: one
+ * readback of a 12000px map would cost hundreds of megabytes, and hex-sized
+ * sampling doesn't need that resolution.
+ */
+async function loadImageData(path: string): Promise<SampledImage> {
+  const img = new Image();
+  img.src = path;
+  await img.decode();
+  const w = img.naturalWidth;
+  const h = img.naturalHeight;
+  if (!w || !h) throw new Error('Image has no pixels');
+  const drawScale = Math.min(1, MAX_SAMPLE_DIMENSION / Math.max(w, h));
+  const cw = Math.max(1, Math.round(w * drawScale));
+  const ch = Math.max(1, Math.round(h * drawScale));
+  const canvas = document.createElement('canvas');
+  canvas.width = cw;
+  canvas.height = ch;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) throw new Error('No 2D canvas context');
+  ctx.drawImage(img, 0, 0, cw, ch);
+  const data = ctx.getImageData(0, 0, cw, ch).data;
+  return { width: cw, height: ch, data, drawScale };
+}
+
+/** Average colour of a small kernel around a canvas point; null if off-image. */
+function sample(image: SampledImage, x: number, y: number, spread: number): Rgb | null {
+  const offsets: [number, number][] = [
+    [0, 0],
+    [-spread, 0],
+    [spread, 0],
+    [0, -spread],
+    [0, spread],
+  ];
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let n = 0;
+  for (const [dx, dy] of offsets) {
+    const px = Math.round(x + dx);
+    const py = Math.round(y + dy);
+    if (px < 0 || py < 0 || px >= image.width || py >= image.height) continue;
+    const i = (py * image.width + px) * 4;
+    // Fully transparent pixels carry no colour — treat them as off-image.
+    if (image.data[i + 3]! < 8) continue;
+    r += image.data[i]!;
+    g += image.data[i + 1]!;
+    b += image.data[i + 2]!;
+    n++;
+  }
+  if (n === 0) return null;
+  return [r / n, g / n, b / n];
+}
+
+/**
+ * Map-colour match: region-grow from the anchor across hexes whose sampled
+ * colour is within `tolerance` of the SEED hex's colour.
+ *
+ * The reference is fixed at the anchor's colour rather than a running mean of
+ * the accepted cells: a running mean drifts, so a gentle gradient (a coastal
+ * fade, a parchment vignette) would walk the fill clean off the region it
+ * started in. A fixed seed means the tolerance says exactly what it looks
+ * like it says — "within this much of where I clicked".
+ *
+ * The transform is the image layer's: a sprite is drawn at `layer.x/y` scaled
+ * by `layer.scale`, so world = layer.xy + imageXY * scale, and therefore
+ * imageXY = (world - layer.xy) / scale.
+ */
+export async function detectByImage(opts: {
+  layer: ImageLayer;
+  layout: HexLayout;
+  anchor: HexCoord;
+  /** 5–80 on the weighted-RGB scale above. */
+  tolerance: number;
+  limits?: DetectLimits;
+}): Promise<HexCoord[]> {
+  const image = await loadImageData(opts.layer.path);
+  const { layer, layout } = opts;
+  // World pixels → source-image pixels → canvas pixels.
+  const toCanvas = (p: { x: number; y: number }) => ({
+    x: ((p.x - layer.x) / layer.scale) * image.drawScale,
+    y: ((p.y - layer.y) / layer.scale) * image.drawScale,
+  });
+  // Kernel spread: a bit under half a hex, in canvas pixels.
+  const spread = Math.max(1, (0.4 * layout.size * image.drawScale) / layer.scale);
+  const colorOf = (hex: HexCoord): Rgb | null => {
+    const p = toCanvas(hexToPixel(layout, hex));
+    return sample(image, p.x, p.y, spread);
+  };
+
+  const seed = colorOf(opts.anchor);
+  if (!seed) return []; // the anchor isn't on the art — nothing to grow from
+  const cells = floodFill({
+    anchor: opts.anchor,
+    accept: (hex) => {
+      const c = colorOf(hex);
+      return c !== null && colorDistance(c, seed) <= opts.tolerance;
+    },
+    maxCells: opts.limits?.maxCells,
+    maxRadius: opts.limits?.maxRadius,
+  });
+  return withoutAnchor(cells, opts.anchor);
+}
+
+export { FLOOD_MAX_CELLS, FLOOD_MAX_RADIUS };

--- a/packages/client/src/stores/ui.ts
+++ b/packages/client/src/stores/ui.ts
@@ -65,8 +65,21 @@ interface UiStore {
   senseHighlight: { clueId: string; cells: HexCoord[] } | null;
   /** Trail highlight: the full path (DM) or discovered cells (player) of a clicked trail. */
   trailHighlight: { trailId: string; cells: HexCoord[] } | null;
-  /** Region footprint highlight: the hexes of a clicked multi-hex content (issue #69). */
-  areaHighlight: { contentId: string; cells: HexCoord[] } | null;
+  /**
+   * Region footprint highlight: the hexes of a clicked multi-hex content
+   * (issue #69). `proposal` marks an auto-detect recommendation that has not
+   * been applied yet (issue #113) — the engine tints it differently so a
+   * suggestion never looks like the stored footprint.
+   */
+  areaHighlight: { contentId: string; cells: HexCoord[]; proposal?: boolean } | null;
+  /**
+   * Auto-detect result awaiting Accept/Cancel (issue #113). Set alongside a
+   * `proposal` highlight; while it's up the region manager collapses to a
+   * floating bar so the DM can see the map underneath.
+   */
+  areaProposal: { contentId: string; cells: HexCoord[] } | null;
+  /** DM region manager dialog (opened from the Region tool panel). */
+  regionManagerOpen: boolean;
   /**
    * DM "paint area" mode (armed from the content dialog): while set, dragging
    * the map brushes hexes into (or out of) `cells` instead of running the
@@ -155,6 +168,8 @@ export const useUi = create<UiStore>((set) => ({
   senseHighlight: null,
   trailHighlight: null,
   areaHighlight: null,
+  areaProposal: null,
+  regionManagerOpen: false,
   areaPaint: null,
   regionTargetId: null,
   regionErase: false,

--- a/packages/client/src/views/TableView.tsx
+++ b/packages/client/src/views/TableView.tsx
@@ -14,6 +14,7 @@ import { SelectionBar } from '../components/SelectionBar.js';
 import { PinActions } from '../components/PinActions.js';
 import { LocationDialog } from '../components/LocationDialog.js';
 import { MapManagerDialog } from '../components/MapManagerDialog.js';
+import { RegionManagerDialog } from '../components/RegionManagerDialog.js';
 
 export function TableView({ campaignId }: { campaignId: string }) {
   const hostRef = useRef<HTMLDivElement>(null);
@@ -24,6 +25,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
   const contentDialogHex = useUi((s) => s.contentDialogHex);
   const locationDialogContentId = useUi((s) => s.locationDialogContentId);
   const mapManagerOpen = useUi((s) => s.mapManagerOpen);
+  const regionManagerOpen = useUi((s) => s.regionManagerOpen);
 
   useEffect(() => {
     connectWs(campaignId);
@@ -33,6 +35,21 @@ export function TableView({ campaignId }: { campaignId: string }) {
   // DM tool keyboard shortcuts + hold-space to pan.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // The region manager (issue #113) answers Escape even from inside its
+      // own inputs: a proposal bar cancels back to the dialog, and an open
+      // dialog closes. Both come before the form-field guard below.
+      if (e.key === 'Escape') {
+        const state = useUi.getState();
+        if (state.areaProposal) {
+          state.set('areaProposal', null);
+          state.set('areaHighlight', null);
+          return;
+        }
+        if (state.regionManagerOpen) {
+          state.set('regionManagerOpen', false);
+          return;
+        }
+      }
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') {
         return;
@@ -144,6 +161,7 @@ export function TableView({ campaignId }: { campaignId: string }) {
       </div>
       {contentDialogHex && <ContentDialog />}
       {locationDialogContentId && <LocationDialog campaignId={campaignId} />}
+      {regionManagerOpen && role === 'dm' && <RegionManagerDialog />}
       {mapManagerOpen && role === 'dm' && (
         <MapManagerDialog
           campaignId={campaignId}

--- a/packages/server/src/region-terrain.test.ts
+++ b/packages/server/src/region-terrain.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { hexKey, seededRng } from '@hexcrawl/shared';
+import type { ClientCommand, Content, TerrainId } from '@hexcrawl/shared';
+import { createTestDb } from './db/index.js';
+import { Store } from './state/store.js';
+import { CampaignRuntime, type SeatRecord } from './state/runtime.js';
+import { Hub } from './ws/hub.js';
+import { dispatchCommand } from './ws/handlers.js';
+
+/**
+ * `content.applyTerrain` (issue #113): one terrain across a region's whole
+ * footprint, with the overlap policy that makes it usable — by default the
+ * hexes another region already claims are left alone.
+ */
+
+let store: Store;
+let runtime: CampaignRuntime;
+let dmSeat: SeatRecord;
+let hub: Hub;
+let cmdCounter = 0;
+
+function asSeat(seat: SeatRecord, cmd: Omit<ClientCommand, 'id'>): void {
+  dispatchCommand({ ...cmd, id: `t${cmdCounter++}` } as ClientCommand, {
+    runtime,
+    seat,
+    hub,
+    rng: seededRng(1),
+  });
+}
+
+function dm(cmd: Omit<ClientCommand, 'id'>): void {
+  asSeat(dmSeat, cmd);
+}
+
+beforeEach(() => {
+  store = new Store(createTestDb());
+  const created = store.createCampaign('Fill', 'The DM');
+  runtime = created.runtime;
+  dmSeat = created.dmSeat;
+  hub = new Hub();
+  cmdCounter = 0;
+});
+
+function mapId(): string {
+  return runtime.campaign.activeMapId!;
+}
+
+/** A region anchored at `anchor` covering the given extra hexes. */
+function region(title: string, anchor: [number, number], area: [number, number][]): Content {
+  dm({
+    kind: 'content.upsert',
+    content: {
+      id: null,
+      mapId: mapId(),
+      q: anchor[0],
+      r: anchor[1],
+      area: area.map(([q, r]) => ({ q, r })),
+      type: 'region',
+      title,
+      dmNotes: '',
+      glyph: '',
+      clues: [],
+    },
+  } as never);
+  return [...runtime.requireMap(mapId()).contents.values()].find((c) => c.title === title)!;
+}
+
+function terrainAt(q: number, r: number): TerrainId | undefined {
+  return runtime.requireMap(mapId()).hexes.get(hexKey(q, r));
+}
+
+function lastNote(): string {
+  return [...runtime.log].reverse().find((e) => e.kind === 'note')?.text ?? '';
+}
+
+describe('content.applyTerrain', () => {
+  it('paints the whole footprint, anchor included', () => {
+    const wood = region('Greenwood', [0, 0], [
+      [1, 0],
+      [2, 0],
+    ]);
+    dm({ kind: 'content.applyTerrain', contentId: wood.id, terrain: 'forest' } as never);
+    expect(terrainAt(0, 0)).toBe('forest');
+    expect(terrainAt(1, 0)).toBe('forest');
+    expect(terrainAt(2, 0)).toBe('forest');
+    expect(lastNote()).toBe('Painted forest across Greenwood — 3 hexes');
+  });
+
+  it('skips hexes claimed by another region by default, and reports the count', () => {
+    const wood = region('Greenwood', [0, 0], [
+      [1, 0],
+      [2, 0],
+    ]);
+    region('Bog', [2, 0], [[3, 0]]);
+    dm({ kind: 'content.applyTerrain', contentId: wood.id, terrain: 'forest' } as never);
+    expect(terrainAt(0, 0)).toBe('forest');
+    expect(terrainAt(1, 0)).toBe('forest');
+    expect(terrainAt(2, 0)).toBeUndefined(); // the Bog's anchor, left alone
+    expect(lastNote()).toBe(
+      'Painted forest across Greenwood — 2 hexes (1 skipped in other regions)',
+    );
+  });
+
+  it('does not treat an anchor-only pin as a region', () => {
+    const wood = region('Greenwood', [0, 0], [[1, 0]]);
+    region('Old Mill', [1, 0], []); // a plain pin inside the wood
+    dm({ kind: 'content.applyTerrain', contentId: wood.id, terrain: 'forest' } as never);
+    expect(terrainAt(1, 0)).toBe('forest');
+    expect(lastNote()).toBe('Painted forest across Greenwood — 2 hexes');
+  });
+
+  it('overwrites overlapping cells when skipOtherRegions is false', () => {
+    const wood = region('Greenwood', [0, 0], [
+      [1, 0],
+      [2, 0],
+    ]);
+    region('Bog', [2, 0], [[3, 0]]);
+    dm({
+      kind: 'content.applyTerrain',
+      contentId: wood.id,
+      terrain: 'forest',
+      skipOtherRegions: false,
+    } as never);
+    expect(terrainAt(2, 0)).toBe('forest');
+    expect(terrainAt(3, 0)).toBeUndefined(); // never in the Greenwood's footprint
+    expect(lastNote()).toBe('Painted forest across Greenwood — 3 hexes');
+  });
+
+  it('erases with a null terrain', () => {
+    const wood = region('Greenwood', [0, 0], [[1, 0]]);
+    dm({ kind: 'terrain.paint', mapId: mapId(), cells: [{ q: 0, r: 0 }, { q: 1, r: 0 }], terrain: 'swamp' } as never);
+    expect(terrainAt(0, 0)).toBe('swamp');
+    dm({ kind: 'content.applyTerrain', contentId: wood.id, terrain: null } as never);
+    expect(terrainAt(0, 0)).toBeUndefined();
+    expect(terrainAt(1, 0)).toBeUndefined();
+    expect(lastNote()).toBe('Erased terrain across Greenwood — 2 hexes');
+  });
+
+  it('is undoable back to the prior terrain', () => {
+    const wood = region('Greenwood', [0, 0], [[1, 0]]);
+    dm({ kind: 'terrain.paint', mapId: mapId(), cells: [{ q: 0, r: 0 }], terrain: 'plains' } as never);
+    // The undo window merges consecutive terrain edits, so step off it first.
+    const top = runtime.undoStack[runtime.undoStack.length - 1];
+    if (top) top.at -= 10_000;
+    dm({ kind: 'content.applyTerrain', contentId: wood.id, terrain: 'forest' } as never);
+    expect(terrainAt(0, 0)).toBe('forest');
+    expect(terrainAt(1, 0)).toBe('forest');
+    dm({ kind: 'undo' } as never);
+    expect(terrainAt(0, 0)).toBe('plains');
+    expect(terrainAt(1, 0)).toBeUndefined();
+  });
+
+  it('is DM-only', () => {
+    const wood = region('Greenwood', [0, 0], [[1, 0]]);
+    const player = runtime.createSeat('player', 'Bob');
+    expect(() =>
+      asSeat(player, {
+        kind: 'content.applyTerrain',
+        contentId: wood.id,
+        terrain: 'forest',
+      } as never),
+    ).toThrow(/Only the DM/);
+    expect(terrainAt(0, 0)).toBeUndefined();
+  });
+
+  it('rejects an unknown content id', () => {
+    expect(() =>
+      dm({ kind: 'content.applyTerrain', contentId: 'nope', terrain: 'forest' } as never),
+    ).toThrow(/not found/i);
+  });
+});

--- a/packages/server/src/ws/handlers.ts
+++ b/packages/server/src/ws/handlers.ts
@@ -12,6 +12,7 @@ import type {
 } from '@hexcrawl/shared';
 import {
   compassDirection,
+  contentCells,
   contentCoversHex,
   distanceToContent,
   formatCalendarClock,
@@ -693,6 +694,52 @@ export const handlers: Record<ClientCommand['kind'], Handler> = {
     // A grown footprint can open entering-the-region gates for whoever is
     // already standing there; a shrunk one costs nothing to re-evaluate.
     deliverDiscoveries(ctx, evaluateKnowledge(ctx.runtime, found.mapId));
+  }) as Handler,
+
+  /**
+   * Terrain fill across a region's footprint (issue #113). The overlap policy
+   * is the interesting part: with `skipOtherRegions` (the default) a hex that
+   * also belongs to another region's footprint keeps its terrain, so filling
+   * "The Greenwood" never repaints the villages inside it. Only real regions
+   * block — a plain single-hex pin has no area, and a landmark sitting in the
+   * woods should be painted with the woods.
+   *
+   * Undo rides the shared terrain mechanism, so a fill merges with adjacent
+   * brush strokes exactly like another stroke would.
+   */
+  'content.applyTerrain': ((
+    cmd: Extract<ClientCommand, { kind: 'content.applyTerrain' }>,
+    ctx: Ctx,
+  ) => {
+    requireDm(ctx);
+    let found: Content | null = null;
+    for (const rt of ctx.runtime.mapStates.values()) {
+      const c = rt.contents.get(cmd.contentId);
+      if (c) { found = c; break; }
+    }
+    if (!found) throw new Error('Content not found');
+    const skip = cmd.skipOtherRegions ?? true;
+    const footprint = contentCells(found);
+    const blocked = new Set<string>();
+    if (skip) {
+      for (const other of ctx.runtime.requireMap(found.mapId).contents.values()) {
+        if (other.id === found.id || other.area.length === 0) continue;
+        for (const cell of contentCells(other)) blocked.add(hexKey(cell.q, cell.r));
+      }
+    }
+    const target = footprint.filter((c) => !blocked.has(hexKey(c.q, c.r)));
+    const skipped = footprint.length - target.length;
+    const changed = ctx.runtime.paintTerrain(found.mapId, target, cmd.terrain);
+    recordCellUndo(ctx, 'terrain', found.mapId, changed);
+    const what = cmd.terrain === null ? 'Erased terrain' : `Painted ${cmd.terrain}`;
+    const entry = ctx.runtime.appendLog(
+      'note',
+      `${what} across ${found.title} — ${target.length} hex${target.length === 1 ? '' : 'es'}` +
+        (skipped > 0 ? ` (${skipped} skipped in other regions)` : ''),
+      'dm',
+      { contentId: found.id },
+    );
+    notifyLog(ctx, entry);
   }) as Handler,
 
   'view.map': ((_cmd: Extract<ClientCommand, { kind: 'view.map' }>, _ctx: Ctx) => {

--- a/packages/shared/src/protocol/commands.ts
+++ b/packages/shared/src/protocol/commands.ts
@@ -468,6 +468,21 @@ export const ContentAreaCommand = z
     message: 'content.area needs add or remove',
   });
 
+/**
+ * DM: paint one terrain across a region's whole footprint (issue #113).
+ * `skipOtherRegions` (default true, server-side — a zod default here would
+ * make the field required in `CommandInput` at every call site) leaves the
+ * hexes that also belong to ANOTHER region's footprint alone; anchor-only
+ * pins are not regions and never block. `terrain: null` erases.
+ */
+export const ContentApplyTerrainCommand = z.object({
+  ...base,
+  kind: z.literal('content.applyTerrain'),
+  contentId: z.string(),
+  terrain: TerrainIdSchema.nullable(),
+  skipOtherRegions: z.boolean().optional(),
+});
+
 /** Any seat: view a different map on this connection (handled per-connection). */
 export const ViewMapCommand = z.object({
   ...base,
@@ -687,6 +702,7 @@ export const ClientCommandSchema = z.discriminatedUnion('kind', [
   ContentSetQuestCommand,
   ContentMoveCommand,
   ContentAreaCommand,
+  ContentApplyTerrainCommand,
   ViewMapCommand,
   TrailUpsertCommand,
   TrailDeleteCommand,

--- a/packages/shared/src/rules/flood.test.ts
+++ b/packages/shared/src/rules/flood.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { hexKey, hexRange, type HexCoord, type TerrainId } from '../index.js';
+import { floodFill, floodFillByTerrain } from './flood.js';
+
+/** Region auto-detect flood fill (issue #113). */
+
+function keys(cells: HexCoord[]): Set<string> {
+  return new Set(cells.map((c) => hexKey(c.q, c.r)));
+}
+
+function paint(cells: [number, number, TerrainId][]): Map<string, TerrainId> {
+  return new Map(cells.map(([q, r, t]) => [hexKey(q, r), t]));
+}
+
+describe('floodFill', () => {
+  it('always returns the anchor, even when nothing is acceptable', () => {
+    const cells = floodFill({ anchor: { q: 3, r: -2 }, accept: () => false });
+    expect(cells).toEqual([{ q: 3, r: -2 }]);
+  });
+
+  it('walks the six axial neighbours breadth-first', () => {
+    const region = keys(hexRange({ q: 0, r: 0 }, 2));
+    const cells = floodFill({
+      anchor: { q: 0, r: 0 },
+      accept: (h) => region.has(hexKey(h.q, h.r)),
+    });
+    expect(cells.length).toBe(19); // radius-2 disc
+    expect(keys(cells)).toEqual(region);
+  });
+
+  it('does not leak across a gap', () => {
+    // Two discs separated by an unaccepted ring: only the anchor's is found.
+    const near = keys(hexRange({ q: 0, r: 0 }, 1));
+    const far = keys(hexRange({ q: 6, r: 0 }, 1));
+    const cells = floodFill({
+      anchor: { q: 0, r: 0 },
+      accept: (h) => near.has(hexKey(h.q, h.r)) || far.has(hexKey(h.q, h.r)),
+    });
+    expect(cells.length).toBe(7);
+    expect(keys(cells)).toEqual(near);
+  });
+
+  it('caps at maxCells', () => {
+    const cells = floodFill({ anchor: { q: 0, r: 0 }, accept: () => true, maxCells: 25 });
+    expect(cells.length).toBe(25);
+  });
+
+  it('stops at the bounding radius', () => {
+    const cells = floodFill({
+      anchor: { q: 0, r: 0 },
+      accept: () => true,
+      maxCells: 100000,
+      maxRadius: 3,
+    });
+    expect(cells.length).toBe(37); // radius-3 disc
+    expect(keys(cells)).toEqual(keys(hexRange({ q: 0, r: 0 }, 3)));
+  });
+});
+
+describe('floodFillByTerrain', () => {
+  const terrain = paint([
+    [0, 0, 'forest'],
+    [1, 0, 'forest'],
+    [2, 0, 'forest'],
+    [1, -1, 'hills'],
+    // (3,0) unpainted — the edge of the painted world
+    [4, 0, 'forest'],
+  ]);
+
+  it('grows across matching terrain only', () => {
+    const cells = floodFillByTerrain(terrain, { q: 0, r: 0 }, new Set<TerrainId>(['forest']));
+    expect(keys(cells)).toEqual(new Set(['0,0', '1,0', '2,0']));
+  });
+
+  it('accepts every terrain in the set', () => {
+    const cells = floodFillByTerrain(
+      terrain,
+      { q: 0, r: 0 },
+      new Set<TerrainId>(['forest', 'hills']),
+    );
+    expect(keys(cells)).toEqual(new Set(['0,0', '1,0', '2,0', '1,-1']));
+  });
+
+  it('never crosses unpainted hexes', () => {
+    const cells = floodFillByTerrain(terrain, { q: 0, r: 0 }, new Set<TerrainId>(['forest']));
+    expect(keys(cells).has('4,0')).toBe(false);
+  });
+
+  it('returns just the anchor when its own terrain is not selected', () => {
+    const cells = floodFillByTerrain(terrain, { q: 0, r: 0 }, new Set<TerrainId>(['swamp']));
+    expect(cells).toEqual([{ q: 0, r: 0 }]);
+  });
+});

--- a/packages/shared/src/rules/flood.ts
+++ b/packages/shared/src/rules/flood.ts
@@ -1,0 +1,76 @@
+import { hexDistance, hexKey, hexNeighbors, type HexCoord } from '../hex/coords.js';
+import type { TerrainId } from '../domain.js';
+
+/**
+ * Region auto-detect (issue #113): a contiguous hex flood fill from an anchor.
+ *
+ * The client's two detection modes (terrain match, map-image colour match)
+ * differ only in what they accept, so the traversal itself lives here as a
+ * pure function with an `accept` predicate — and is unit-tested, which the
+ * client (no test runner) could not be.
+ *
+ * Two invariants worth knowing:
+ * - the anchor is ALWAYS in the result, whether or not it passes `accept`;
+ *   it is the region's home hex by definition, and the fill grows from it.
+ * - the walk is bounded twice — by `maxCells` and by a ring radius — because
+ *   a loose colour tolerance on flat art would otherwise walk the plane.
+ */
+export interface FloodOptions {
+  anchor: HexCoord;
+  /** Called at most once per candidate hex; the anchor is never asked. */
+  accept: (hex: HexCoord) => boolean;
+  /** Hard cap on the returned cells, anchor included. Default 3000. */
+  maxCells?: number;
+  /** Hard stop at this hex distance from the anchor. Default 60. */
+  maxRadius?: number;
+}
+
+export const FLOOD_MAX_CELLS = 3000;
+export const FLOOD_MAX_RADIUS = 60;
+
+/** Breadth-first flood fill over the six axial neighbours. Anchor first. */
+export function floodFill(opts: FloodOptions): HexCoord[] {
+  const maxCells = Math.max(1, opts.maxCells ?? FLOOD_MAX_CELLS);
+  const maxRadius = Math.max(0, opts.maxRadius ?? FLOOD_MAX_RADIUS);
+  const anchor = { q: opts.anchor.q, r: opts.anchor.r };
+  const out: HexCoord[] = [anchor];
+  const seen = new Set<string>([hexKey(anchor.q, anchor.r)]);
+  const queue: HexCoord[] = [anchor];
+  let head = 0;
+  while (head < queue.length && out.length < maxCells) {
+    const hex = queue[head++]!;
+    for (const next of hexNeighbors(hex)) {
+      const key = hexKey(next.q, next.r);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (hexDistance(anchor, next) > maxRadius) continue;
+      if (!opts.accept(next)) continue;
+      out.push(next);
+      queue.push(next);
+      if (out.length >= maxCells) break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Terrain-match detection: grow from the anchor across hexes whose PAINTED
+ * terrain is in `terrains`. Unpainted hexes are never accepted — an empty
+ * hex is not "the same terrain", it's the edge of the painted world.
+ */
+export function floodFillByTerrain(
+  terrainAt: ReadonlyMap<string, TerrainId>,
+  anchor: HexCoord,
+  terrains: ReadonlySet<TerrainId>,
+  opts: { maxCells?: number; maxRadius?: number } = {},
+): HexCoord[] {
+  return floodFill({
+    anchor,
+    accept: (hex) => {
+      const terrain = terrainAt.get(hexKey(hex.q, hex.r));
+      return terrain !== undefined && terrains.has(terrain);
+    },
+    maxCells: opts.maxCells,
+    maxRadius: opts.maxRadius,
+  });
+}

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -1,4 +1,5 @@
 export * from './dice.js';
+export * from './flood.js';
 export * from './gates.js';
 export * from './filter.js';
 export * from './time.js';


### PR DESCRIPTION
Closes #113

## Design

**Region manager dialog** (`components/RegionManagerDialog.tsx`), opened from a
"Manage regions…" button in the Region tool panel. Left: every region on the
current map (contents typed `region` plus anything that has grown an area) with
hex counts and a terrain histogram. Right: the selected region — highlight
toggle, auto-detect, terrain fill, rename, open the full editor, clear area.

**Auto-detect is a proposal, not a write.** Preview runs detection client-side
and parks the result in `ui.areaProposal` plus an `areaHighlight` carrying a new
`proposal: true` flag; the engine tints those amber with a heavier outline (Pixi
Graphics has no dashed stroke), and `syncRegionHighlight` refuses to touch the
highlight while a proposal stands, so a snapshot mid-preview can't yank it back.
The dialog collapses to a floating Accept/Cancel bar — the content dialog's
paint-bar pattern — and Accept applies the delta through the existing
`content.area` command (chunked at 5000). Escape cancels the proposal back to
the dialog; a second Escape closes the dialog.

Two engines:

- **Terrain match** — BFS across hexes whose painted terrain is in the selected
  set (defaults to the anchor's). Unpainted hexes always stop the fill.
- **Map colours** — samples the base art per hex and grows by colour similarity.
  The reference is the *anchor's* colour, fixed, not a running mean: a running
  mean drifts, so a gradient (a coastal fade, a parchment vignette) would walk
  the fill out of the region it started in. Distance is weighted RGB (2/4/3) on
  a 0–441 scale, which is what the 5–80 tolerance slider is calibrated against.
  Base art = the bottom-most visible non-`dmOnly` image layer. The image is read
  back once (drawn down past 4096px so a huge scan doesn't cost hundreds of MB),
  and a 5-point kernel per hex averages out line work. Transform is the sprite's:
  `image = (world − layer.xy) / layer.scale`.

Both are bounded twice — a max-cells input and a hard 60-hex radius — so a loose
tolerance on flat art can't walk the plane.

**The traversal lives in shared.** `shared/rules/flood.ts` exposes `floodFill`
with an `accept` predicate (plus a terrain wrapper), so both modes share one
tested BFS; only pixel sampling stays client-side, where there is no test runner.

**`content.applyTerrain`** (DM-only) paints one terrain — or erases with `null` —
across a footprint. `skipOtherRegions` (optional on the wire, defaulted true
server-side so it doesn't become required in `CommandInput`) leaves alone every
hex some *other* content's non-empty area covers; anchor-only pins are not
regions and never block, so a mill inside a wood gets painted with the wood.
Undo rides `recordCellUndo('terrain', …)`, so a fill merges with adjacent brush
strokes into a single undo. Counts come back as a DM-only `note` log entry
("Painted forest across Greenwood — 17 hexes (2 skipped in other regions)")
rather than a command reply.

## Tests

`packages/server/src/region-terrain.test.ts` (8): footprint fill including the
anchor, skip vs. overwrite across two overlapping regions, anchor-only pins not
blocking, null erases, undo restores the prior terrain, DM-only, unknown id.
`packages/shared/src/rules/flood.test.ts` (9): anchor always returned, six-way
BFS, no leaking across gaps, both caps, terrain acceptance/rejection.

`pnpm typecheck && pnpm test && pnpm build` green (219 server, 70 shared).

## Verified in the app

Smoke-tested against a scratch campaign: terrain-mode detect on a painted
radius-2 forest patch proposed exactly those 19 hexes and Accept grew the
footprint; terrain fill with skip painted 17 and left the 2 hexes of an
overlapping region alone, overwrite (with its confirm) took all 19, and Cmd+Z
restored them. Colour mode was verified against an uploaded 2400×1800 image
placed at `x:-600, y:-450, scale:0.5` with a green disc centred on hex (2,0):
the proposal landed exactly on the disc, which exercises the layer transform
(offset and scale both non-trivial).

## Docs notes

`docs/AI-DEVELOPMENT.md` gains two gotcha entries: the proposal/highlight
protocol and where detection lives (shared traversal vs. client sampling, the
fixed-seed choice, the colour scale, the transform), and the overlap/undo/log
semantics of `content.applyTerrain`.