### PR TITLE
tune: colour-detect default tolerance from real-art calibration

### DIFF
--- a/packages/client/src/components/RegionManagerDialog.tsx
+++ b/packages/client/src/components/RegionManagerDialog.tsx
@@ -73,7 +73,10 @@ export function RegionManagerDialog() {
   const [detect, setDetect] = useState<DetectSettings>({
     mode: 'terrain',
     terrains: [],
-    tolerance: 25,
+    // Calibrated against the real Sword Coast art: 25 (the synthetic-test
+    // default) barely grew past the anchor on textured sourcebook scans, while
+    // 45–65 tracked the painted blob stably without flooding. 50 sits mid-band.
+    tolerance: 50,
     maxCells: 800,
   });
   // The terrain chips default to the selected region's own terrain; the rest


### PR DESCRIPTION
Follow-up to #114. Imported the live campaign into a local instance and measured colour detection against the actual Sword Coast art: tolerance 25 (tuned on a synthetic hard-edged disc) barely grows past the anchor on textured scans; 45–65 is a stable plateau tracking the painted forest without flooding. Default moved to 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)