### PR TITLE
Info tab: token grid, roll-encounter button; any-terrain fallback table

### DIFF
--- a/packages/client/src/components/panels/EncountersTab.tsx
+++ b/packages/client/src/components/panels/EncountersTab.tsx
@@ -193,9 +193,12 @@ function TablesPanel() {
   const [editing, setEditing] = useState<EncounterTable | 'new' | null>(null);
   const tables = state?.encounterTables ?? [];
 
-  // Presets whose terrain isn't already covered by an existing table.
-  const missingPresets = ENCOUNTER_PRESETS.filter(
-    (p) => !tables.some((t) => p.terrains.some((tr) => t.terrains.includes(tr))),
+  // Presets whose terrain isn't already covered by an existing table. The
+  // any-terrain preset counts as covered once any terrain-agnostic table exists.
+  const missingPresets = ENCOUNTER_PRESETS.filter((p) =>
+    p.terrains.length === 0
+      ? !tables.some((t) => t.terrains.length === 0)
+      : !tables.some((t) => p.terrains.some((tr) => t.terrains.includes(tr))),
   );
   const loadPresets = () => {
     for (const p of missingPresets) {

--- a/packages/client/src/components/panels/InspectTab.tsx
+++ b/packages/client/src/components/panels/InspectTab.tsx
@@ -65,6 +65,28 @@ export function InspectTab() {
       </div>
 
       {isDm && (
+        <div className="mb-3">
+          <Button
+            size="sm"
+            className="w-full"
+            title={`Wandering encounter check (${map.encounterCheck.die}, ${map.encounterCheck.threshold}+) using this hex's terrain — result lands in the DM log`}
+            onClick={() =>
+              send({
+                kind: 'encounter.roll',
+                mapId: map.id,
+                q: hex.q,
+                r: hex.r,
+                tableId: null,
+                skipCheck: false,
+              })
+            }
+          >
+            🎲 Roll encounter here
+          </Button>
+        </div>
+      )}
+
+      {isDm && (
         <Section title="Fog">
           <div className="flex gap-1">
             {(['visible', 'explored', 'hidden'] as FogState[]).map((s) => (
@@ -87,9 +109,10 @@ export function InspectTab() {
 
       {tokens.length > 0 && (
         <Section title="Tokens here">
-          <ul className="space-y-1">
+          {/* auto-fill: one column in a narrow sidebar, more as it widens */}
+          <ul className="grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-x-3 gap-y-1">
             {tokens.map((t) => (
-              <li key={t.id} className="flex items-center gap-2 text-sm text-ink-100">
+              <li key={t.id} className="flex items-center gap-2 text-sm text-ink-100 min-w-0">
                 <span
                   className="w-4 h-4 rounded-full inline-block border border-white/40 shrink-0"
                   style={{ background: t.color }}

--- a/packages/shared/src/rules/encounterPresets.test.ts
+++ b/packages/shared/src/rules/encounterPresets.test.ts
@@ -9,6 +9,10 @@ describe('encounter presets', () => {
     expect([...seen].sort()).toEqual([...TERRAIN_IDS].sort());
   });
 
+  it('includes exactly one terrain-agnostic fallback table', () => {
+    expect(ENCOUNTER_PRESETS.filter((p) => p.terrains.length === 0)).toHaveLength(1);
+  });
+
   it('validates against the table schema', () => {
     for (const p of ENCOUNTER_PRESETS) {
       expect(() =>

--- a/packages/shared/src/rules/encounterPresets.ts
+++ b/packages/shared/src/rules/encounterPresets.ts
@@ -196,4 +196,20 @@ export const ENCOUNTER_PRESETS: EncounterPreset[] = [
     ['Colossal weathered bones jutting from a ridge'],
     ['Cracked earth and shimmering heat — no encounter'],
   ]),
+  // The terrain-agnostic fallback: rolls on unpainted hexes, or wherever no
+  // terrain table matches, land here instead of "improvise!".
+  preset('Wilderness (any terrain)', [], [
+    ['Ogre looking for an easy meal'],
+    ['Bandits sizing up the party', '2d6'],
+    ['Goblin scouts who bolt toward their warren', '2d4'],
+    ['Wolves keeping pace at the treeline', '1d6'],
+    ['Worgs hunting without riders', '1d2'],
+    ['Stirges dropping from above', '1d6'],
+    ['Skeletons of an old battle, still standing watch', '1d6'],
+    ['Traveling peddler with an overloaded mule'],
+    ['Pilgrims or refugees, footsore and wary'],
+    ['Abandoned campsite — cold fire, scattered gear'],
+    ['The weather turns fast — seek shelter or push through'],
+    ['An uneventful stretch — no encounter'],
+  ]),
 ];


### PR DESCRIPTION
## Summary
- **Tokens Here** on the Info tab uses a `repeat(auto-fill, minmax(11rem, 1fr))` grid — single column in a narrow sidebar, 2–3 columns as it's dragged wider; rows keep truncation via `min-w-0`.
- DM-only **🎲 Roll encounter here** button under the Info tab's hex header — same `encounter.roll` command as the Encounters tab, pinned to the inspected hex so terrain matching uses that hex; tooltip surfaces the map's check die/threshold.
- New **Wilderness (any terrain)** preset — the terrain-agnostic fallback the roller picks for unpainted hexes, so those rolls resolve instead of returning "improvise!". "+ Standard tables" counts it as covered once any terrain-agnostic table exists (no duplicate re-adds). All 12 painted terrains were already covered 1:1 by the existing presets (asserted by tests).

## Test plan
- `pnpm typecheck && pnpm test` (75 shared + 217 server tests pass)
- Browser-verified: token grid reflows to 3 columns on a wide sidebar; Roll encounter here logged both a failed check and a triggered roll resolving on the Forest table with quantity dice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)